### PR TITLE
data: adding more tests covering #85

### DIFF
--- a/data/Pandora.Data/Transformers/OperationTests.cs
+++ b/data/Pandora.Data/Transformers/OperationTests.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text.Json.Serialization;
 using NUnit.Framework;
 using Pandora.Data.Models;
 using Pandora.Definitions.Attributes;
-using Pandora.Definitions.Interfaces;
 using Pandora.Definitions.Operations;
 
 namespace Pandora.Data.Transformers
@@ -64,7 +61,6 @@ namespace Pandora.Data.Transformers
             Assert.AreEqual("2018-01-01", actual.ApiVersion);
             Assert.AreEqual("MyApi", actual.ApiName);
             Assert.AreEqual("LongRunningOperationWithResponseObject", actual.Name);
-            Assert.AreEqual("application/json", actual.ContentType);
             Assert.AreEqual("DELETE", actual.Method);
             Assert.AreEqual(true, actual.LongRunning);
             Assert.Null(actual.ResponseObject);
@@ -78,13 +74,10 @@ namespace Pandora.Data.Transformers
             Assert.AreEqual("2018-01-01", actual.ApiVersion);
             Assert.AreEqual("MyApi", actual.ApiName);
             Assert.AreEqual("OperationWithRequestObject", actual.Name);
-            Assert.AreEqual("application/json", actual.ContentType);
             Assert.AreEqual("PUT", actual.Method);
             Assert.AreEqual(false, actual.LongRunning);
             Assert.NotNull(actual.RequestObject);
             Assert.Null(actual.ResponseObject);
-            Assert.AreEqual(1, actual.ExpectedStatusCodes.Count);
-            Assert.AreEqual(200, actual.ExpectedStatusCodes.First());
             Assert.AreEqual("TestObject", actual.RequestObject!.ReferenceName);
             Assert.AreEqual(ObjectType.Reference, actual.RequestObject!.Type);
         }
@@ -137,13 +130,10 @@ namespace Pandora.Data.Transformers
             Assert.AreEqual("2018-01-01", actual.ApiVersion);
             Assert.AreEqual("MyApi", actual.ApiName);
             Assert.AreEqual("OperationWithAResourceId", actual.Name);
-            Assert.AreEqual("application/json", actual.ContentType);
             Assert.AreEqual("GET", actual.Method);
             Assert.AreEqual(false, actual.LongRunning);
             Assert.Null(actual.RequestObject);
             Assert.NotNull(actual.ResponseObject);
-            Assert.AreEqual(1, actual.ExpectedStatusCodes.Count);
-            Assert.AreEqual(200, actual.ExpectedStatusCodes.First());
             Assert.AreEqual("FakeResponseObject", actual.ResponseObject!.ReferenceName);
             Assert.AreEqual(ObjectType.Reference, actual.ResponseObject!.Type);
             Assert.AreEqual("FakeResourceId", actual.ResourceIdName);
@@ -157,7 +147,6 @@ namespace Pandora.Data.Transformers
             Assert.AreEqual("2018-01-01", actual.ApiVersion);
             Assert.AreEqual("MyApi", actual.ApiName);
             Assert.AreEqual("OperationWithResponseObject", actual.Name);
-            Assert.AreEqual("application/json", actual.ContentType);
             Assert.AreEqual("GET", actual.Method);
             Assert.AreEqual(false, actual.LongRunning);
             Assert.Null(actual.RequestObject);
@@ -177,15 +166,12 @@ namespace Pandora.Data.Transformers
             Assert.AreEqual("2018-01-01", actual.ApiVersion);
             Assert.AreEqual("MyApi", actual.ApiName);
             Assert.AreEqual("OperationWithRequestAndResponseObject", actual.Name);
-            Assert.AreEqual("application/json", actual.ContentType);
             Assert.AreEqual("PUT", actual.Method);
             Assert.AreEqual(false, actual.LongRunning);
             Assert.NotNull(actual.RequestObject);
             Assert.NotNull(actual.RequestObject!.ReferenceName);
             Assert.NotNull(actual.ResponseObject);
             Assert.NotNull(actual.ResponseObject!.ReferenceName);
-            Assert.AreEqual(1, actual.ExpectedStatusCodes.Count);
-            Assert.AreEqual(200, actual.ExpectedStatusCodes.First());
             Assert.AreEqual("TestObject", actual.RequestObject!.ReferenceName);
             Assert.AreEqual(ObjectType.Reference, actual.RequestObject!.Type);
             Assert.AreEqual("TestObject", actual.ResponseObject!.ReferenceName);
@@ -200,7 +186,6 @@ namespace Pandora.Data.Transformers
             Assert.AreEqual("2018-01-01", actual.ApiVersion);
             Assert.AreEqual("MyApi", actual.ApiName);
             Assert.AreEqual("OperationWithASuffix", actual.Name);
-            Assert.AreEqual("application/json", actual.ContentType);
             Assert.AreEqual("POST", actual.Method);
             Assert.AreEqual(false, actual.LongRunning);
             Assert.Null(actual.RequestObject);
@@ -219,13 +204,11 @@ namespace Pandora.Data.Transformers
             Assert.AreEqual("2018-01-01", actual.ApiVersion);
             Assert.AreEqual("MyApi", actual.ApiName);
             Assert.AreEqual("OperationWithOptions", actual.Name);
-            Assert.AreEqual("application/json", actual.ContentType);
             Assert.AreEqual("POST", actual.Method);
             Assert.AreEqual(false, actual.LongRunning);
             Assert.Null(actual.ResponseObject);
             Assert.Null(actual.ResponseObject);
-            Assert.AreEqual(1, actual.ExpectedStatusCodes.Count);
-            Assert.AreEqual(200, actual.ExpectedStatusCodes.First());
+
             Assert.AreEqual(3, actual.Options.Count);
 
             var firstOption = actual.Options.First(o => o.Name == "First");
@@ -278,91 +261,30 @@ namespace Pandora.Data.Transformers
             Assert.AreEqual("OperationSimple", actual.Name);
         }
 
-        private class OperationWithNoStatusCodes : ApiOperation
+        private class OperationWithNoStatusCodes : DeleteOperation
         {
-            public string? ContentType()
-            {
-                return "application/json";
-            }
-
-            public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
+            public override IEnumerable<HttpStatusCode> ExpectedStatusCodes()
             {
                 return new List<HttpStatusCode>();
             }
-
-            public bool LongRunning()
-            {
-                return false;
-            }
-
-            public HttpMethod Method()
-            {
-                return HttpMethod.Delete;
-            }
-
-            public Type? RequestObject()
-            {
-                return null;
-            }
-
-            public Type? ResponseObject()
-            {
-                return null;
-            }
-            public string? FieldContainingPaginationDetails() => null;
-
-            public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-            public Type? OptionsObject() => null;
-            public string? UriSuffix() => null;
         }
 
-        private class OperationWithNoRequestOrResponseObjects : ApiOperation
+        private class OperationWithNoRequestOrResponseObjects : DeleteOperation
         {
-            public string? ContentType()
+            public override string? ContentType()
+            {
+                return "application/json";
+            }
+        }
+
+        private class OperationWithMultipleStatusCodes : DeleteOperation
+        {
+            public override string? ContentType()
             {
                 return "application/json";
             }
 
-            public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
-            {
-                return new List<HttpStatusCode> { HttpStatusCode.OK };
-            }
-
-            public bool LongRunning()
-            {
-                return false;
-            }
-
-            public HttpMethod Method()
-            {
-                return HttpMethod.Delete;
-            }
-
-            public Type? RequestObject()
-            {
-                return null;
-            }
-
-            public Type? ResponseObject()
-            {
-                return null;
-            }
-            public string? FieldContainingPaginationDetails() => null;
-
-            public Definitions.Interfaces.ResourceID? ResourceId() => null;
-            public Type? OptionsObject() => null;
-            public string? UriSuffix() => null;
-        }
-
-        private class OperationWithMultipleStatusCodes : ApiOperation
-        {
-            public string? ContentType()
-            {
-                return "application/json";
-            }
-
-            public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
+            public override IEnumerable<HttpStatusCode> ExpectedStatusCodes()
             {
                 return new List<HttpStatusCode>
                 {
@@ -370,183 +292,28 @@ namespace Pandora.Data.Transformers
                     HttpStatusCode.Created
                 };
             }
-
-            public bool LongRunning()
-            {
-                return false;
-            }
-
-            public HttpMethod Method()
-            {
-                return HttpMethod.Delete;
-            }
-
-            public Type? RequestObject()
-            {
-                return null;
-            }
-
-            public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-            public Type? ResponseObject()
-            {
-                return null;
-            }
-            public string? FieldContainingPaginationDetails() => null;
-            public Type? OptionsObject() => null;
-            public string? UriSuffix() => null;
         }
 
-        private class LongRunningOperationWithResponseObject : ApiOperation
+        private class LongRunningOperationWithResponseObject : LongRunningDeleteOperation
         {
-            public string? ContentType()
-            {
-                return "application/json";
-            }
-
-            public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
-            {
-                return new List<HttpStatusCode> { HttpStatusCode.OK };
-            }
-
-            public bool LongRunning()
-            {
-                return true;
-            }
-
-            public HttpMethod Method()
-            {
-                return HttpMethod.Delete;
-            }
-
-            public Type? RequestObject()
-            {
-                return null;
-            }
-
-            public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-            public Type? ResponseObject()
-            {
-                return typeof(TestObject);
-            }
-            public string? FieldContainingPaginationDetails() => null;
-            public Type? OptionsObject() => null;
-            public string? UriSuffix() => null;
+            public override Type? ResponseObject() => typeof(TestObject);
         }
 
-        private class OperationWithRequestObject : ApiOperation
+        private class OperationWithRequestObject : PutOperation
         {
-            public string? ContentType()
-            {
-                return "application/json";
-            }
-
-            public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
-            {
-                return new List<HttpStatusCode> { HttpStatusCode.OK };
-            }
-
-            public bool LongRunning()
-            {
-                return false;
-            }
-
-            public HttpMethod Method()
-            {
-                return HttpMethod.Put;
-            }
-
-            public Type? RequestObject()
-            {
-                return typeof(TestObject);
-            }
-
-            public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-            public Type? ResponseObject()
-            {
-                return null;
-            }
-            public string? FieldContainingPaginationDetails() => null;
-            public Type? OptionsObject() => null;
-            public string? UriSuffix() => null;
+            public override Type? RequestObject() => typeof(TestObject);
         }
 
-        private class OperationWithResponseObject : ApiOperation
+        private class OperationWithResponseObject : GetOperation
         {
-            public string? ContentType()
-            {
-                return "application/json";
-            }
-
-            public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
-            {
-                return new List<HttpStatusCode> { HttpStatusCode.OK };
-            }
-
-            public bool LongRunning()
-            {
-                return false;
-            }
-
-            public HttpMethod Method()
-            {
-                return HttpMethod.Get;
-            }
-
-            public Type? RequestObject()
-            {
-                return null;
-            }
-
-            public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-            public Type? ResponseObject()
-            {
-                return typeof(TestObject);
-            }
-            public string? FieldContainingPaginationDetails() => null;
-            public Type? OptionsObject() => null;
-            public string? UriSuffix() => null;
+            public override Type? ResponseObject() => typeof(TestObject);
         }
 
-        private class OperationWithRequestAndResponseObject : ApiOperation
+        private class OperationWithRequestAndResponseObject : PutOperation
         {
-            public string? ContentType()
-            {
-                return "application/json";
-            }
+            public override Type? RequestObject() => typeof(TestObject);
 
-            public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
-            {
-                return new List<HttpStatusCode> { HttpStatusCode.OK };
-            }
-
-            public bool LongRunning()
-            {
-                return false;
-            }
-
-            public HttpMethod Method()
-            {
-                return HttpMethod.Put;
-            }
-
-            public Type? RequestObject()
-            {
-                return typeof(TestObject);
-            }
-
-            public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-            public Type? ResponseObject()
-            {
-                return typeof(TestObject);
-            }
-            public string? FieldContainingPaginationDetails() => null;
-            public Type? OptionsObject() => null;
-            public string? UriSuffix() => null;
+            public override Type? ResponseObject() => typeof(TestObject);
         }
     }
 
@@ -566,68 +333,20 @@ namespace Pandora.Data.Transformers
         }
     }
 
-    public class OperationSimpleOperation : ApiOperation
+    public class OperationSimpleOperation : PutOperation
     {
-        public string? ContentType()
-        {
-            return "application/json";
-        }
+        public override Type? RequestObject() => typeof(TestObject);
 
-        public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
-        {
-            return new List<HttpStatusCode> { HttpStatusCode.OK };
-        }
+        public override Type? ResponseObject() => typeof(TestObject);
 
-        public bool LongRunning()
-        {
-            return false;
-        }
-
-        public HttpMethod Method()
-        {
-            return HttpMethod.Put;
-        }
-
-        public Type? RequestObject()
-        {
-            return typeof(TestObject);
-        }
-
-        public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-        public Type? ResponseObject()
-        {
-            return typeof(TestObject);
-        }
-        public string? FieldContainingPaginationDetails() => null;
-        public Type? OptionsObject() => null;
-        public string? UriSuffix() => "/hello";
+        public override string? UriSuffix() => "/hello";
     }
 
-    public class OperationWithAResourceId : ApiOperation
+    public class OperationWithAResourceId : GetOperation
     {
-        public string? ContentType() => "application/json";
+        public override Type? ResponseObject() => typeof(FakeResponseObject);
 
-        public IEnumerable<HttpStatusCode> ExpectedStatusCodes() => new List<HttpStatusCode>
-        {
-            HttpStatusCode.OK,
-        };
-
-        public string? FieldContainingPaginationDetails() => null;
-
-        public bool LongRunning() => false;
-
-        public HttpMethod Method() => HttpMethod.Get;
-
-        public Type? OptionsObject() => null;
-
-        public Type? RequestObject() => null;
-
-        public Type? ResponseObject() => typeof(FakeResponseObject);
-
-        public Definitions.Interfaces.ResourceID? ResourceId() => new FakeResourceId();
-
-        public string? UriSuffix() => null;
+        public override Definitions.Interfaces.ResourceID? ResourceId() => new FakeResourceId();
 
         public class FakeResponseObject
         {
@@ -644,62 +363,17 @@ namespace Pandora.Data.Transformers
         }
     }
 
-    public class OperationWithASuffix : ApiOperation
+    public class OperationWithASuffix : PostOperation
     {
-        public string? ContentType()
-        {
-            return "application/json";
-        }
+        public override Type? RequestObject() => null;
 
-        public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
-        {
-            return new List<HttpStatusCode> { HttpStatusCode.OK };
-        }
-
-        public bool LongRunning() => false;
-
-        public HttpMethod Method()
-        {
-            return HttpMethod.Post;
-        }
-
-        public Type? RequestObject() => null;
-
-        public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-        public Type? ResponseObject() => null;
-        public string? FieldContainingPaginationDetails() => null;
-        public Type? OptionsObject() => null;
-        public string? UriSuffix() => "/shutdown";
+        public override string? UriSuffix() => "/shutdown";
     }
 
-    public class OperationWithOptions : ApiOperation
+    public class OperationWithOptions : PostOperation
     {
-        public string? ContentType()
-        {
-            return "application/json";
-        }
-
-        public IEnumerable<HttpStatusCode> ExpectedStatusCodes()
-        {
-            return new List<HttpStatusCode> { HttpStatusCode.OK };
-        }
-
-        public bool LongRunning() => false;
-
-        public HttpMethod Method()
-        {
-            return HttpMethod.Post;
-        }
-
-        public Type? RequestObject() => null;
-
-        public Definitions.Interfaces.ResourceID? ResourceId() => null;
-
-        public Type? ResponseObject() => null;
-        public string? FieldContainingPaginationDetails() => null;
-        public Type? OptionsObject() => typeof(NestedOptionsObject);
-        public string? UriSuffix() => null;
+        public override Type? OptionsObject() => typeof(NestedOptionsObject);
+        public override Type? RequestObject() => null;
 
         public class NestedOptionsObject
         {


### PR DESCRIPTION
This PR adds a few more tests covering #85 and refactors some of the Operation tests to use the base types

I believe that should be all of the changes needed in the Data Layer, as such we should be able to update the Go SDK Generator next (and then the importer) to ultimately enable us to fix #85 (and #81)