### PR TITLE
tools/importer-rest-api-specs: adding emoji's to the output for "generate all"

### DIFF
--- a/tools/importer-rest-api-specs/data_test.go
+++ b/tools/importer-rest-api-specs/data_test.go
@@ -16,7 +16,7 @@ func TestExistingDataCanBeGenerated(t *testing.T) {
 	for _, data := range input {
 		t.Run(fmt.Sprintf("%s-%s", data.ServiceName, data.ApiVersion), func(t *testing.T) {
 			generationData := data
-			if err := run(generationData, *swaggerGitSha); err != nil {
+			if err := run(generationData, *swaggerGitSha, true); err != nil {
 				t.Fatalf("error: %+v", err)
 			}
 		})

--- a/tools/importer-rest-api-specs/generate.go
+++ b/tools/importer-rest-api-specs/generate.go
@@ -141,7 +141,7 @@ func distinctServiceNames(input []parsedData) []string {
 }
 
 func generateAllResourceManagerServices(swaggerGitSha string, justLatestVersion bool) error {
-	services, err := parser.FindResourceManagerServices(swaggerDirectory+"/specification", justLatestVersion)
+	services, err := parser.FindResourceManagerServices(swaggerDirectory+"/specification", justLatestVersion, false)
 	if err != nil {
 		return err
 	}
@@ -152,6 +152,7 @@ func generateAllResourceManagerServices(swaggerGitSha string, justLatestVersion 
 			swaggerFiles, err := parser.SwaggerFilesInDirectory(versionPath)
 			if err != nil {
 				fmt.Println(err.Error())
+				continue
 			}
 			swaggerFilesTrimmed := make([]string, 0)
 			for _, swaggerFile := range *swaggerFiles {
@@ -170,11 +171,16 @@ func generateAllResourceManagerServices(swaggerGitSha string, justLatestVersion 
 
 			wg.Add(1)
 			go func(input RunInput, sha string) {
-				defer wg.Done()
-				err := run(input, sha)
+				err := run(input, sha, false)
 				if err != nil {
-					log.Printf("error: %+v", err)
+					log.Printf("❌ Service %q - Api Version %q", input.ServiceName, input.ApiVersion)
+					log.Printf("     💥 Error: %+v", err)
+					wg.Done()
+					return
 				}
+
+				log.Printf("✅ Service %q - Api Version %q", input.ServiceName, input.ApiVersion)
+				wg.Done()
 			}(runInput, swaggerGitSha)
 		}
 	}

--- a/tools/importer-rest-api-specs/main.go
+++ b/tools/importer-rest-api-specs/main.go
@@ -31,8 +31,9 @@ func main() {
 	}
 
 	if !strings.EqualFold(os.Getenv("PANDORA_GENERATE_EVERYTHING"), "true") {
+		debug := strings.TrimSpace(os.Getenv("DEBUG")) != ""
 		for _, v := range input {
-			if err := run(v, *swaggerGitSha); err != nil {
+			if err := run(v, *swaggerGitSha, debug); err != nil {
 				log.Printf("error: %+v", err)
 				os.Exit(1)
 			}
@@ -64,9 +65,7 @@ func determineGitSha(repositoryPath string) (*string, error) {
 	return &commit, nil
 }
 
-func run(input RunInput, swaggerGitSha string) error {
-	debug := strings.TrimSpace(os.ExpandEnv("DEBUG")) != ""
-
+func run(input RunInput, swaggerGitSha string, debug bool) error {
 	if debug {
 		log.Printf("[STAGE] Parsing Swagger Files..")
 	}

--- a/tools/importer-rest-api-specs/parser/helpers.go
+++ b/tools/importer-rest-api-specs/parser/helpers.go
@@ -212,7 +212,7 @@ type resourceManagerService struct {
 	resourceProvider string
 }
 
-func FindResourceManagerServices(directory string, justLatestVersion bool) (*[]ResourceManagerService, error) {
+func FindResourceManagerServices(directory string, justLatestVersion, debug bool) (*[]ResourceManagerService, error) {
 	services := make(map[string]resourceManagerService, 0)
 	err := filepath.Walk(directory,
 		func(fullPath string, info os.FileInfo, err error) error {
@@ -238,8 +238,11 @@ func FindResourceManagerServices(directory string, justLatestVersion bool) (*[]R
 			resourceProvider := segments[2]
 			serviceReleaseState := segments[3]
 			apiVersion := segments[4]
-			log.Printf("Service %q / Type %q / RP %q / Status %q / Version %q", serviceName, serviceType, resourceProvider, serviceReleaseState, apiVersion)
-			log.Printf("Path %q", fullPath)
+
+			if debug {
+				log.Printf("Service %q / Type %q / RP %q / Status %q / Version %q", serviceName, serviceType, resourceProvider, serviceReleaseState, apiVersion)
+				log.Printf("Path %q", fullPath)
+			}
 
 			if !strings.EqualFold(serviceType, "resource-manager") {
 				return nil

--- a/tools/importer-rest-api-specs/parser/parser_test.go
+++ b/tools/importer-rest-api-specs/parser/parser_test.go
@@ -23,7 +23,7 @@ func TestAllSwaggersUsingParser(t *testing.T) {
 		t.Skipf("skipping since %q is unset", runAllEnvVar)
 	}
 
-	services, err := FindResourceManagerServices(swaggerDirectory, false)
+	services, err := FindResourceManagerServices(swaggerDirectory, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestAllSwaggersValidateAllContainTypes(t *testing.T) {
 		t.Skipf("skipping since %q is unset", runAllEnvVar)
 	}
 
-	services, err := FindResourceManagerServices(swaggerDirectory, false)
+	services, err := FindResourceManagerServices(swaggerDirectory, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestAllSwaggersValidateFindOAIGenParserBug(t *testing.T) {
 		t.Skipf("skipping since %q is unset", runAllEnvVar)
 	}
 
-	services, err := FindResourceManagerServices(swaggerDirectory, false)
+	services, err := FindResourceManagerServices(swaggerDirectory, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestAllSwaggersValidateFindUnknownBugs(t *testing.T) {
 		t.Skipf("skipping since %q is unset", runAllEnvVar)
 	}
 
-	services, err := FindResourceManagerServices(swaggerDirectory, false)
+	services, err := FindResourceManagerServices(swaggerDirectory, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Also disabling the debug logs for "generate everything" since it's way too long to be usable