### PR TITLE
tools/generator-go-sdk: updating the definitions

### DIFF
--- a/tools/importer-rest-api-specs/generator/data.go
+++ b/tools/importer-rest-api-specs/generator/data.go
@@ -31,6 +31,7 @@ func GenerationDataForService(serviceName, rootDirectory, rootNamespace string) 
 func GenerationDataForServiceAndApiVersion(serviceName, apiVersion, rootDirectory, rootNamespace string) GenerationData {
 	normalizedApiVersion := normalizeApiVersion(apiVersion)
 	data := GenerationDataForService(serviceName, rootDirectory, rootNamespace)
+	data.ApiVersion = apiVersion
 	data.NamespaceForApiVersion = fmt.Sprintf("%s.%s", data.NamespaceForService, normalizedApiVersion)
 	data.WorkingDirectoryForApiVersion = path.Join(data.WorkingDirectoryForService, normalizedApiVersion)
 	return data

--- a/tools/importer-rest-api-specs/generator/definition_service.go
+++ b/tools/importer-rest-api-specs/generator/definition_service.go
@@ -43,28 +43,13 @@ func (g PandoraDefinitionGenerator) GenerateServiceDefinition() error {
 	return nil
 }
 
-func codeForServiceDefinitionGenerationSettings(namespace string, serviceName string) string {
-	return fmt.Sprintf(`using System.Collections.Generic;
-using Pandora.Definitions.Interfaces;
-
-namespace %[1]s
-{
-    public partial class Service : ServiceDefinition
-    {
-        public bool Generate => true;
-    }
-}
-`, namespace, serviceName)
-}
-
 func codeForServiceDefinition(namespace, serviceName string, resourceProvider *string) string {
 	rp := "null"
 	if resourceProvider != nil {
 		rp = fmt.Sprintf("%q", *resourceProvider)
 	}
 
-	return fmt.Sprintf(`using System.Collections.Generic;
-using Pandora.Definitions.Interfaces;
+	return fmt.Sprintf(`using Pandora.Definitions.Interfaces;
 
 namespace %[1]s
 {
@@ -75,4 +60,15 @@ namespace %[1]s
     }
 }
 `, namespace, serviceName, rp)
+}
+
+func codeForServiceDefinitionGenerationSettings(namespace string, serviceName string) string {
+	return fmt.Sprintf(`namespace %[1]s
+{
+    public partial class Service
+    {
+        public bool Generate => true;
+    }
+}
+`, namespace, serviceName)
 }

--- a/tools/importer-rest-api-specs/generator/definition_version.go
+++ b/tools/importer-rest-api-specs/generator/definition_version.go
@@ -76,7 +76,7 @@ func codeForApiVersionDefinition(namespace, apiVersion string, isPreview bool, r
 
 	lines := make([]string, 0)
 	for _, name := range names {
-		lines = append(lines, fmt.Sprintf("\t\t\tnew %s.Definition()", name))
+		lines = append(lines, fmt.Sprintf("\t\t\tnew %s.Definition(),", name))
 	}
 
 	return fmt.Sprintf(`using System.Collections.Generic;
@@ -99,12 +99,9 @@ namespace %[1]s
 }
 
 func codeForApiVersionDefinitionSetting(namespace string) string {
-	return fmt.Sprintf(`using System.Collections.Generic;
-using Pandora.Definitions.Interfaces;
-
-namespace %[1]s
+	return fmt.Sprintf(`namespace %[1]s
 {
-	public partial class Definition : ApiVersionDefinition
+	public partial class Definition
 	{
 		public bool Generate => true;
 	}

--- a/tools/importer-rest-api-specs/main.go
+++ b/tools/importer-rest-api-specs/main.go
@@ -152,16 +152,16 @@ func main() {
 		//},
 
 		// Data Protection (PSql)
-		//{
-		//	RootNamespace:    "Pandora.Definitions.ResourceManager",
-		//	ServiceName:      "DataProtection",
-		//	ApiVersion:       "2021-01-01",
-		//	OutputDirectory:  outputDirectory,
-		//	SwaggerDirectory: apiSpecsPath + "/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2021-01-01",
-		//	SwaggerFiles: []string{
-		//		"dataprotection.json",
-		//	},
-		//},
+		{
+			RootNamespace:    "Pandora.Definitions.ResourceManager",
+			ServiceName:      "DataProtection",
+			ApiVersion:       "2021-01-01",
+			OutputDirectory:  outputDirectory,
+			SwaggerDirectory: apiSpecsPath + "/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2021-01-01",
+			SwaggerFiles: []string{
+				"dataprotection.json",
+			},
+		},
 
 		// Healthcare APIS
 		//{


### PR DESCRIPTION
Refactoring these, making the class valid when there's multiple definitions present