### PR TITLE
github action: conditionally pushing the branch/PR when there's codegen changes

### DIFF
--- a/.github/workflows/data-codegen-on-swagger-changes.yaml
+++ b/.github/workflows/data-codegen-on-swagger-changes.yaml
@@ -22,6 +22,7 @@ jobs:
           go-version: '1.16.x'
 
       - name: build and run importer-rest-api-specs
+        id: generate
         run: |
           cd ./tools/importer-rest-api-specs
           make tools
@@ -29,6 +30,7 @@ jobs:
           make import
 
       - name: then commit the diff
+        id: commit
         run: |
           git checkout -b data/regeneration-from-${{ github.sha }}
           git config user.name "GitHub Actions"
@@ -38,6 +40,8 @@ jobs:
 
       - name: then open a pull request
         uses: repo-sync/pull-request@v2
+        id: open-pr
+        if: ${{ steps.commit.outputs.has_changes_to_push == 'true' }}
         with:
           source_branch: "data/regeneration-from-${{ github.sha }}"
           destination_branch: "main"

--- a/scripts/conditionally-commit-codegen-changes.sh
+++ b/scripts/conditionally-commit-codegen-changes.sh
@@ -3,6 +3,7 @@
 if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
   git add --all
   git commit -m "data: regenerating based on the latest Swagger"
+  echo "::set-output name=has_changes_to_push::true"
 else
-  exit 1
+  echo "::set-output name=has_changes_to_push::false"
 fi


### PR DESCRIPTION
Exiting with a exit code of 1 fails the script (which makes sense) - so trialing switching this to using an output based on:

https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#determining-when-to-use-contexts
and
https://docs.github.com/en/actions/reference/events-that-trigger-workflows