### PR TITLE
tools/generator-go-sdk: adding a reference on the identity types

### DIFF
--- a/tools/generator-go-sdk/generator/stage_models.go
+++ b/tools/generator-go-sdk/generator/stage_models.go
@@ -139,6 +139,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/formatting"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/identity"
 )
 
 type %[2]s struct {


### PR DESCRIPTION
Available from https://github.com/hashicorp/terraform-provider-azurerm/pull/12725