### PR TITLE
tools/generator-go-sdk: prefixing the Parse methods with Parse

### DIFF
--- a/tools/generator-go-sdk/generator/templater_id_parser.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser.go
@@ -309,8 +309,8 @@ func (id resourceIdParserData) codeForParser() string {
 	}
 	parserStatementsStr := strings.Join(parserStatements, "\n")
 	return fmt.Sprintf(`
-// %[1]sID parses a %[1]s ID into an %[1]sId struct 
-func %[1]sID(input string) (*%[1]sId, error) {
+// Parse%[1]sID parses a %[1]s ID into an %[1]sId struct 
+func Parse%[1]sID(input string) (*%[1]sId, error) {
 	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
@@ -373,10 +373,10 @@ func (id resourceIdParserData) codeForParserInsensitive() string {
 	}
 	parserStatementsStr := strings.Join(parserStatements, "\n")
 	return fmt.Sprintf(`
-// %[1]sIDInsensitively parses an %[1]s ID into an %[1]sId struct, insensitively
+// Parse%[1]sIDInsensitively parses an %[1]s ID into an %[1]sId struct, insensitively
 // This should only be used to parse an ID for rewriting to a consistent casing,
-// the %[1]sID method should be used instead for validation etc.
-func %[1]sIDInsensitively(input string) (*%[1]sId, error) {
+// the Parse%[1]sID method should be used instead for validation etc.
+func Parse%[1]sIDInsensitively(input string) (*%[1]sId, error) {
 	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err

--- a/tools/generator-go-sdk/generator/templater_id_parser_tests.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser_tests.go
@@ -116,7 +116,7 @@ func (id resourceIdParserData) testCodeForParser() string {
 	testCasesStr := strings.Join(testCases, "\n")
 	assignmentCheckStr := strings.Join(assignmentChecks, "\n")
 	return fmt.Sprintf(`
-func Test%[1]sID(t *testing.T) {
+func TestParse%[1]sID(t *testing.T) {
 	testData := []struct {
 		Input  string
 		Error  bool
@@ -128,7 +128,7 @@ func Test%[1]sID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %%q", v.Input)
 
-		actual, err := %[1]sID(v.Input)
+		actual, err := Parse%[1]sID(v.Input)
 		if err != nil {
 			if v.Error {
 				continue
@@ -230,7 +230,7 @@ func (id resourceIdParserData) testCodeForParserInsensitive() string {
 	testCasesStr := strings.Join(testCases, "\n")
 	assignmentCheckStr := strings.Join(assignmentChecks, "\n")
 	return fmt.Sprintf(`
-func Test%[1]sIDInsensitively(t *testing.T) {
+func TestParse%[1]sIDInsensitively(t *testing.T) {
 	testData := []struct {
 		Input  string
 		Error  bool
@@ -242,7 +242,7 @@ func Test%[1]sIDInsensitively(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %%q", v.Input)
 
-		actual, err := %[1]sIDInsensitively(v.Input)
+		actual, err := Parse%[1]sIDInsensitively(v.Input)
 		if err != nil {
 			if v.Error {
 				continue


### PR DESCRIPTION
Fixes #43