### PR TITLE
tools/importer-rest-api-specs: generating the Package Definition

### DIFF
--- a/tools/importer-rest-api-specs/generator/package.go
+++ b/tools/importer-rest-api-specs/generator/package.go
@@ -74,7 +74,7 @@ func (g PandoraDefinitionGenerator) Generate(resourceName string, resource model
 		fileName := path.Join(workingDirectory, fmt.Sprintf("Model-%s.cs", modelName))
 		if *code != "" {
 			if err := writeToFile(fileName, *code); err != nil {
-				return fmt.Errorf("generating code for %q: %+v", modelName, err)
+				return fmt.Errorf("writing code for model %q: %+v", modelName, err)
 			}
 		}
 	}
@@ -89,7 +89,7 @@ func (g PandoraDefinitionGenerator) Generate(resourceName string, resource model
 		code := g.codeForOperation(namespace, operationName, operation)
 		fileName := path.Join(workingDirectory, fmt.Sprintf("Operation-%s.cs", operationName))
 		if err := writeToFile(fileName, code); err != nil {
-			return fmt.Errorf("generating code for %q: %+v", operationName, err)
+			return fmt.Errorf("writing code for operation %q: %+v", operationName, err)
 		}
 	}
 
@@ -103,11 +103,18 @@ func (g PandoraDefinitionGenerator) Generate(resourceName string, resource model
 		code := g.codeForResourceID(namespace, name, id)
 		fileName := path.Join(workingDirectory, fmt.Sprintf("ResourceId-%s.cs", name))
 		if err := writeToFile(fileName, code); err != nil {
-			return fmt.Errorf("generating code for %q: %+v", name, err)
+			return fmt.Errorf("writing code for Resource Id %q: %+v", name, err)
 		}
 	}
 
-	// TODO: also generate the Resource Definition
+	if g.debugLog {
+		log.Printf("[DEBUG] Generating Package Definition..")
+	}
+	packageDefinitionCode := g.codeForPackageDefinition(namespace, resource.Operations)
+	packageDefinitionFileName := path.Join(workingDirectory, "Definition.cs")
+	if err := writeToFile(packageDefinitionFileName, packageDefinitionCode); err != nil {
+		return fmt.Errorf("writing package definition for %q: %+v", packageDefinitionFileName, err)
+	}
 
 	return nil
 }

--- a/tools/importer-rest-api-specs/generator/package_definition.go
+++ b/tools/importer-rest-api-specs/generator/package_definition.go
@@ -1,0 +1,39 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+func (g PandoraDefinitionGenerator) codeForPackageDefinition(namespace string, operations map[string]models.OperationDetails) string {
+	operationNames := make([]string, 0)
+	for operation := range operations {
+		operationNames = append(operationNames, operation)
+	}
+	sort.Strings(operationNames)
+
+	lines := make([]string, 0)
+	for _, operationName := range operationNames {
+		lines = append(lines, fmt.Sprintf("\t\t\tnew %s(),", operationName))
+	}
+
+	return fmt.Sprintf(`using System.Collections.Generic;
+using Pandora.Definitions.Interfaces;
+
+namespace %[1]s
+{
+	internal class Definition : ApiDefinition
+	{
+		public string ApiVersion => "%[3]s";
+		public string Name => "%[2]s";
+		public IEnumerable<ApiOperation> Operations => new List<ApiOperation>
+		{
+%[4]s
+		};
+	}
+}
+`, namespace, g.serviceName, g.apiVersion, strings.Join(lines, "\n"))
+}


### PR DESCRIPTION
This fixes the first part of #55 by outputting the Package Definition, once this is in we'll can look at generating the ApiVersionDefinition and ServiceDefinition