### PR TITLE
importer/generator-go-sdk: adding a feature flag for id aliases

### DIFF
--- a/tools/generator-go-sdk/generator/data.go
+++ b/tools/generator-go-sdk/generator/data.go
@@ -15,12 +15,16 @@ type ServiceGeneratorData struct {
 	// the name of the Client e.g. MyThingClient
 	serviceClientName string
 
+	// This is the output path for Resource IDs, which then gets aliased by packages
+	// for example {workingDir}/service/version/ids
+	idsOutputPath string
+
 	// This is the working directory where files should be output for this specific service
 	// for example {workingDir}/service/version/resource
 	outputPath string
 
 	// constants is a map of key (constant name) to value (ConstantDetails) describing
-	// the contants and their values used in this Resource
+	// the constants and their values used in this Resource
 	constants map[string]resourcemanager.ConstantDetails
 
 	// API Version is the default API version for this Resource
@@ -35,6 +39,13 @@ type ServiceGeneratorData struct {
 	operations map[string]resourcemanager.ApiOperation
 
 	resourceIds map[string]string
+
+	// the name of the service as a package (e.g. resources or eventhub)
+	servicePackageName string
+
+	// development feature flag - this requires work in the Resource ID parser to handle name conflicts
+	// @tombuildsstuff: fix this
+	useIdAliases bool
 }
 
 func (i ServiceGeneratorInput) generatorData() ServiceGeneratorData {
@@ -43,15 +54,20 @@ func (i ServiceGeneratorInput) generatorData() ServiceGeneratorData {
 	// TODO: it'd be nice to make these snake_case but that's a problem for another day
 	resourcePackageName := strings.ToLower(i.ResourceName)
 	outputPath := filepath.Join(i.OutputDirectory, servicePackageName, versionPackageName, resourcePackageName)
+	idsPath := filepath.Join(i.OutputDirectory, servicePackageName, versionPackageName, "ids")
 
 	return ServiceGeneratorData{
-		apiVersion:        i.VersionName,
-		constants:         i.ResourceDetails.Schema.Constants,
-		models:            i.ResourceDetails.Schema.Models,
-		operations:        i.ResourceDetails.Operations.Operations,
-		outputPath:        outputPath,
-		packageName:       resourcePackageName,
-		resourceIds:       i.ResourceDetails.Schema.ResourceIds,
-		serviceClientName: fmt.Sprintf("%sClient", strings.Title(i.ResourceName)),
+		apiVersion:         i.VersionName,
+		constants:          i.ResourceDetails.Schema.Constants,
+		idsOutputPath:      idsPath,
+		models:             i.ResourceDetails.Schema.Models,
+		operations:         i.ResourceDetails.Operations.Operations,
+		outputPath:         outputPath,
+		packageName:        resourcePackageName,
+		resourceIds:        i.ResourceDetails.Schema.ResourceIds,
+		serviceClientName:  fmt.Sprintf("%sClient", strings.Title(i.ResourceName)),
+		servicePackageName: strings.ToLower(i.ServiceName),
+
+		useIdAliases: false,
 	}
 }

--- a/tools/generator-go-sdk/generator/service.go
+++ b/tools/generator-go-sdk/generator/service.go
@@ -35,14 +35,20 @@ func (s *ServiceGenerator) Generate(input ServiceGeneratorInput) error {
 	if err := cleanAndRecreateWorkingDirectory(data.outputPath); err != nil {
 		return fmt.Errorf("cleaning/recreating working directory %q: %+v", data.outputPath, err)
 	}
+	if data.useIdAliases {
+		if err := ensureWorkingDirectoryExists(data.idsOutputPath); err != nil {
+			return fmt.Errorf("ensuring the ids working directory %q exists: %+v", data.idsOutputPath, err)
+		}
+	}
 
 	stages := map[string]func(data ServiceGeneratorData) error{
-		"clients":   s.clients,
-		"constants": s.constants,
-		"ids":       s.ids,
-		"methods":   s.methods,
-		"models":    s.models,
-		"version":   s.version,
+		"clients":    s.clients,
+		"constants":  s.constants,
+		"ids":        s.ids,
+		"id-aliases": s.idAliases,
+		"methods":    s.methods,
+		"models":     s.models,
+		"version":    s.version,
 	}
 	for name, stage := range stages {
 		log.Printf("[DEBUG] Running Stage %q..", name)
@@ -67,6 +73,17 @@ func cleanAndRecreateWorkingDirectory(path string) error {
 	// TODO: make these less exciting
 	if err := os.MkdirAll(path, 0777); err != nil {
 		return fmt.Errorf("creating %q: %+v", path, err)
+	}
+
+	return nil
+}
+
+func ensureWorkingDirectoryExists(path string) error {
+	// TODO: make these less exciting
+	if err := os.MkdirAll(path, 0777); err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("creating %q: %+v", path, err)
+		}
 	}
 
 	return nil

--- a/tools/generator-go-sdk/generator/stage_clients.go
+++ b/tools/generator-go-sdk/generator/stage_clients.go
@@ -3,7 +3,7 @@ package generator
 import "fmt"
 
 func (s *ServiceGenerator) clients(data ServiceGeneratorData) error {
-	if err := s.writeToPath("client.go", clientsTemplater{}, data); err != nil {
+	if err := s.writeToPath(data.outputPath, "client.go", clientsTemplater{}, data); err != nil {
 		return fmt.Errorf("templating client: %+v", err)
 	}
 

--- a/tools/generator-go-sdk/generator/stage_constants.go
+++ b/tools/generator-go-sdk/generator/stage_constants.go
@@ -13,7 +13,7 @@ func (s *ServiceGenerator) constants(data ServiceGeneratorData) error {
 		return nil
 	}
 
-	if err := s.writeToPath("constants.go", constantsTemplater{}, data); err != nil {
+	if err := s.writeToPath(data.outputPath, "constants.go", constantsTemplater{}, data); err != nil {
 		return fmt.Errorf("templating constants: %+v", err)
 	}
 

--- a/tools/generator-go-sdk/generator/stage_ids.go
+++ b/tools/generator-go-sdk/generator/stage_ids.go
@@ -6,19 +6,29 @@ import (
 )
 
 func (s *ServiceGenerator) ids(data ServiceGeneratorData) error {
+	outputDirectory := data.outputPath
+	packageName := data.packageName
+
+	if data.useIdAliases {
+		outputDirectory = data.idsOutputPath
+		packageName = "ids"
+	}
+
 	for idName, idFormat := range data.resourceIds {
 		nameWithoutSuffix := strings.TrimSuffix(idName, "Id") // we suffix 'Id' and 'ID' in places
 		fileNamePrefix := strings.ToLower(nameWithoutSuffix)
-		if err := s.writeToPath(fmt.Sprintf("id_%s.go", fileNamePrefix), idParserTemplater{
-			name:   nameWithoutSuffix,
-			format: idFormat,
+		if err := s.writeToPath(outputDirectory, fmt.Sprintf("id_%s.go", fileNamePrefix), idParserTemplater{
+			name:        nameWithoutSuffix,
+			format:      idFormat,
+			packageName: packageName,
 		}, data); err != nil {
 			return fmt.Errorf("templating ids: %+v", err)
 		}
 
-		if err := s.writeToPath(fmt.Sprintf("id_%s_test.go", fileNamePrefix), idParserTestsTemplater{
-			name:   nameWithoutSuffix,
-			format: idFormat,
+		if err := s.writeToPath(outputDirectory, fmt.Sprintf("id_%s_test.go", fileNamePrefix), idParserTestsTemplater{
+			name:        nameWithoutSuffix,
+			format:      idFormat,
+			packageName: packageName,
 		}, data); err != nil {
 			return fmt.Errorf("templating tests for id: %+v", err)
 		}

--- a/tools/generator-go-sdk/generator/stage_methods.go
+++ b/tools/generator-go-sdk/generator/stage_methods.go
@@ -16,7 +16,7 @@ func (s *ServiceGenerator) methods(data ServiceGeneratorData) error {
 			operationName: operationName,
 			operation:     operation,
 		}
-		if err := s.writeToPath(fileName, gen, data); err != nil {
+		if err := s.writeToPath(data.outputPath, fileName, gen, data); err != nil {
 			return fmt.Errorf("templating methods (using autorest): %+v", err)
 		}
 	}

--- a/tools/generator-go-sdk/generator/stage_models.go
+++ b/tools/generator-go-sdk/generator/stage_models.go
@@ -24,7 +24,7 @@ func (s *ServiceGenerator) models(data ServiceGeneratorData) error {
 			name:  modelName,
 			model: model,
 		}
-		if err := s.writeToPath(fileName, gen, data); err != nil {
+		if err := s.writeToPath(data.outputPath, fileName, gen, data); err != nil {
 			return fmt.Errorf("templating model for %q: %+v", modelName, err)
 		}
 	}

--- a/tools/generator-go-sdk/generator/stage_version.go
+++ b/tools/generator-go-sdk/generator/stage_version.go
@@ -3,7 +3,7 @@ package generator
 import "fmt"
 
 func (s *ServiceGenerator) version(data ServiceGeneratorData) error {
-	if err := s.writeToPath("version.go", versionTemplater{}, data); err != nil {
+	if err := s.writeToPath(data.outputPath, "version.go", versionTemplater{}, data); err != nil {
 		return fmt.Errorf("templating version: %+v", err)
 	}
 

--- a/tools/generator-go-sdk/generator/templater.go
+++ b/tools/generator-go-sdk/generator/templater.go
@@ -10,13 +10,13 @@ type templater interface {
 	template(data ServiceGeneratorData) (*string, error)
 }
 
-func (s *ServiceGenerator) writeToPath(filePath string, templater templater, data ServiceGeneratorData) error {
+func (s *ServiceGenerator) writeToPath(directory, filePath string, templater templater, data ServiceGeneratorData) error {
 	fileContents, err := templater.template(data)
 	if err != nil {
 		return fmt.Errorf("templating: %+v", err)
 	}
 
-	fullFilePath := filepath.Join(data.outputPath, filePath)
+	fullFilePath := filepath.Join(directory, filePath)
 
 	// remove any existing file if it exists
 	_ = os.Remove(fullFilePath)

--- a/tools/generator-go-sdk/generator/templater_id_aliases.go
+++ b/tools/generator-go-sdk/generator/templater_id_aliases.go
@@ -1,0 +1,45 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (s *ServiceGenerator) idAliases(data ServiceGeneratorData) error {
+	if !data.useIdAliases {
+		return nil
+	}
+
+	return s.writeToPath(data.outputPath, "ids.go", idAliasesTemplater{}, data)
+}
+
+var _ templater = idAliasesTemplater{}
+
+type idAliasesTemplater struct {
+}
+
+func (t idAliasesTemplater) template(data ServiceGeneratorData) (*string, error) {
+	keys := make([]string, 0)
+	for k := range data.resourceIds {
+		nameWithoutSuffix := strings.TrimSuffix(k, "Id") // we suffix 'Id' and 'ID' in places
+		keys = append(keys, nameWithoutSuffix)
+	}
+	sort.Strings(keys)
+
+	aliases := make([]string, 0)
+	for _, key := range keys {
+		aliases = append(aliases, fmt.Sprintf(`type %[1]sId = ids.%[1]sId
+func Parse%[1]sID = ids.Parse%[1]sID
+func Parse%[1]sIDInsensitively = ids.Parse%[1]sIDInsensitively
+`, key))
+	}
+
+	output := fmt.Sprintf(`package %[1]s
+
+import "github.com/hashicorp/pandora/sdk/services/%[2]s/%[3]s/ids"
+
+%[4]s
+`, data.packageName, data.servicePackageName, data.apiVersion, strings.Join(aliases, "\n\n"))
+	return &output, nil
+}

--- a/tools/generator-go-sdk/generator/templater_id_parser.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser.go
@@ -9,12 +9,13 @@ import (
 var _ templater = idParserTemplater{}
 
 type idParserTemplater struct {
-	name   string
-	format string
+	name        string
+	format      string
+	packageName string
 }
 
 func (c idParserTemplater) template(data ServiceGeneratorData) (*string, error) {
-	rid, err := newResourceID(c.name, data.packageName, c.format)
+	rid, err := newResourceID(c.name, c.packageName, c.format)
 	if err != nil {
 		return nil, fmt.Errorf("scaffolding ID Parser for %q (%q): %+v", c.name, c.format, err)
 	}

--- a/tools/generator-go-sdk/generator/templater_id_parser_tests.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser_tests.go
@@ -9,12 +9,13 @@ import (
 var _ templater = idParserTestsTemplater{}
 
 type idParserTestsTemplater struct {
-	name   string
-	format string
+	name        string
+	format      string
+	packageName string
 }
 
 func (i idParserTestsTemplater) template(data ServiceGeneratorData) (*string, error) {
-	rid, err := newResourceID(i.name, data.packageName, i.format)
+	rid, err := newResourceID(i.name, i.packageName, i.format)
 	if err != nil {
 		return nil, fmt.Errorf("scaffolding Tests for ID Parser for %q (%q): %+v", i.name, i.format, err)
 	}


### PR DESCRIPTION
First part of #44

Next up is de-duplicating the names when we output them in the ID Package, since it's possible that the same name can be used for multiple Resource ID's - but that's a larger task so this is intentionally feature-flagged off for now since this is touching a large number of files in the generator