### PR TITLE
tools/importer-rest-api-specs: updating the Options reference to include the suffix

### DIFF
--- a/tools/importer-rest-api-specs/generator/operations.go
+++ b/tools/importer-rest-api-specs/generator/operations.go
@@ -79,7 +79,7 @@ func (g PandoraDefinitionGenerator) codeForOperation(namespace string, operation
 	if len(operation.Options) > 0 {
 		code = append(code, fmt.Sprintf(`		public override object? OptionsObject()
 		{
-			return new %[1]s.%[1]sOptions();
+			return new %[1]sOperation.%[1]sOptions();
 		}`, operationName))
 
 		optionsCode = append(optionsCode, fmt.Sprintf("\t\tinternal class %sOptions", operationName))


### PR DESCRIPTION
This fixes a compile-time issue when referencing those