### PR TITLE
github action: updating the permission to write

### DIFF
--- a/.github/workflows/data-codegen-on-swagger-changes.yaml
+++ b/.github/workflows/data-codegen-on-swagger-changes.yaml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: true
     permissions:
-      issues: write
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This needs to be able to push a branch and open a PR

Context: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/