### PR TITLE
data: parsing improvements

### DIFF
--- a/data/Pandora.Api/V1/ResourceManager/APISchema.cs
+++ b/data/Pandora.Api/V1/ResourceManager/APISchema.cs
@@ -55,7 +55,8 @@ namespace Pandora.Api.V1.ResourceManager
             return new ApiSchemaResponse
             {
                 Constants = api.Constants.ToDictionary(c => c.Name, ConstantApiDefinition.Map),
-                Models = api.Models.ToDictionary(m => m.Name, MapModel)
+                Models = api.Models.ToDictionary(m => m.Name, MapModel),
+                ResourceIds = api.ResourceIds.ToDictionary(id => id.Name, id => id.Format),
             };
         }
 
@@ -165,6 +166,9 @@ namespace Pandora.Api.V1.ResourceManager
 
             [JsonPropertyName("models")]
             public Dictionary<string, ModelApiDefinition> Models { get; set; }
+
+            [JsonPropertyName("resourceIds")]
+            public Dictionary<string, string> ResourceIds { get; set; }
         }
 
         private class PropertyApiDefinition

--- a/data/Pandora.Api/V1/ResourceManager/ServiceVersion.cs
+++ b/data/Pandora.Api/V1/ResourceManager/ServiceVersion.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualBasic.CompilerServices;
 using Pandora.Data.Models;
 using Pandora.Data.Repositories;
+using Pandora.Data.Transformers;
 
 namespace Pandora.Api.V1.ResourceManager
 {
@@ -43,15 +44,9 @@ namespace Pandora.Api.V1.ResourceManager
         {
             return new ApiVersionResponse
             {
-                ResourceIds = MapResourceIds(version),
                 Resources = version.Apis.ToDictionary(a => a.Name, 
                     a => MapResourceForApiVersion(a, versionNumber, serviceName)),
             };
-        }
-
-        private static Dictionary<string, string> MapResourceIds(VersionDefinition version)
-        {
-            return version.Apis.SelectMany(api => api.ResourceIds).ToDictionary(id => id.Name, id => id.Format);
         }
 
         private static ApiTypeInformation MapResourceForApiVersion(ApiDefinition definition, string versionNumber, string serviceName)
@@ -64,10 +59,8 @@ namespace Pandora.Api.V1.ResourceManager
         }
     }
     
-    public class ApiVersionResponse {
-        [JsonPropertyName("resourceIds")]
-        public Dictionary<string, string> ResourceIds { get; set; }
-        
+    public class ApiVersionResponse
+    {
         [JsonPropertyName("resources")]
         public Dictionary<string, ApiTypeInformation> Resources { get; set; }
     }

--- a/data/Pandora.Data/Transformers/Model.cs
+++ b/data/Pandora.Data/Transformers/Model.cs
@@ -44,8 +44,11 @@ namespace Pandora.Data.Transformers
                     }
 
                     var innerType = property.PropertyType.GetGenericArguments()[0];
-                    var mappedInner = MapObject(innerType);
-                    models.AddRange(mappedInner);
+                    if (!Helpers.IsNativeType(innerType)) // e.g. List<string>
+                    {
+                        var mappedInner = MapObject(innerType);
+                        models.AddRange(mappedInner);
+                    }
                 }
                 else if (property.PropertyType.IsClass && !property.PropertyType.IsEnum &&
                          !Helpers.IsNativeType(property.PropertyType) &&

--- a/data/Pandora.Data/Transformers/Operation.cs
+++ b/data/Pandora.Data/Transformers/Operation.cs
@@ -38,8 +38,8 @@ namespace Pandora.Data.Transformers
             var responseObject = input.ResponseObject();
             if (longRunning && responseObject != null)
             {
-                throw new NotSupportedException(
-                    "cannot be long running with a response object, lookup the object instead");
+                // disregard the response object since this shouldn't be useful
+                responseObject = null;
             }
 
             // TODO: tests covering this?

--- a/tools/generator-go-sdk/generator/data.go
+++ b/tools/generator-go-sdk/generator/data.go
@@ -51,7 +51,7 @@ func (i ServiceGeneratorInput) generatorData() ServiceGeneratorData {
 		operations:        i.ResourceDetails.Operations.Operations,
 		outputPath:        outputPath,
 		packageName:       resourcePackageName,
-		resourceIds:       i.VersionDetails.Details.ResourceIds,
+		resourceIds:       i.ResourceDetails.Schema.ResourceIds,
 		serviceClientName: fmt.Sprintf("%sClient", strings.Title(i.ResourceName)),
 	}
 }

--- a/tools/generator-go-sdk/generator/stage_models.go
+++ b/tools/generator-go-sdk/generator/stage_models.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
+// TODO: dynamic imports
+
 func (s *ServiceGenerator) models(data ServiceGeneratorData) error {
 	if len(data.models) == 0 {
 		return nil
@@ -105,7 +107,11 @@ func (c modelsTemplater) template(data ServiceGeneratorData) (*string, error) {
 
 		template := fmt.Sprintf(`package %[1]s
 
-import "github.com/hashicorp/go-azure-helpers/formatting"
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/formatting"
+)
 
 type %[2]s interface {
 }
@@ -129,7 +135,11 @@ type %[2]s interface {
 
 	template := fmt.Sprintf(`package %[1]s
 
-import "github.com/hashicorp/go-azure-helpers/formatting"
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/formatting"
+)
 
 type %[2]s struct {
 %[3]s

--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -32,6 +32,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"

--- a/tools/importer-rest-api-specs/main.go
+++ b/tools/importer-rest-api-specs/main.go
@@ -55,6 +55,50 @@ func main() {
 			},
 		},
 
+		// EventHubs (2018-01-01-preview and 2017-04-01)
+		{
+			RootNamespace:    "Pandora.Definitions.ResourceManager",
+			ServiceName:      "EventHub",
+			ApiVersion:       "2017-04-01",
+			OutputDirectory:  "../../generated/pandora-definitions",
+			SwaggerDirectory: apiSpecsPath + "/specification/eventhub/resource-manager/Microsoft.EventHub/stable/2017-04-01",
+			SwaggerFiles: []string{
+				"AuthorizationRules.json",
+				"CheckNameAvailability.json",
+				"consumergroups.json",
+				"disasterRecoveryConfigs.json",
+				"eventhubs.json",
+				"namespaces.json",
+				"networkRuleSets.json",
+				"operations.json",
+				"sku.json",
+			},
+		},
+		{
+			RootNamespace:    "Pandora.Definitions.ResourceManager",
+			ServiceName:      "EventHub",
+			ApiVersion:       "2018-01-01-preview",
+			OutputDirectory:  "../../generated/pandora-definitions",
+			SwaggerDirectory: apiSpecsPath + "/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2018-01-01-preview",
+			SwaggerFiles: []string{
+				"AuthorizationRules.json",
+				"AvailableClusterRegions-preview.json",
+				"CheckNameAvailability.json",
+				"Clusters-preview.json",
+				"consumergroups.json",
+				"disasterRecoveryConfigs.json",
+				"eventhubs.json",
+				"ipfilterrules-preview.json",
+				"namespaces-preview.json",
+				"networkrulessets-preview.json",
+				"operations-preview.json",
+				"operations.json",
+				"quotaConfiguration-preview.json",
+				"sku.json",
+				"virtualnetworkrules-preview.json",
+			},
+		},
+
 		// Batch
 		//{
 		//	RootNamespace:    "Pandora.Definitions.ResourceManager",

--- a/tools/sdk/resourcemanager/api_schema.go
+++ b/tools/sdk/resourcemanager/api_schema.go
@@ -34,6 +34,10 @@ type ApiSchemaDetails struct {
 	// Models is a map of key (Model Name) to value (ModelDetails) describing
 	// each Model supported by this API version, used in either Requests or Responses
 	Models map[string]ModelDetails `json:"models"`
+
+	// ResourceIds is a map of key (Resource Name) to value (Resource ID strings)
+	// used by this API
+	ResourceIds map[string]string `json:"resourceIds"`
 }
 
 type ConstantDetails struct {

--- a/tools/sdk/resourcemanager/service_version.go
+++ b/tools/sdk/resourcemanager/service_version.go
@@ -30,10 +30,6 @@ type ServiceVersionDetails struct {
 	// Resources is a key (Resource Name) value (ResourceSummary) pair of Resource
 	// supported by this Service Version
 	Resources map[string]ResourceSummary `json:"resources"`
-
-	// ResourceIds is a map of key (Resource Name) to value (Resource ID strings)
-	// used by this Service or it's API's
-	ResourceIds map[string]string `json:"resourceIds"`
 }
 
 type ResourceSummary struct {


### PR DESCRIPTION
1. Outputting Resource ID's from the Schema endpoint rather than the Version endpoint since it's possible for these to be reused across different packages within a version (fixes #38)
2. Updating the SDK and Go Generator to account for this
3. Importer / Transform - avoiding reflecting into system types (e.g. string)