### PR TITLE
tools/importer-rest-api-specs: normalizing the casing on Swagger Tags

### DIFF
--- a/tools/importer-rest-api-specs/parser/parser.go
+++ b/tools/importer-rest-api-specs/parser/parser.go
@@ -125,7 +125,8 @@ func (d *SwaggerDefinition) findTags() []string {
 	for _, operation := range d.swaggerSpecExpanded.Operations() {
 		for _, details := range operation {
 			for _, tag := range details.Tags {
-				tags[tag] = struct{}{}
+				normalizedTag := normalizeTag(tag)
+				tags[normalizedTag] = struct{}{}
 			}
 		}
 	}
@@ -136,4 +137,13 @@ func (d *SwaggerDefinition) findTags() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func normalizeTag(input string) string {
+	// NOTE: we could be smarter here, but given this is a handful of cases it's
+	// probably prudent to hard-code these for now (and fix the swaggers as we
+	// come across them?)
+	output := input
+	output = strings.ReplaceAll(output, "NetWork", "Network")
+	return output
 }


### PR DESCRIPTION
Since there's only a single case of these right now it's probably fine to string replace these (and patch the swaggers) - we can decide later on if this is worth a smarter fix.

Fixes #35