### PR TITLE
tools/generator-terraform: scaffolding the project

### DIFF
--- a/tools/generator-terraform/.gitignore
+++ b/tools/generator-terraform/.gitignore
@@ -1,0 +1,1 @@
+generator-terraform

--- a/tools/generator-terraform/generator/data.go
+++ b/tools/generator-terraform/generator/data.go
@@ -1,0 +1,158 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Data struct {
+	// ClientName is the full path to access this SDK Client
+	// for example `Example.ExampleClients` or `Resources.GroupsClient`
+	ClientName string
+
+	// ResourceIDTypeName is the name of the Type used for the Resource ID
+	ResourceIDTypeName *string
+
+	// IsResource specifies whether this is a Terraform Data Source or a Resource
+	IsResource bool
+
+	// ResourceName is the name of this resource e.g. `Foo` which gets transformed into `azurerm_foo`
+	ResourceName string
+
+	// ResourceType is the Terraform Resource Type e.g. `azurerm_foo`
+	ResourceType string
+
+	// PackageName is the name of the Go Package where this resource should be generated
+	PackageName string
+
+	// PackageWorkingDirectory is a fully qualified path for the Working Directory for this Package
+	PackageWorkingDirectory string
+
+	// ProviderPrefix is the prefix used for this provider (e.g. `azurerm`)
+	ProviderPrefix string
+
+	// DataSourceReadOperation describes the Read operation for a Data Source
+	DataSourceReadOperation *OperationDetails
+
+	// DataSourceTestCases describes the test cases for a Data Source
+	DataSourceTestCases *TestCasesDefinition
+
+	// ResourceCreateOperation describes the Create operation for a resource
+	ResourceCreateOperation *OperationDetails
+
+	// ResourceDeleteOperation describes the Delete operation for a Resource
+	ResourceDeleteOperation *OperationDetails
+
+	// ResourceReadOperation describes the Read operation for a resource
+	ResourceReadOperation *OperationDetails
+
+	// ResourceUpdateOperation describes the Read operation for a resource
+	ResourceUpdateOperation *OperationDetails
+
+	// ResourceTestCases describes the test cases for a Resource
+	ResourceTestCases *TestCasesDefinition
+
+	// SchemaFieldsToResourceIDMappings is a list of schema fields within the Model which should be used
+	// to construct the Resource ID Mapping
+	SchemaFieldsToResourceIDMappings *[]string
+
+	// TopLevelSchema defines the top level fields
+	TopLevelSchema *ModelDefinition
+
+	// Objects defines the Constants and Models used by the Top Level Schema
+	Objects *Objects
+
+	// fileNamePrefix is the computed filename prefix for this resource
+	// in the format `example_resource` or `example_data_source`
+	fileNamePrefix string
+}
+
+type TestCasesDefinition struct {
+	Configs map[string]TestConfigDefinition
+	Tests   map[string]TestCaseDefinition
+}
+
+type TestCaseDefinition struct {
+	Stages []TestCaseDefinitionStage
+}
+
+type TestCaseDefinitionStage struct {
+	ConfigName     *string
+	Import         bool
+	RequiresImport bool
+	// TODO: assertions ..
+}
+
+type TestConfigDefinition struct {
+	Config string
+	// TODO: this could also house 'variables' I guess?
+}
+
+func (d *Data) process() error {
+	resourceType := "resource"
+	if !d.IsResource {
+		resourceType = "data"
+	}
+	d.fileNamePrefix = fmt.Sprintf("%s_%s", strings.ToLower(d.ResourceName), resourceType)
+
+	return nil
+}
+
+type Objects struct {
+	Constants map[string]ConstantDefinition
+	Models    map[string]ModelDefinition
+}
+
+type ConstantDefinition struct {
+	Values    map[string]string
+	FieldType ConstantFieldType
+}
+
+type ConstantFieldType string
+
+const (
+	IntegerConstant ConstantFieldType = "int"
+	FloatConstant   ConstantFieldType = "float"
+	StringConstant  ConstantFieldType = "string"
+	UnknownConstant ConstantFieldType = "unknown"
+)
+
+type ModelDefinition struct {
+	Description string
+	Fields      map[string]FieldDefinition
+}
+
+type FieldDefinition struct {
+	Computed          bool
+	ConstantReference *string
+	Default           *interface{}
+	Deprecated        bool
+	Description       string
+	ForceNew          bool
+	HclLabel          string
+	MaxItems          *int
+	ModelReference    *string
+	MinItems          *int
+	Optional          bool
+	Required          bool
+	Sensitive         bool
+	Type              FieldTypeDefinition
+	// TODO: validation
+}
+
+type FieldTypeDefinition string
+
+const (
+	FieldTypeDefinitionBoolean       FieldTypeDefinition = "Boolean"
+	FieldTypeDefinitionFloat         FieldTypeDefinition = "Float"
+	FieldTypeDefinitionInteger       FieldTypeDefinition = "Integer"
+	FieldTypeDefinitionJson          FieldTypeDefinition = "Json"
+	FieldTypeDefinitionMap           FieldTypeDefinition = "Map"
+	FieldTypeDefinitionList          FieldTypeDefinition = "List"
+	FieldTypeDefinitionLocation      FieldTypeDefinition = "Location"
+	FieldTypeDefinitionResourceGroup FieldTypeDefinition = "ResourceGroup"
+	FieldTypeDefinitionSet           FieldTypeDefinition = "Set"
+	FieldTypeDefinitionString        FieldTypeDefinition = "String"
+	FieldTypeDefinitionTags          FieldTypeDefinition = "Tags"
+	FieldTypeDefinitionUnknown       FieldTypeDefinition = "Unknown"
+)

--- a/tools/generator-terraform/generator/defaults.go
+++ b/tools/generator-terraform/generator/defaults.go
@@ -1,0 +1,6 @@
+package generator
+
+const defaultCreateTimeout = 30
+const defaultDeleteTimeout = 30
+const defaultReadTimeout = 5
+const defaultUpdateTimeout = 30

--- a/tools/generator-terraform/generator/generator.go
+++ b/tools/generator-terraform/generator/generator.go
@@ -1,0 +1,111 @@
+package generator
+
+import (
+	"fmt"
+	"log"
+	"path"
+	"strings"
+)
+
+type Generator struct {
+	data  *Data
+	debug bool
+}
+
+func NewGenerator(data Data, debug bool) *Generator {
+	return &Generator{
+		data:  &data,
+		debug: debug,
+	}
+}
+
+func (g Generator) Generate() error {
+	if g.debug {
+		log.Printf("[DEBUG] Processing Data..")
+	}
+	if err := g.data.process(); err != nil {
+		return fmt.Errorf("processing data: %+v", err)
+	}
+	if g.debug {
+		log.Printf("[DEBUG] Ensuring working directory exists..")
+	}
+	ensureDirectoryExists(g.data.PackageWorkingDirectory)
+	removeGeneratedFiles(g.data.PackageWorkingDirectory, g.data.fileNamePrefix)
+
+	if g.debug {
+		log.Printf("[DEBUG] Running Generation..")
+	}
+
+	stages := map[string]stage{
+		"dataSourceDefinition": dataSourceDefinitionStage{},
+		"dataSourceRead":       dataSourceReadStage{},
+		"dataSourceTests":      dataSourceTestsStage{},
+
+		"resourceDefinition": resourceDefinitionStage{},
+		"resourceCreate":     resourceCreateStage{},
+		"resourceDelete":     resourceDeleteStage{},
+		"resourceRead":       resourceReadStage{},
+		"resourceUpdate":     resourceUpdateStage{},
+		"resourceTests":      resourceTestsStage{},
+
+		// TODO: finish implementing these
+		"dataSourceSchema": dataSourceSchemaStage{},
+		"resourceSchema":   resourceSchemaStage{},
+		"model":            modelStage{},
+
+		// TODO: implement this
+		// "validationFuncs": validationFuncsStage{},
+	}
+	for name, stage := range stages {
+		if g.debug {
+			log.Printf("  [DEBUG] Stage %q..", name)
+		}
+
+		if !stage.applicable(g.data) {
+			log.Printf("  [DEBUG] .. is not applicable - skipping stage.")
+			continue
+		}
+
+		filePath := stage.filePath(*g.data)
+		filePath = path.Join(g.data.PackageWorkingDirectory, filePath)
+
+		// Generated files are `*.gen.go` - hand maintained are `*.go` - if a hand-maintained file
+		// exists then we don't output a generated version
+		generatedFileName := fmt.Sprintf("%s.gen.go", strings.TrimSuffix(filePath, ".go"))
+		handMaintainedFileName := filePath
+		if fileExistsAtPath(handMaintainedFileName) {
+			if g.debug {
+				log.Printf("  [DEBUG] Hand-maintained file exists at %q - skipping stage.", handMaintainedFileName)
+			}
+			continue
+		}
+
+		fileContent, err := stage.generate(*g.data)
+		if err != nil {
+			return fmt.Errorf("running generation stage %q for %q: %+v", name, g.data.fileNamePrefix, err)
+		}
+
+		if g.debug {
+			log.Printf("  [DEBUG] Writing to %q..", generatedFileName)
+		}
+		if err := writeToFile(generatedFileName, *fileContent); err != nil {
+			return fmt.Errorf("outputting generated contents to %q: %+v", generatedFileName, err)
+		}
+
+		if g.debug {
+			log.Printf("  [DEBUG] Completed Stage %q.", name)
+		}
+	}
+
+	if g.debug {
+		log.Printf("  [DEBUG] Running Go Fmt..")
+	}
+	runGoFmt(g.data.PackageWorkingDirectory)
+
+	if g.debug {
+		log.Printf("  [DEBUG] Running Go Imports..")
+	}
+	runGoImports(g.data.PackageWorkingDirectory)
+
+	return nil
+}

--- a/tools/generator-terraform/generator/helpers.go
+++ b/tools/generator-terraform/generator/helpers.go
@@ -1,0 +1,65 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+)
+
+func ensureDirectoryExists(directory string) {
+	os.MkdirAll(directory, 0755)
+}
+
+func fileExistsAtPath(filePath string) bool {
+	exists, err := os.Stat(filePath)
+	if err != nil {
+		return false
+	}
+
+	return exists.Size() > 0
+}
+
+func removeGeneratedFiles(directory string, fileNamePrefix string) error {
+	match := fmt.Sprintf("%s*.gen.go", fileNamePrefix)
+	files, err := filepath.Glob(path.Join(directory, match))
+	if err != nil {
+		return fmt.Errorf("finding files matching %q: %+v", match, err)
+	}
+
+	for _, file := range files {
+		os.Remove(file)
+	}
+	return nil
+}
+
+func runGoFmt(path string) {
+	cmd := exec.Command("gofmt", "-w", path)
+	_ = cmd.Start()
+	_ = cmd.Wait()
+}
+
+func runGoImports(path string) {
+	cmd := exec.Command("goimports", "-w", path)
+	_ = cmd.Start()
+	_ = cmd.Wait()
+}
+
+func writeToFile(fileName, fileContents string) error {
+	existing, err := os.Open(fileName)
+	if os.IsExist(err) {
+		return fmt.Errorf("existing file exists at %q", fileName)
+	}
+	existing.Close()
+
+	file, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("creating %q: %+v", fileName, err)
+	}
+
+	file.WriteString(fileContents)
+	file.Close()
+
+	return nil
+}

--- a/tools/generator-terraform/generator/models.go
+++ b/tools/generator-terraform/generator/models.go
@@ -1,0 +1,21 @@
+package generator
+
+type OperationDetails struct {
+	// CustomTimeoutInMinutes is a custom timeout which should be used for the context instead of the default
+	// timeout when this method is being called - this can be useful in extremely quick, or extremely slow
+	// operations
+	CustomTimeoutInMinutes *int
+
+	// Generate defines whether or not this should be generated this is useful for Read functions
+	// which are needed for other functions but may not be explicitly generated.
+	Generate bool
+
+	// SDKMethodIsLongRunning specifies whether the SDK Method is a Long Running/Polling Operation
+	SDKMethodIsLongRunning bool
+
+	// SDKMethodName is the name of the method within the SDK which should be called
+	SDKMethodName string
+
+	// SDKModelName is the name of the model used in the SDK by this operation
+	SDKModelName *string
+}

--- a/tools/generator-terraform/generator/stage.go
+++ b/tools/generator-terraform/generator/stage.go
@@ -1,0 +1,7 @@
+package generator
+
+type stage interface {
+	applicable(data *Data) bool
+	filePath(data Data) string
+	generate(data Data) (*string, error)
+}

--- a/tools/generator-terraform/generator/stage_data_definition.go
+++ b/tools/generator-terraform/generator/stage_data_definition.go
@@ -1,0 +1,40 @@
+package generator
+
+import "fmt"
+
+var _ stage = dataSourceDefinitionStage{}
+
+type dataSourceDefinitionStage struct {
+}
+
+func (r dataSourceDefinitionStage) applicable(data *Data) bool {
+	return !data.IsResource
+}
+
+func (r dataSourceDefinitionStage) filePath(data Data) string {
+	return fmt.Sprintf("%s.go", data.fileNamePrefix)
+}
+
+func (r dataSourceDefinitionStage) generate(data Data) (*string, error) {
+	contents := fmt.Sprintf(`package %[1]s
+
+import (
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+)
+
+var _ tfsdk.DataSource = %[2]sDataSource{}
+
+type %[2]sDataSource struct{}
+
+func (r %[2]sDataSource) ModelObject() interface{} {
+	return %[2]sDataSourceModel{}
+}
+
+func (r %[2]sDataSource) ResourceType() string {
+	return %[3]q
+}
+`, data.PackageName, data.ResourceName, data.ResourceType)
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_data_read.go
+++ b/tools/generator-terraform/generator/stage_data_read.go
@@ -1,0 +1,101 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+var _ stage = dataSourceReadStage{}
+
+type dataSourceReadStage struct{}
+
+func (d dataSourceReadStage) applicable(data *Data) bool {
+	return !data.IsResource && data.DataSourceReadOperation != nil && data.DataSourceReadOperation.Generate
+}
+
+func (d dataSourceReadStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_read.go", data.fileNamePrefix)
+}
+
+func (d dataSourceReadStage) generate(data Data) (*string, error) {
+	sdkMethodName := data.DataSourceReadOperation.SDKMethodName
+	isLongRunning := data.DataSourceReadOperation.SDKMethodIsLongRunning
+	timeoutInMinutes := defaultReadTimeout
+	if data.DataSourceReadOperation.CustomTimeoutInMinutes != nil {
+		timeoutInMinutes = *data.DataSourceReadOperation.CustomTimeoutInMinutes
+	}
+
+	if isLongRunning {
+		return nil, fmt.Errorf("long running read operations are not supported")
+	}
+
+	// TODO: we assume everything has an ID at this point which is _fine for now_ but needs fixing
+	// TODO: we don't handle options objects but that's _fine_ for now
+	// TODO: support for List operations
+
+	idConstructor := "r.IDFromSchema(config)" // which requires someone creates this by hand at present
+	if data.SchemaFieldsToResourceIDMappings != nil && len(*data.SchemaFieldsToResourceIDMappings) > 0 {
+		segments := make([]string, 0)
+		for _, v := range *data.SchemaFieldsToResourceIDMappings {
+			segments = append(segments, fmt.Sprintf("model.%s", v))
+		}
+		idConstructor = fmt.Sprintf("gosdk.New%sID(subscriptionId, %s)", *data.ResourceIDTypeName, strings.Join(segments, ", "))
+	}
+
+	mapper := mappingData{
+		typeAlias:  "ds",
+		typeName:   fmt.Sprintf("%sDataSource", data.ResourceName),
+		methodName: "mapReadModelToSchema",
+		modelName:  *data.DataSourceReadOperation.SDKModelName,
+
+		// TODO: mapping definitions
+	}
+	mappingCode, err := mapper.modelToSchemaCode()
+	if err != nil {
+		return nil, fmt.Errorf("generating mapping code: %+v", err)
+	}
+
+	contents := fmt.Sprintf(`package %[1]s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+)
+
+func (ds %[2]sDataSource) Read() tfsdk.ResourceFunc {
+	return tfsdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata tfsdk.ResourceMetaData) error {
+			client := metadata.Client.%[4]s
+
+			id := %[5]s
+			metadata.Logger.Infof("Retrieving %%s..", id)
+			resp, err := client.%[6]s(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %%s: %%+v", id, err)
+			}
+
+			metadata.Logger.Infof("Decoding schema into model for %%s..", id)
+			var schema %[2]sDataSourceModel
+			metadata.Logger.Infof("Mapping %%s..", id)
+			if err := ds.mapReadModelToSchema(&model); err != nil {
+				return fmt.Errorf("mapping response model to schema for %%s: %%+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return metadata.Encode(&schema)
+		},
+		Timeout: %[3]d * time.Minute,
+	}
+}
+
+%[7]s
+`, data.PackageName, data.ResourceName, timeoutInMinutes, data.ClientName, idConstructor, sdkMethodName, *mappingCode)
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_data_schema.go
+++ b/tools/generator-terraform/generator/stage_data_schema.go
@@ -1,0 +1,59 @@
+package generator
+
+import (
+	"fmt"
+)
+
+var _ stage = dataSourceSchemaStage{}
+
+type dataSourceSchemaStage struct{}
+
+func (r dataSourceSchemaStage) applicable(data *Data) bool {
+	return !data.IsResource && data.TopLevelSchema != nil
+}
+
+func (r dataSourceSchemaStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_schema.go", data.fileNamePrefix)
+}
+
+func (r dataSourceSchemaStage) generate(data Data) (*string, error) {
+	argumentsFields := make(map[string]FieldDefinition, 0)
+	attributesFields := make(map[string]FieldDefinition, 0)
+	for name, field := range data.TopLevelSchema.Fields {
+		if field.Computed {
+			if !field.Optional && !field.Required {
+				attributesFields[name] = field
+				continue
+			}
+		}
+
+		argumentsFields[name] = field
+	}
+
+	argumentsCode, err := schemaForFields(argumentsFields, data.Objects, true)
+	if err != nil {
+		return nil, fmt.Errorf("generating schema code for arguments: %+v", err)
+	}
+	attributesCode, err := schemaForFields(attributesFields, data.Objects, true)
+	if err != nil {
+		return nil, fmt.Errorf("generating schema code for attributes: %+v", err)
+	}
+
+	content := fmt.Sprintf(`package %[1]s
+
+import (
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+)
+
+func (r %[2]sDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return %[3]s
+}
+
+func (r %[2]sDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return %[4]s
+}
+`, data.PackageName, data.ResourceName, *argumentsCode, *attributesCode)
+	return &content, nil
+}

--- a/tools/generator-terraform/generator/stage_data_source_tests.go
+++ b/tools/generator-terraform/generator/stage_data_source_tests.go
@@ -1,0 +1,96 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var _ stage = dataSourceTestsStage{}
+
+type dataSourceTestsStage struct{}
+
+func (d dataSourceTestsStage) applicable(data *Data) bool {
+	return !data.IsResource && data.DataSourceTestCases != nil
+}
+
+func (d dataSourceTestsStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_test.go", data.fileNamePrefix)
+}
+
+func (d dataSourceTestsStage) generate(data Data) (*string, error) {
+	testNames := make([]string, 0)
+	for name := range data.DataSourceTestCases.Tests {
+		testNames = append(testNames, name)
+	}
+	sort.Strings(testNames)
+
+	testFuncs := make([]string, 0)
+	for _, testName := range testNames {
+		test := data.DataSourceTestCases.Tests[testName]
+
+		stages := make([]string, 0)
+		for i, stage := range test.Stages {
+			if stage.ConfigName == nil {
+				return nil, fmt.Errorf("missing ConfigName for Test Stage %d for %q", i, testName)
+			}
+
+			if stage.Import || stage.RequiresImport {
+				return nil, fmt.Errorf("Import/RequiresImport can only be configured for a Resource")
+			}
+
+			stages = append(stages, fmt.Sprintf(`		{
+			Config: ds.%[1]s(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				// TODO: assertions
+				// check.That(data.ResourceName).Key("is_online").HasValue("false"),
+			),
+		},`, *stage.ConfigName))
+		}
+
+		testFuncs = append(testFuncs, fmt.Sprintf(`
+func TestAcc%[1]sDataSource_%[2]s(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.%[3]s", "test")
+	ds := %[1]sDataSourceTest{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+%[4]s
+	})
+}
+`, data.ResourceName, testName, data.ResourceType, strings.Join(stages, "\n")))
+	}
+
+	testConfigNames := make([]string, 0)
+	for name := range data.DataSourceTestCases.Configs {
+		testConfigNames = append(testConfigNames, name)
+	}
+	sort.Strings(testConfigNames)
+
+	testConfigFuncs := make([]string, 0)
+	for _, name := range testConfigNames {
+		testConfig := data.DataSourceTestCases.Configs[name]
+		backtick := "`"
+		testConfigFuncs = append(testConfigFuncs, fmt.Sprintf(`
+func (r %[1]sDataSourceTest) %[2]s(data acceptance.TestData) string {
+	return fmt.Sprintf(%[4]s%[3]s%[4]s, data.RandomInteger, data.RandomString)
+}
+		`, data.ResourceName, name, testConfig.Config, backtick))
+	}
+
+	contents := fmt.Sprintf(`package %[1]s_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+)
+
+type %[2]sDataSourceTest struct {
+}
+
+%[3]s
+%[4]s
+`, data.PackageName, data.ResourceName, strings.Join(testFuncs, "\n"), strings.Join(testConfigFuncs, "\n"))
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_model.go
+++ b/tools/generator-terraform/generator/stage_model.go
@@ -1,0 +1,87 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var _ stage = modelStage{}
+
+type modelStage struct{}
+
+func (m modelStage) applicable(data *Data) bool {
+	return data.TopLevelSchema != nil || data.Objects != nil
+}
+
+func (m modelStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_model.go", data.fileNamePrefix)
+}
+
+func (m modelStage) generate(data Data) (*string, error) {
+	lines := make([]string, 0)
+
+	if data.TopLevelSchema != nil {
+		topLevelCode, err := m.topLevelModelCode(data.ResourceName, data.IsResource, data.TopLevelSchema.Fields)
+		if err != nil {
+			return nil, fmt.Errorf("generating model for top level model: %+v", err)
+		}
+
+		lines = append(lines, *topLevelCode)
+	}
+
+	if data.Objects != nil {
+		// we're only concerned with models, constants come from the SDK
+		sortedModelNames := make([]string, 0)
+		for name := range data.Objects.Models {
+			sortedModelNames = append(sortedModelNames, name)
+		}
+		sort.Strings(sortedModelNames)
+
+		for _, name := range sortedModelNames {
+			model := data.Objects.Models[name]
+			code, err := m.codeForModel(name, model.Fields)
+			if err != nil {
+				return nil, fmt.Errorf("generating code for model %q: %+v", name, err)
+			}
+
+			lines = append(lines, *code)
+		}
+	}
+
+	contents := fmt.Sprintf(`package %[1]s
+
+%[2]s
+`, data.PackageName, strings.Join(lines, "\n"))
+	return &contents, nil
+}
+
+func (m modelStage) topLevelModelCode(modelName string, isResource bool, input map[string]FieldDefinition) (*string, error) {
+	name := fmt.Sprintf("%sResourceModel", modelName)
+	if !isResource {
+		name = fmt.Sprintf("%sDataSourceModel", modelName)
+	}
+
+	return m.codeForModel(name, input)
+}
+
+func (m modelStage) codeForModel(name string, fields map[string]FieldDefinition) (*string, error) {
+	fieldNames := make([]string, 0)
+	for k := range fields {
+		fieldNames = append(fieldNames, k)
+	}
+	sort.Strings(fieldNames)
+
+	codeForFields := make([]string, 0)
+	for _, fieldName := range fieldNames {
+		field := fields[fieldName]
+		fieldType := "string" // TODO: make this dynamic
+		codeForFields = append(codeForFields, fmt.Sprintf("\t%[1]s %[2]s `tfschema:%[3]q`", fieldName, fieldType, field.HclLabel))
+	}
+
+	contents := fmt.Sprintf(`type %[1]s struct {
+%[2]s
+}
+`, name, strings.Join(codeForFields, "\n"))
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_resource_create.go
+++ b/tools/generator-terraform/generator/stage_resource_create.go
@@ -1,0 +1,118 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+var _ stage = resourceCreateStage{}
+
+type resourceCreateStage struct{}
+
+func (r resourceCreateStage) applicable(data *Data) bool {
+	return data.IsResource && data.ResourceCreateOperation != nil && data.ResourceCreateOperation.Generate
+}
+
+func (r resourceCreateStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_create.go", data.fileNamePrefix)
+}
+
+func (r resourceCreateStage) generate(data Data) (*string, error) {
+	if data.ResourceReadOperation == nil {
+		return nil, fmt.Errorf("Create requires that a ReadOperation is defined to be able to generate Requires Import")
+	}
+
+	sdkCreateMethodName := data.ResourceCreateOperation.SDKMethodName
+	isLongRunning := data.ResourceCreateOperation.SDKMethodIsLongRunning
+	timeoutInMinutes := defaultCreateTimeout
+	if data.ResourceCreateOperation.CustomTimeoutInMinutes != nil {
+		timeoutInMinutes = *data.ResourceCreateOperation.CustomTimeoutInMinutes
+	}
+
+	if isLongRunning {
+		sdkCreateMethodName = fmt.Sprintf("%sThenPoll", sdkCreateMethodName)
+	}
+
+	sdkReadMethodName := data.ResourceReadOperation.SDKMethodName
+
+	// TODO: we assume everything has an ID at this point which is _fine for now_ but needs fixing
+	// TODO: we don't handle options objects but that's _fine_ for now
+
+	idConstructor := "r.IDFromSchema(config)" // which requires someone creates this by hand at present
+	if data.SchemaFieldsToResourceIDMappings != nil && len(*data.SchemaFieldsToResourceIDMappings) > 0 {
+		segments := make([]string, 0)
+		for _, v := range *data.SchemaFieldsToResourceIDMappings {
+			segments = append(segments, fmt.Sprintf("model.%s", v))
+		}
+		idConstructor = fmt.Sprintf("gosdk.New%sID(subscriptionId, %s)", *data.ResourceIDTypeName, strings.Join(segments, ", "))
+	}
+
+	mapper := mappingData{
+		typeAlias:  "r",
+		typeName:   fmt.Sprintf("%sResource", data.ResourceName),
+		methodName: "mapSchemaToCreateModel",
+		modelName:  *data.ResourceCreateOperation.SDKModelName,
+
+		// TODO: mapping definitions
+	}
+	mappingCode, err := mapper.schemaToModelCode(false)
+	if err != nil {
+		return nil, fmt.Errorf("generating mapping code: %+v", err)
+	}
+
+	contents := fmt.Sprintf(`package %[1]s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+)
+
+func (r %[2]sResource) Create() tfsdk.ResourceFunc {
+	return tfsdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata tfsdk.ResourceMetaData) error {
+			client := metadata.Client.%[4]s
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var config %[2]sResourceModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %%+v", err)
+			}
+
+			id := %[5]s
+			metadata.Logger.Infof("Checking for the presence of an existing %%s..", *id)
+			existing, err := client.%[7]s(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for the presence of an existing %%s: %%+v", id, err)
+				}
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			metadata.Logger.Infof("Mapping create model for %%s..", *id)
+			if err := r.mapSchemaToCreateModel(config, &model); err != nil {
+				return fmt.Errorf("building model for creation of %%s: %%+v", id, err)
+			}
+
+			metadata.Logger.Infof("Creating %%s..", *id)
+			if err := client.%[6]s(ctx, id, *model); err != nil {
+				return fmt.Errorf("creating %%s: %%+v", *id, err)
+			}
+			metadata.Logger.Infof("Created %%s.", *id)
+
+			metadata.SetID(id)
+			return nil
+		},
+		Timeout: %[3]d * time.Minute,
+	}
+}
+
+%[8]s
+`, data.PackageName, data.ResourceName, timeoutInMinutes, data.ClientName, idConstructor, sdkCreateMethodName, sdkReadMethodName, *mappingCode)
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_resource_definition.go
+++ b/tools/generator-terraform/generator/stage_resource_definition.go
@@ -1,0 +1,44 @@
+package generator
+
+import "fmt"
+
+var _ stage = resourceDefinitionStage{}
+
+type resourceDefinitionStage struct {
+}
+
+func (r resourceDefinitionStage) applicable(data *Data) bool {
+	return data.IsResource
+}
+
+func (r resourceDefinitionStage) filePath(data Data) string {
+	return fmt.Sprintf("%s.go", data.fileNamePrefix)
+}
+
+func (r resourceDefinitionStage) generate(data Data) (*string, error) {
+	contents := fmt.Sprintf(`package %[1]s
+
+import (
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+)
+
+var _ tfsdk.Resource = %[2]sResource{}
+
+type %[2]sResource struct{}
+
+func (r %[2]sResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return nil // TODO
+}
+
+func (r %[2]sResource) ModelObject() interface{} {
+	return %[2]sResourceModel{}
+}
+
+func (r %[2]sResource) ResourceType() string {
+	return %[3]q
+}
+`, data.PackageName, data.ResourceName, data.ResourceType)
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_resource_delete.go
+++ b/tools/generator-terraform/generator/stage_resource_delete.go
@@ -1,0 +1,66 @@
+package generator
+
+import "fmt"
+
+var _ stage = resourceDeleteStage{}
+
+type resourceDeleteStage struct{}
+
+func (r resourceDeleteStage) applicable(data *Data) bool {
+	return data.IsResource && data.ResourceDeleteOperation != nil && data.ResourceDeleteOperation.Generate
+}
+
+func (r resourceDeleteStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_delete.go", data.fileNamePrefix)
+}
+
+func (r resourceDeleteStage) generate(data Data) (*string, error) {
+	sdkMethodName := data.ResourceDeleteOperation.SDKMethodName
+	isLongRunning := data.ResourceDeleteOperation.SDKMethodIsLongRunning
+	timeoutInMinutes := defaultDeleteTimeout
+	if data.ResourceDeleteOperation.CustomTimeoutInMinutes != nil {
+		timeoutInMinutes = *data.ResourceDeleteOperation.CustomTimeoutInMinutes
+	}
+
+	if isLongRunning {
+		sdkMethodName = fmt.Sprintf("%sThenPoll", sdkMethodName)
+	}
+
+	// TODO: we assume everything has an ID at this point which is _fine for now_ but needs fixing
+	// TODO: we don't handle options objects but that's _fine_ for now
+
+	contents := fmt.Sprintf(`package %[1]s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+)
+
+func (r %[2]sResource) Delete() tfsdk.ResourceFunc {
+	return tfsdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata tfsdk.ResourceMetaData) error {
+			client := metadata.Client.%[4]s
+
+			id, err := gosdk.Parse%[5]sID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("Deleting %%s..", *id)
+			if err := client.%[6]s(ctx, id); err != nil {
+				return fmt.Errorf("deleting %%s: %%+v", *id, err)
+			}
+			metadata.Logger.Infof("Deleted %%s.", *id)
+
+			return nil
+		},
+		Timeout: %[3]d * time.Minute,
+	}
+}
+`, data.PackageName, data.ResourceName, timeoutInMinutes, data.ClientName, *data.ResourceIDTypeName, sdkMethodName)
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_resource_read.go
+++ b/tools/generator-terraform/generator/stage_resource_read.go
@@ -1,0 +1,99 @@
+package generator
+
+import "fmt"
+
+var _ stage = resourceReadStage{}
+
+type resourceReadStage struct {
+}
+
+func (r resourceReadStage) applicable(data *Data) bool {
+	return data.IsResource && data.ResourceReadOperation != nil && data.ResourceReadOperation.Generate
+}
+
+func (r resourceReadStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_read.go", data.fileNamePrefix)
+}
+
+func (r resourceReadStage) generate(data Data) (*string, error) {
+	sdkMethodName := data.ResourceReadOperation.SDKMethodName
+	isLongRunning := data.ResourceReadOperation.SDKMethodIsLongRunning
+	timeoutInMinutes := defaultReadTimeout
+	if data.ResourceReadOperation.CustomTimeoutInMinutes != nil {
+		timeoutInMinutes = *data.ResourceReadOperation.CustomTimeoutInMinutes
+	}
+
+	if isLongRunning {
+		return nil, fmt.Errorf("long running read operations are not supported")
+	}
+
+	// TODO: we assume everything has an ID at this point which is _fine for now_ but needs fixing
+	// TODO: we don't handle options objects but that's _fine_ for now
+	// TODO: support for List operations
+
+	mapper := mappingData{
+		typeAlias:  "r",
+		typeName:   fmt.Sprintf("%sResource", data.ResourceName),
+		methodName: "mapReadModelToSchema",
+		modelName:  *data.ResourceReadOperation.SDKModelName,
+
+		// TODO: mapping definitions
+	}
+	mappingCode, err := mapper.modelToSchemaCode()
+	if err != nil {
+		return nil, fmt.Errorf("generating mapping code: %+v", err)
+	}
+
+	// TODO: we also need to map the ID Segments back to the Schema fields, by inverting `data.SchemaFieldsToResourceIDMappings`
+
+	contents := fmt.Sprintf(`package %[1]s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+)
+
+func (r %[2]sResource) Read() tfsdk.ResourceFunc {
+	return tfsdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata tfsdk.ResourceMetaData) error {
+			client := metadata.Client.%[4]s
+
+			id, err := gosdk.Parse%[5]sID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("Retrieving %%s..", *id)
+			resp, err := client.%[6]s(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(*id)
+				}
+				return fmt.Errorf("retrieving %%s: %%+v", *id, err)
+			}
+
+			metadata.Logger.Infof("Decoding schema into model for %%s..", *id)
+			var schema %[2]sResourceModel
+			if err := metadata.Decode(&schema); err != nil {
+				return fmt.Errorf("decoding schema into model: %%+v", err)
+			}
+
+			metadata.Logger.Infof("Mapping %%s..", *id)
+			if err := r.mapReadModelToSchema(&model); err != nil {
+				return fmt.Errorf("mapping response model to schema for %%s: %%+v", *id, err)
+			}
+
+			return metadata.Encode(&schema)
+		},
+		Timeout: %[3]d * time.Minute,
+	}
+}
+
+%[7]s
+`, data.PackageName, data.ResourceName, timeoutInMinutes, data.ClientName, *data.ResourceIDTypeName, sdkMethodName, *mappingCode)
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_resource_schema.go
+++ b/tools/generator-terraform/generator/stage_resource_schema.go
@@ -1,0 +1,59 @@
+package generator
+
+import (
+	"fmt"
+)
+
+var _ stage = resourceSchemaStage{}
+
+type resourceSchemaStage struct{}
+
+func (r resourceSchemaStage) applicable(data *Data) bool {
+	return data.IsResource && data.TopLevelSchema != nil
+}
+
+func (r resourceSchemaStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_schema.go", data.fileNamePrefix)
+}
+
+func (r resourceSchemaStage) generate(data Data) (*string, error) {
+	argumentsFields := make(map[string]FieldDefinition, 0)
+	attributesFields := make(map[string]FieldDefinition, 0)
+	for name, field := range data.TopLevelSchema.Fields {
+		if field.Computed {
+			if !field.Optional && !field.Required {
+				attributesFields[name] = field
+				continue
+			}
+		}
+
+		argumentsFields[name] = field
+	}
+
+	argumentsCode, err := schemaForFields(argumentsFields, data.Objects, false)
+	if err != nil {
+		return nil, fmt.Errorf("generating schema code for arguments: %+v", err)
+	}
+	attributesCode, err := schemaForFields(attributesFields, data.Objects, false)
+	if err != nil {
+		return nil, fmt.Errorf("generating schema code for attributes: %+v", err)
+	}
+
+	content := fmt.Sprintf(`package %[1]s
+
+import (
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+)
+
+func (r %[2]sResource) Arguments() map[string]*pluginsdk.Schema {
+	return %[3]s
+}
+
+func (r %[2]sResource) Attributes() map[string]*pluginsdk.Schema {
+	return %[4]s
+}
+`, data.PackageName, data.ResourceName, *argumentsCode, *attributesCode)
+	return &content, nil
+}

--- a/tools/generator-terraform/generator/stage_resource_tests.go
+++ b/tools/generator-terraform/generator/stage_resource_tests.go
@@ -1,0 +1,120 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var _ stage = resourceTestsStage{}
+
+type resourceTestsStage struct{}
+
+func (d resourceTestsStage) applicable(data *Data) bool {
+	return data.IsResource && data.ResourceTestCases != nil
+}
+
+func (d resourceTestsStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_test.go", data.fileNamePrefix)
+}
+
+func (d resourceTestsStage) generate(data Data) (*string, error) {
+	testNames := make([]string, 0)
+	for name := range data.ResourceTestCases.Tests {
+		testNames = append(testNames, name)
+	}
+	sort.Strings(testNames)
+
+	testFuncs := make([]string, 0)
+	for _, testName := range testNames {
+		test := data.ResourceTestCases.Tests[testName]
+
+		stages := make([]string, 0)
+		for i, stage := range test.Stages {
+			if stage.RequiresImport {
+				stages = append(stages, fmt.Sprintf("\t\tdata.RequiresImportErrorStep(r.%[1]s),", *stage.ConfigName))
+				continue
+			}
+			if stage.Import {
+				stages = append(stages, "\t\tdata.ImportStep(),")
+				continue
+			}
+
+			if stage.ConfigName == nil {
+				return nil, fmt.Errorf("missing ConfigName for Test Stage %d for %q", i, testName)
+			}
+
+			stages = append(stages, fmt.Sprintf(`		{
+			Config: r.%[1]s(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				// TODO: assertions
+			),
+		},`, *stage.ConfigName))
+		}
+
+		testFuncs = append(testFuncs, fmt.Sprintf(`
+func TestAcc%[1]sResource_%[2]s(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.%[3]s", "test")
+	r := %[1]sResourceTest{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+%[4]s
+	})
+}
+`, data.ResourceName, testName, data.ResourceType, strings.Join(stages, "\n")))
+	}
+
+	testConfigNames := make([]string, 0)
+	for name := range data.ResourceTestCases.Configs {
+		testConfigNames = append(testConfigNames, name)
+	}
+	sort.Strings(testConfigNames)
+
+	testConfigFuncs := make([]string, 0)
+	for _, name := range testConfigNames {
+		testConfig := data.ResourceTestCases.Configs[name]
+		backtick := "`"
+		testConfigFuncs = append(testConfigFuncs, fmt.Sprintf(`
+func (r %[1]sResourceTest) %[2]s(data acceptance.TestData) string {
+	return fmt.Sprintf(%[4]s%[3]s%[4]s, data.RandomInteger, data.RandomString)
+}
+		`, data.ResourceName, name, testConfig.Config, backtick))
+	}
+
+	existsFunc := fmt.Sprintf(`
+func (r %[2]sResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := gosdk.%[3]sID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.%[4]s.%[5]s(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("checking if %%s exists: %%+v", *id, err)
+	}
+
+	return utils.Bool(resp.Model != nil), nil
+}
+`, data.PackageName, data.ResourceName, *data.ResourceIDTypeName, data.ClientName, data.ResourceReadOperation.SDKMethodName)
+
+	contents := fmt.Sprintf(`package %[1]s_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+)
+
+type %[2]sResourceTest struct {
+}
+
+%[3]s
+%[4]s
+%[5]s
+`, data.PackageName, data.ResourceName, strings.Join(testFuncs, "\n"), existsFunc, strings.Join(testConfigFuncs, "\n"))
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/stage_resource_update.go
+++ b/tools/generator-terraform/generator/stage_resource_update.go
@@ -1,0 +1,132 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+var _ stage = resourceUpdateStage{}
+
+type resourceUpdateStage struct{}
+
+func (r resourceUpdateStage) applicable(data *Data) bool {
+	return data.IsResource && data.ResourceUpdateOperation != nil && data.ResourceUpdateOperation.Generate
+}
+
+func (r resourceUpdateStage) filePath(data Data) string {
+	return fmt.Sprintf("%s_update.go", data.fileNamePrefix)
+}
+
+func (r resourceUpdateStage) generate(data Data) (*string, error) {
+	if data.ResourceReadOperation == nil {
+		return nil, fmt.Errorf("Updates require a ReadOperation is defined for mapping updates across")
+	}
+
+	sdkReadMethodName := data.ResourceReadOperation.SDKMethodName
+	sdkReadModelName := data.ResourceReadOperation.SDKModelName
+	sdkUpdateMethodName := data.ResourceUpdateOperation.SDKMethodName
+	sdkUpdateModelName := data.ResourceUpdateOperation.SDKModelName
+	isLongRunning := data.ResourceUpdateOperation.SDKMethodIsLongRunning
+	timeoutInMinutes := defaultUpdateTimeout
+	if data.ResourceUpdateOperation.CustomTimeoutInMinutes != nil {
+		timeoutInMinutes = *data.ResourceUpdateOperation.CustomTimeoutInMinutes
+	}
+
+	if isLongRunning {
+		sdkUpdateMethodName = fmt.Sprintf("%sThenPoll", sdkUpdateMethodName)
+	}
+
+	mappings := make([]string, 0)
+
+	// map the read object onto the update object
+	mapper := mappingData{
+		typeAlias:       "r",
+		typeName:        fmt.Sprintf("%sResource", data.ResourceName),
+		methodName:      "mapReadObjectToUpdateObject",
+		modelName:       *sdkUpdateModelName,
+		originModelName: sdkReadModelName,
+
+		// TODO: mapping definitions from Read -> Update
+	}
+	mappingCode, err := mapper.modelToModelCode()
+	if err != nil {
+		return nil, fmt.Errorf("generating mapping code for Read -> Update obj: %+v", err)
+	}
+	mappings = append(mappings, *mappingCode)
+
+	// then conditionally map (only) the changed schema fields onto the update object
+	mapper = mappingData{
+		typeAlias:  "r",
+		typeName:   fmt.Sprintf("%sResource", data.ResourceName),
+		methodName: "mapChangedSchemaFieldsToUpdateObject",
+		modelName:  *sdkUpdateModelName,
+
+		// TODO: mapping definitions from Schema -> Update
+	}
+	mappingCode, err = mapper.schemaToModelCode(true)
+	if err != nil {
+		return nil, fmt.Errorf("generating mapping code for Schema -> Update obj: %+v", err)
+	}
+	mappings = append(mappings, *mappingCode)
+
+	contents := fmt.Sprintf(`package %[1]s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tfsdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
+	gosdk "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[1]s/sdk"
+)
+
+var _ tfsdk.ResourceWithUpdate = %[2]sResource{} 
+
+func (r %[2]sResource) Update() tfsdk.ResourceFunc {
+	return tfsdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata tfsdk.ResourceMetaData) error {
+			client := metadata.Client.%[4]s
+
+			id, err := gosdk.Parse%[5]sID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("Decoding model from the config %%s..", *id)
+			var config %[2]sResourceModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %%+v", err)
+			}
+
+			metadata.Logger.Infof("Retrieving existing %%s..", *id)
+			resp, err := client.%[6]s(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving existing %%s: %%+v", *id, err)
+			}
+
+			metadata.Logger.Infof("Mapping response object onto update object for %%s..", *id)
+			var updateObj sdk.%[8]s
+			if err := r.mapReadObjectToUpdateObject(resp.Model, &updateObj); err != nil {
+				return fmt.Errorf("mapping read response to update object %%s: %%+v", *id, err)
+			}
+
+			metadata.Logger.Infof("Mapping changed fields onto update object for %%s..", *id)
+			if err := r.mapChangedSchemaFieldsToUpdateObject(config, &updateObj); err != nil {
+				return fmt.Errorf("mapping changed fields onto update object %%s: %%+v", *id, err)
+			}
+
+			metadata.Logger.Infof("Updating %%s..", *id)
+			if err := client.%[7]s(ctx, id); err != nil {
+				return fmt.Errorf("updating %%s: %%+v", *id, err)
+			}
+			metadata.Logger.Infof("Updated %%s.", *id)
+
+			return nil
+		},
+		Timeout: %[3]d * time.Minute,
+	}
+}
+%[9]s
+`, data.PackageName, data.ResourceName, timeoutInMinutes, data.ClientName, *data.ResourceIDTypeName, sdkReadMethodName, sdkUpdateMethodName, *sdkUpdateModelName, strings.Join(mappings, "\n"))
+	return &contents, nil
+}

--- a/tools/generator-terraform/generator/templater_mapper.go
+++ b/tools/generator-terraform/generator/templater_mapper.go
@@ -1,0 +1,56 @@
+package generator
+
+import "fmt"
+
+type mappingData struct {
+	typeAlias  string
+	typeName   string
+	methodName string
+	modelName  string
+
+	// originModelName is the model where this should be mapped from
+	originModelName *string
+
+	// TODO: mapping definitions from A -> B
+}
+
+// TODO: the other way too
+
+func (d mappingData) schemaToModelCode(onlyWhenHasChanges bool) (*string, error) {
+	// TODO: mappings and things
+	code := fmt.Sprintf(`
+func (%[1]s %[2]s) %[3]s(schema interface{}, model *sdk.%[4]s) error {
+	// TODO: return the actual object type we're expecting
+	// TODO: also this likely wants building out elsewhere?
+	return fmt.Errorf("Not implemented..")
+}
+`, d.typeAlias, d.typeName, d.methodName, d.modelName)
+	return &code, nil
+}
+
+func (d mappingData) modelToSchemaCode() (*string, error) {
+	// TODO: mappings and things
+	code := fmt.Sprintf(`
+func (%[1]s %[2]s) %[3]s(model *sdk.%[4]s, schema *sdk.%[2]sModel) error {
+	// TODO: return the actual object type we're expecting
+	// TODO: also this likely wants building out elsewhere?
+	return fmt.Errorf("Not implemented..")
+}
+`, d.typeAlias, d.typeName, d.methodName, d.modelName)
+	return &code, nil
+}
+
+func (d mappingData) modelToModelCode() (*string, error) {
+	if d.originModelName == nil {
+		return nil, fmt.Errorf("originModelName needs to be specified")
+	}
+
+	// TODO: mappings and things
+	code := fmt.Sprintf(`
+func (%[1]s %[2]s) %[3]s(from sdk.%[4]s, to *sdk.%[5]s) error {
+	// TODO: mappings
+	return fmt.Errorf("Not implemented..")
+}
+`, d.typeAlias, d.typeName, d.methodName, *d.originModelName, d.modelName)
+	return &code, nil
+}

--- a/tools/generator-terraform/generator/templater_schema.go
+++ b/tools/generator-terraform/generator/templater_schema.go
@@ -1,0 +1,253 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func schemaForFields(input map[string]FieldDefinition, objects *Objects, isDataSource bool) (*string, error) {
+	sortedFields := sortSchemaFields(input)
+
+	fields := make([]string, 0)
+	for _, val := range sortedFields {
+		if val.Type == FieldTypeDefinitionLocation {
+			fields = append(fields, schemaForLocationField(val, isDataSource))
+			continue
+		}
+		if val.Type == FieldTypeDefinitionJson {
+			fields = append(fields, schemaForJsonField(val))
+			continue
+		}
+		if val.Type == FieldTypeDefinitionResourceGroup {
+			fields = append(fields, schemaForResourceGroupField(val, isDataSource))
+			continue
+		}
+		if val.Type == FieldTypeDefinitionTags {
+			fields = append(fields, schemaForTagsField(val, isDataSource))
+			continue
+		}
+
+		lines := make([]string, 0)
+		schemaType := terraformSchemaName(val.Type)
+		lines = append(lines, fmt.Sprintf("Type: pluginsdk.%s", schemaType))
+
+		if val.Required {
+			lines = append(lines, "Required: true")
+		}
+		if val.Optional {
+			lines = append(lines, "Optional: true")
+		}
+		if val.Computed {
+			lines = append(lines, "Computed: true")
+		}
+		if val.ForceNew {
+			lines = append(lines, "ForceNew: true")
+		}
+		if val.Sensitive {
+			lines = append(lines, "Sensitive: true")
+		}
+		if val.Default != nil {
+			v := *val.Default
+			if str, ok := v.(string); ok {
+				lines = append(lines, fmt.Sprintf("Default: %q", str))
+			} else {
+				lines = append(lines, fmt.Sprintf("Default: %+v", v))
+			}
+		}
+
+		if val.MinItems != nil {
+			lines = append(lines, fmt.Sprintf("MinItems: %d", *val.MinItems))
+		}
+		if val.MaxItems != nil {
+			lines = append(lines, fmt.Sprintf("MaxItems: %d", *val.MaxItems))
+		}
+
+		if val.ConstantReference != nil {
+			if objects == nil {
+				return nil, fmt.Errorf("no objects were defined")
+			}
+			constant, ok := objects.Constants[*val.ConstantReference]
+			if !ok {
+				return nil, fmt.Errorf("a constant was not found with the name %q", *val.ConstantReference)
+			}
+			vals := make([]string, 0)
+			for k := range constant.Values {
+				vals = append(vals, fmt.Sprintf("string(gosdk.%[1]s)", k))
+			}
+
+			// TODO: we can do validation for it
+			lines = append(lines, fmt.Sprintf(`
+				ValidateFunc: validation.StringInSlice([]string{
+%[1]s
+				}, false)
+`, strings.Join(vals, ",\n")))
+		}
+		if val.ModelReference != nil {
+			if objects == nil {
+				return nil, fmt.Errorf("no objects were defined")
+			}
+			model, ok := objects.Models[*val.ModelReference]
+			if !ok {
+				return nil, fmt.Errorf("a model was not found with the name %q", *val.ModelReference)
+			}
+			nestedLines, err := schemaForFields(model.Fields, objects, isDataSource)
+			if err != nil {
+				return nil, fmt.Errorf("building nested schema for %q: %+v", *val.ModelReference, err)
+			}
+
+			lines = append(lines, fmt.Sprintf(`Elem: &pluginsdk.Resource{
+					Schema: %[1]s,
+}`, *nestedLines))
+		}
+		if val.Type == FieldTypeDefinitionMap {
+			lines = append(lines, fmt.Sprintf(`Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				}`))
+		}
+
+		fields = append(fields, fmt.Sprintf(`%[1]q: {
+%[2]s,
+}`, val.HclLabel, strings.Join(lines, ",\n")))
+	}
+
+	content := fmt.Sprintf(`map[string]*pluginsdk.Schema{
+%[1]s,
+}`, strings.Join(fields, ",\n"))
+	if len(fields) == 0 {
+		content = "map[string]*pluginsdk.Schema{}"
+	}
+	return &content, nil
+}
+
+func schemaForLocationField(input FieldDefinition, isDataSource bool) string {
+	// TODO: move these into a common package
+	if isDataSource || input.Computed {
+		return schemaForField(input, "location.SchemaComputed()")
+	}
+
+	if input.Optional {
+		return schemaForField(input, "location.SchemaOptional()")
+	}
+
+	if !input.ForceNew {
+		return schemaForField(input, "location.SchemaWithoutForceNew()")
+	}
+
+	return schemaForField(input, "location.Schema()")
+}
+
+func schemaForJsonField(input FieldDefinition) string {
+	// TODO: we should add definitions for these
+	lines := []string{
+		"Type: pluginsdk.TypeString",
+		"StateFunc: utils.NormalizeJson",
+	}
+	if input.Computed {
+		lines = append(lines, "Computed: true")
+	}
+	if input.Deprecated {
+		lines = append(lines, "Deprecated: true")
+	}
+	if input.ForceNew {
+		lines = append(lines, "ForceNew: true")
+	}
+	if input.Optional {
+		lines = append(lines, "Optional: true")
+	}
+	if input.Required {
+		lines = append(lines, "Required: true")
+	}
+
+	out := fmt.Sprintf("{%s}", strings.Join(lines, ",\n"))
+	return schemaForField(input, out)
+}
+
+func schemaForResourceGroupField(input FieldDefinition, isDataSource bool) string {
+	// TODO: these definitions should be moved elsewhere
+	if isDataSource {
+		return schemaForField(input, "azure.SchemaResourceGroupNameForDataSource()")
+	}
+
+	if input.Deprecated {
+		if input.Computed {
+			return schemaForField(input, "azure.SchemaResourceGroupNameDeprecatedComputed()")
+		}
+		return schemaForField(input, "azure.SchemaResourceGroupNameDeprecated()")
+	}
+
+	if input.Optional {
+		if input.Computed {
+			return schemaForField(input, "azure.SchemaResourceGroupNameOptionalComputed()")
+		}
+
+		return schemaForField(input, "azure.SchemaResourceGroupNameOptional()")
+	}
+
+	return schemaForField(input, "azure.SchemaResourceGroupName()")
+}
+
+func schemaForTagsField(input FieldDefinition, isDataSource bool) string {
+	// TODO: move these to a common location
+	if isDataSource || (input.Computed && (!input.Optional || !input.Computed)) {
+		return schemaForField(input, "tags.SchemaDataSource()")
+	}
+
+	if input.ForceNew {
+		return schemaForField(input, "tags.ForceNewSchema()")
+	}
+
+	return schemaForField(input, "tags.Schema()")
+}
+
+func schemaForField(input FieldDefinition, body string) string {
+	return fmt.Sprintf("%q: %s", input.HclLabel, body)
+}
+
+func terraformSchemaName(input FieldTypeDefinition) string {
+	// TODO: implement me
+	return "string"
+}
+
+func sortSchemaFields(input map[string]FieldDefinition) []FieldDefinition {
+	fieldsByHclName := make(map[string]FieldDefinition, len(input))
+	for _, v := range input {
+		fieldsByHclName[v.HclLabel] = v
+	}
+
+	requiredFieldNames := make([]string, 0)
+	optionalFieldNames := make([]string, 0)
+	computedFieldNames := make([]string, 0)
+	for name, value := range fieldsByHclName {
+		if value.Required {
+			requiredFieldNames = append(requiredFieldNames, name)
+			continue
+		}
+
+		if value.Optional {
+			optionalFieldNames = append(optionalFieldNames, name)
+			continue
+		}
+
+		computedFieldNames = append(computedFieldNames, name)
+	}
+	sort.Strings(requiredFieldNames)
+	sort.Strings(optionalFieldNames)
+	sort.Strings(computedFieldNames)
+
+	output := make([]FieldDefinition, 0)
+	for _, name := range requiredFieldNames {
+		field := fieldsByHclName[name]
+		output = append(output, field)
+	}
+	for _, name := range optionalFieldNames {
+		field := fieldsByHclName[name]
+		output = append(output, field)
+	}
+	for _, name := range computedFieldNames {
+		field := fieldsByHclName[name]
+		output = append(output, field)
+	}
+
+	return output
+}

--- a/tools/generator-terraform/go.mod
+++ b/tools/generator-terraform/go.mod
@@ -1,0 +1,7 @@
+module github.com/hashicorp/pandora/tools/generator-terraform
+
+go 1.16
+
+replace github.com/hashicorp/pandora/tools/sdk => ../sdk
+
+require github.com/hashicorp/pandora/tools/sdk v0.0.0-00010101000000-000000000000

--- a/tools/generator-terraform/main.go
+++ b/tools/generator-terraform/main.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/hashicorp/pandora/tools/generator-terraform/generator"
+)
+
+func main() {
+	dataEndpoint := "http://localhost:5000"
+	debug := true
+	homeDir, _ := os.UserHomeDir()
+	if err := run(dataEndpoint, homeDir, debug); err != nil {
+		log.Printf("error: %+v", err)
+		os.Exit(1)
+		return
+	}
+
+	os.Exit(0)
+}
+
+func run(endpoint, homeDir string, debug bool) error {
+	data := map[string]generator.Data{
+		"EventHub Namespace": {
+			ClientName:              "EventHubs.NamespacesClient",
+			IsResource:              true,
+			ResourceName:            "Namespace",
+			PackageName:             "eventhubs",
+			ProviderPrefix:          "azurerm",
+			PackageWorkingDirectory: path.Join(homeDir, "Desktop/pandora-terraform/eventhubs"),
+			ResourceType:            "azurerm_eventhub_namespace",
+			ResourceIDTypeName:      strPtr("Namespace"),
+
+			ResourceDeleteOperation: &generator.OperationDetails{
+				CustomTimeoutInMinutes: intPtr(60),
+				Generate:               true,
+				SDKMethodIsLongRunning: false,
+				SDKMethodName:          "Delete",
+			},
+			ResourceReadOperation: &generator.OperationDetails{
+				Generate:               true,
+				SDKMethodIsLongRunning: false,
+				SDKMethodName:          "Get",
+				SDKModelName:           strPtr("SomeReadModel"),
+			},
+		},
+		"Resource Group - Data Source": {
+			ClientName:              "Resources.GroupsClient",
+			IsResource:              false,
+			PackageName:             "resources",
+			ProviderPrefix:          "azurerm",
+			PackageWorkingDirectory: path.Join(homeDir, "Desktop/pandora-terraform/resources"),
+			ResourceIDTypeName:      strPtr("ResourceGroup"),
+			ResourceName:            "ResourceGroup",
+			ResourceType:            "azurerm_resource_group",
+
+			DataSourceReadOperation: &generator.OperationDetails{
+				Generate:      true,
+				SDKMethodName: "DataSourceGetPlz",
+				SDKModelName:  strPtr("ModelForDataSource"),
+			},
+			DataSourceTestCases: &generator.TestCasesDefinition{
+				Tests: map[string]generator.TestCaseDefinition{
+					"Basic": {
+						Stages: []generator.TestCaseDefinitionStage{
+							{
+								ConfigName:     strPtr("basic"),
+								Import:         false,
+								RequiresImport: false,
+							},
+						},
+					},
+				},
+				Configs: map[string]generator.TestConfigDefinition{
+					"basic": {
+						Config: `
+resource "azurerm_resource_group" "test" {
+  name     = "tom-dev"
+  location = "west europe"
+}
+`,
+					},
+				},
+			},
+		},
+		"Resource Group - Resource": {
+			ClientName:              "Resources.GroupsClient",
+			IsResource:              true,
+			PackageName:             "resources",
+			ProviderPrefix:          "azurerm",
+			PackageWorkingDirectory: path.Join(homeDir, "Desktop/pandora-terraform/resources"),
+			ResourceIDTypeName:      strPtr("ResourceGroup"),
+			ResourceName:            "ResourceGroup",
+			ResourceType:            "azurerm_resource_group",
+			SchemaFieldsToResourceIDMappings: &[]string{
+				"Name",
+			},
+
+			TopLevelSchema: &generator.ModelDefinition{
+				Fields: map[string]generator.FieldDefinition{
+					"Name": {
+						Type:     generator.FieldTypeDefinitionResourceGroup,
+						Required: true,
+						ForceNew: true,
+						HclLabel: "name",
+					},
+					"Location": {
+						Type:     generator.FieldTypeDefinitionLocation,
+						Required: true,
+						ForceNew: true,
+						HclLabel: "location",
+					},
+					"Tags": {
+						Type:     generator.FieldTypeDefinitionTags,
+						Computed: true,
+						HclLabel: "tags",
+					},
+				},
+			},
+
+			ResourceCreateOperation: &generator.OperationDetails{
+				Generate:               true,
+				SDKMethodIsLongRunning: true,
+				SDKMethodName:          "Create",
+				SDKModelName:           strPtr("SomeCreateModel"),
+			},
+			ResourceDeleteOperation: &generator.OperationDetails{
+				Generate:               true,
+				SDKMethodIsLongRunning: true,
+				SDKMethodName:          "Delete",
+			},
+			ResourceReadOperation: &generator.OperationDetails{
+				Generate:      true,
+				SDKMethodName: "Read",
+				SDKModelName:  strPtr("MyCustomReadObj"),
+			},
+			ResourceUpdateOperation: &generator.OperationDetails{
+				Generate:      true,
+				SDKMethodName: "UpdateAllTheThings",
+				SDKModelName:  strPtr("MyCustomUpdateObj"),
+			},
+			ResourceTestCases: &generator.TestCasesDefinition{
+				Tests: map[string]generator.TestCaseDefinition{
+					"Basic": {
+						Stages: []generator.TestCaseDefinitionStage{
+							{
+								ConfigName: strPtr("basic"),
+							},
+							{
+								Import: true,
+							},
+						},
+					},
+					"Complete": {
+						Stages: []generator.TestCaseDefinitionStage{
+							{
+								ConfigName: strPtr("basic"),
+							},
+							{
+								Import: true,
+							},
+							{
+								ConfigName: strPtr("complete"),
+							},
+							{
+								Import: true,
+							},
+						},
+					},
+					"RequiresImport": {
+						Stages: []generator.TestCaseDefinitionStage{
+							{
+								ConfigName: strPtr("basic"),
+							},
+							{
+								ConfigName:     strPtr("requiresImport"),
+								RequiresImport: true,
+							},
+						},
+					},
+				},
+				Configs: map[string]generator.TestConfigDefinition{
+					"basic": {
+						Config: `
+resource "azurerm_resource_group" "test" {
+  name     = "tom-dev"
+  location = "west europe"
+}
+`,
+					},
+					"complete": {
+						Config: `
+resource "azurerm_resource_group" "test" {
+  name     = "tom-dev"
+  location = "west europe"
+  tags = {
+    "generated-by" = "Pandora"
+  }
+}
+`,
+					},
+					"requiresImport": {
+						Config: `
+resource "azurerm_resource_group" "test" {
+  name     = "tom-dev"
+  location = "west europe"
+}
+
+resource "azurerm_resource_group" "import" {
+  name     = azurerm_resource_group.test.name
+  location = azurerm_resource_group.test.location
+}
+`,
+					},
+				},
+			},
+		},
+	}
+
+	for name, val := range data {
+		log.Printf("[DEBUG] Generating %q..", name)
+		gen := generator.NewGenerator(val, debug)
+		if err := gen.Generate(); err != nil {
+			return fmt.Errorf("generating: %+v", err)
+		}
+	}
+
+	//client := resourcemanager.NewClient(endpoint)
+	//services, err := services.GetResourceManagerServices(client)
+	//if err != nil {
+	//	return fmt.Errorf("retrieving services: %+v", err)
+	//}
+	//
+	//for _, val := range services.Services {
+	//	if !val.Details.Generate {
+	//		continue
+	//	}
+	//
+	//
+	//}
+
+	return nil
+}
+
+func intPtr(in int) *int {
+	return &in
+}
+
+func strPtr(in string) *string {
+	return &in
+}


### PR DESCRIPTION
This PR scaffolds the Terraform Generator - which allows mixing hand-written and generated files - hand-written files being `*.go` and generated are `*.gen.go`. This is currently using hard-coded test data which outputs:

```
 $ tree
.
├── eventhubs
│   ├── namespace_resource.gen.go
│   ├── namespace_resource_delete.gen.go
│   └── namespace_resource_read.gen.go
└── resources
    ├── resourcegroup_data.gen.go
    ├── resourcegroup_data_read.gen.go
    ├── resourcegroup_data_test.gen.go
    ├── resourcegroup_resource.gen.go
    ├── resourcegroup_resource_create.gen.go
    ├── resourcegroup_resource_delete.gen.go
    ├── resourcegroup_resource_model.gen.go
    ├── resourcegroup_resource_read.gen.go
    ├── resourcegroup_resource_schema.gen.go
    ├── resourcegroup_resource_test.go <-- hand-coded and persistent across runs
    └── resourcegroup_resource_update.gen.go

2 directories, 14 files
```

Generated files are output conditionally, depending on:

1. If the stage is disabled (for example the Read method shouldn't be generated)
2. If the stage is enabled - but a hand-written file exists at (for example) `file.go` when we'd output to `file.gen.go` - skip generating.

Generated files are removed at the start of each run and are assumed to be safe to remove at any time - in time these'll want headers to this effect but this is fine for now.

This is very much scaffolding, but this makes a good point to break this up - there's a bunch left to do, namely:

1. Generating the bi-directional Mappings
2. Sourcing this data from the API
3. Generating the Terraform validation functions for Resource ID's (which requires thought on how to make those more generic)