### PR TITLE
tools/importer-rest-api-specs: supporting importing List operations against a Resource Provider

### DIFF
--- a/tools/importer-rest-api-specs/parser/helpers.go
+++ b/tools/importer-rest-api-specs/parser/helpers.go
@@ -124,10 +124,6 @@ func (u operationUri) shouldBeIgnored() bool {
 	if strings.HasPrefix(strings.ToLower(uri), "/providers/") {
 		return true
 	}
-	// or /subscriptions/{subscriptionId}/providers/Microsoft.EnterpriseKnowledgeGraph/services
-	if v := strings.TrimPrefix(strings.ToLower(uri), "/subscriptions/{subscriptionid}"); strings.HasPrefix(v, "/providers/") {
-		return true
-	}
 	// LRO's shouldn't be directly exposed, ignore bad data
 	if strings.Contains(strings.ToLower(uri), "/operationresults/{operationid}") {
 		return true

--- a/tools/importer-rest-api-specs/parser/parser_operations.go
+++ b/tools/importer-rest-api-specs/parser/parser_operations.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -31,6 +32,9 @@ func (d *SwaggerDefinition) findOperationsForTag(tag *string, uriToDetails map[s
 
 			url := newOperationUri(uri)
 			if url.shouldBeIgnored() {
+				if d.debugLog {
+					log.Printf("[DEBUG] Skipping URI %q", url.normalizedUri())
+				}
 				continue
 			}
 


### PR DESCRIPTION
Required for #157 since we need the "List" operation against the Resource Provider which is located at `/subscriptions/{subscriptionId}/providers/Microsoft.Relay/namespaces` - as such this PR removes that from the exclusion list, since we can now support these operations.