### PR TITLE
switch to goroutines in `generateEverything` 

### DIFF
--- a/tools/importer-rest-api-specs/generate.go
+++ b/tools/importer-rest-api-specs/generate.go
@@ -170,11 +170,11 @@ func generateEverything(swaggerGitSha string) {
 
 			wg.Add(1)
 			go func(input RunInput, sha string) {
+				defer wg.Done()
 				err := run(input, sha)
 				if err != nil {
 					log.Printf("error: %+v", err)
 				}
-				wg.Done()
 			}(runInput, swaggerGitSha)
 		}
 	}


### PR DESCRIPTION
Local execution on 16-core MBP drop a full generation from ~13mins to ~2.5mins