### PR TITLE
tools/importer-rest-api-specs: skipping non-resource manager services for `make import-all`

### DIFF
--- a/tools/importer-rest-api-specs/generate.go
+++ b/tools/importer-rest-api-specs/generate.go
@@ -140,8 +140,8 @@ func distinctServiceNames(input []parsedData) []string {
 	return names
 }
 
-func generateEverything(swaggerGitSha string) error {
-	services, err := parser.FindResourceManagerServices(swaggerDirectory + "/specification")
+func generateAllResourceManagerServices(swaggerGitSha string, justLatestVersion bool) error {
+	services, err := parser.FindResourceManagerServices(swaggerDirectory+"/specification", justLatestVersion)
 	if err != nil {
 		return err
 	}

--- a/tools/importer-rest-api-specs/main.go
+++ b/tools/importer-rest-api-specs/main.go
@@ -38,7 +38,8 @@ func main() {
 			}
 		}
 	} else {
-		if err := generateEverything(*swaggerGitSha); err != nil {
+		justLatestVersion := true
+		if err := generateAllResourceManagerServices(*swaggerGitSha, justLatestVersion); err != nil {
 			log.Printf("error: %+v", err)
 			os.Exit(1)
 		}

--- a/tools/importer-rest-api-specs/parser/helpers.go
+++ b/tools/importer-rest-api-specs/parser/helpers.go
@@ -212,7 +212,7 @@ type resourceManagerService struct {
 	resourceProvider string
 }
 
-func FindResourceManagerServices(directory string) (*[]ResourceManagerService, error) {
+func FindResourceManagerServices(directory string, justLatestVersion bool) (*[]ResourceManagerService, error) {
 	services := make(map[string]resourceManagerService, 0)
 	err := filepath.Walk(directory,
 		func(fullPath string, info os.FileInfo, err error) error {
@@ -270,11 +270,25 @@ func FindResourceManagerServices(directory string) (*[]ResourceManagerService, e
 	for _, serviceName := range serviceNames {
 		paths := services[serviceName]
 
-		out = append(out, ResourceManagerService{
+		sortedApiVersions := make([]string, 0)
+		for k := range paths.apiVersions {
+			sortedApiVersions = append(sortedApiVersions, k)
+		}
+		sort.Strings(sortedApiVersions)
+
+		newestApiVersion := sortedApiVersions[len(sortedApiVersions)-1]
+
+		service := ResourceManagerService{
 			Name:             serviceName,
 			ApiVersionPaths:  paths.apiVersions,
 			ResourceProvider: paths.resourceProvider,
-		})
+		}
+		if justLatestVersion {
+			service.ApiVersionPaths = map[string]string{
+				newestApiVersion: paths.apiVersions[newestApiVersion],
+			}
+		}
+		out = append(out, service)
 	}
 	return &out, nil
 }

--- a/tools/importer-rest-api-specs/parser/parser_test.go
+++ b/tools/importer-rest-api-specs/parser/parser_test.go
@@ -23,7 +23,7 @@ func TestAllSwaggersUsingParser(t *testing.T) {
 		t.Skipf("skipping since %q is unset", runAllEnvVar)
 	}
 
-	services, err := FindResourceManagerServices(swaggerDirectory)
+	services, err := FindResourceManagerServices(swaggerDirectory, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestAllSwaggersValidateAllContainTypes(t *testing.T) {
 		t.Skipf("skipping since %q is unset", runAllEnvVar)
 	}
 
-	services, err := FindResourceManagerServices(swaggerDirectory)
+	services, err := FindResourceManagerServices(swaggerDirectory, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestAllSwaggersValidateFindOAIGenParserBug(t *testing.T) {
 		t.Skipf("skipping since %q is unset", runAllEnvVar)
 	}
 
-	services, err := FindResourceManagerServices(swaggerDirectory)
+	services, err := FindResourceManagerServices(swaggerDirectory, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestAllSwaggersValidateFindUnknownBugs(t *testing.T) {
 		t.Skipf("skipping since %q is unset", runAllEnvVar)
 	}
 
-	services, err := FindResourceManagerServices(swaggerDirectory)
+	services, err := FindResourceManagerServices(swaggerDirectory, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We're not supporting those initially, so those can be filtered out for now - also for time purposes updated this to only generate the latest version for now