### PR TITLE
strip hyphens from service names

### DIFF
--- a/tools/importer-rest-api-specs/generator/data.go
+++ b/tools/importer-rest-api-specs/generator/data.go
@@ -18,11 +18,12 @@ type GenerationData struct {
 }
 
 func GenerationDataForService(serviceName, rootDirectory, rootNamespace string) GenerationData {
-	serviceNamespace := fmt.Sprintf("%s.%s", rootNamespace, strings.Title(serviceName))
-	serviceWorkingDirectory := path.Join(rootDirectory, strings.Title(serviceName))
+	normalisedServiceName := strings.ReplaceAll(serviceName, "-", "")
+	serviceNamespace := fmt.Sprintf("%s.%s", rootNamespace, strings.Title(normalisedServiceName))
+	serviceWorkingDirectory := path.Join(rootDirectory, strings.Title(normalisedServiceName))
 
 	return GenerationData{
-		ServiceName:                serviceName,
+		ServiceName:                normalisedServiceName,
 		NamespaceForService:        serviceNamespace,
 		WorkingDirectoryForService: serviceWorkingDirectory,
 	}


### PR DESCRIPTION
prevents the following happening:
![image](https://user-images.githubusercontent.com/11830746/119791087-67434600-becc-11eb-8b33-e84ed8909417.png)
