### PR TITLE
tools/importer-rest-api-specs: skipping `api-version` and `$skipToken`

### DIFF
--- a/tools/importer-rest-api-specs/parser/parser_operations.go
+++ b/tools/importer-rest-api-specs/parser/parser_operations.go
@@ -141,6 +141,17 @@ func constantsInOperationParameters(input *spec.Operation) (*result, error) {
 			continue
 		}
 
+		// these are (currently) handled elsewhere, so we're good for now
+		if strings.EqualFold(param.Name, "$skipToken") {
+			// NOTE: we may also need to do the odata ones, media has an example
+			continue
+		}
+
+		// handled elsewhere
+		if strings.EqualFold(param.Name, "api-version") {
+			continue
+		}
+
 		types := []string{
 			param.Type,
 		}


### PR DESCRIPTION
Today's results:

```
2021/08/18 17:52:51 [DEBUG] Swagger Repository Commit SHA is "60d6c393c7e71b45ebe0976a35fd7a5841993159"

Total Services: 195
Passing: 143
Failing: 52
Failure Rate: 26,66666667
```

# Passing

```
✅ Service "addons" - Api Version "2018-03-01"
✅ Service "adhybridhealthservice" - Api Version "2014-01-01"
✅ Service "adp" - Api Version "2021-02-01-preview"
✅ Service "advisor" - Api Version "2020-07-01-preview"
✅ Service "alertsmanagement" - Api Version "2021-04-01"
✅ Service "analysisservices" - Api Version "2017-08-01-beta"
✅ Service "appconfiguration" - Api Version "2021-03-01-preview"
✅ Service "attestation" - Api Version "2021-06-01-preview"
✅ Service "authorization" - Api Version "2021-07-01-preview"
✅ Service "automanage" - Api Version "2020-06-30-preview"
✅ Service "automation" - Api Version "v1"
✅ Service "azsadmin" - Api Version "stable"
✅ Service "azure-kusto" - Api Version "2021-01-01"
✅ Service "azureactivedirectory" - Api Version "2020-07-01-preview"
✅ Service "azuredata" - Api Version "2019-07-24-preview"
✅ Service "azurestack" - Api Version "2020-06-01-preview"
✅ Service "azurestackhci" - Api Version "2021-01-01-preview"
✅ Service "baremetalinfrastructure" - Api Version "2020-08-06-preview"
✅ Service "batch" - Api Version "2021-06-01"
✅ Service "billing" - Api Version "2020-11-01-preview"
✅ Service "blockchain" - Api Version "2018-06-01-preview"
✅ Service "botservice" - Api Version "2021-05-01-preview"
✅ Service "changeanalysis" - Api Version "2021-04-01"
✅ Service "cloudshell" - Api Version "2018-10-01"
✅ Service "cognitiveservices" - Api Version "2021-04-30"
✅ Service "commerce" - Api Version "2015-06-01-preview"
✅ Service "communication" - Api Version "2020-08-20-preview"
✅ Service "compute" - Api Version "2021-04-01"
✅ Service "confidentialledger" - Api Version "2021-05-13-preview"
✅ Service "confluent" - Api Version "2021-03-01-preview"
✅ Service "consumption" - Api Version "2021-05-01"
✅ Service "containerinstance" - Api Version "2021-03-01"
✅ Service "containerregistry" - Api Version "2021-06-01-preview"
✅ Service "containerservice" - Api Version "2021-07-01"
✅ Service "cost-management" - Api Version "2021-01-01"
✅ Service "cpim" - Api Version "2020-05-01-preview"
✅ Service "customer-insights" - Api Version "2017-04-26"
✅ Service "customerlockbox" - Api Version "2018-02-28-preview"
✅ Service "customproviders" - Api Version "2018-09-01-preview"
✅ Service "databox" - Api Version "2021-05-01"
✅ Service "databoxedge" - Api Version "2021-02-01-preview"
✅ Service "databricks" - Api Version "2021-04-01-preview"
✅ Service "datacatalog" - Api Version "2016-03-30"
✅ Service "datadog" - Api Version "2021-03-01"
✅ Service "datamigration" - Api Version "2021-06-30"
✅ Service "dataprotection" - Api Version "2021-06-01-preview"
✅ Service "datashare" - Api Version "2020-10-01-preview"
✅ Service "deploymentmanager" - Api Version "2019-11-01-preview"
✅ Service "deviceprovisioningservices" - Api Version "2020-09-01-preview"
✅ Service "deviceupdate" - Api Version "2020-03-01-preview"
✅ Service "devops" - Api Version "2020-07-13-preview"
✅ Service "devspaces" - Api Version "2019-04-01"
✅ Service "devtestlabs" - Api Version "2018-09-15"
✅ Service "dfp" - Api Version "2021-02-01-preview"
✅ Service "digitaltwins" - Api Version "2020-12-01"
✅ Service "dnc" - Api Version "2021-03-15"
✅ Service "dns" - Api Version "2018-05-01"
✅ Service "domainservices" - Api Version "2021-05-01"
✅ Service "dynamicstelemetry" - Api Version "2019-01-24"
✅ Service "edgeorder" - Api Version "2020-12-01-preview"
✅ Service "edgeorderpartner" - Api Version "2020-12-01-preview"
✅ Service "elastic" - Api Version "2020-07-01-preview"
✅ Service "engagementfabric" - Api Version "2018-09-01"
✅ Service "eventhub" - Api Version "2021-06-01-preview"
✅ Service "extendedlocation" - Api Version "2021-03-15-preview"
✅ Service "fluidrelay" - Api Version "2021-06-15-preview"
✅ Service "frontdoor" - Api Version "2020-11-01"
✅ Service "guestconfiguration" - Api Version "v1"
✅ Service "hanaonazure" - Api Version "2020-02-07-preview"
✅ Service "healthbot" - Api Version "2021-06-10"
✅ Service "healthcareapis" - Api Version "2021-06-01-preview"
✅ Service "hybriddatamanager" - Api Version "2019-06-01"
✅ Service "hybridkubernetes" - Api Version "2021-04-01-preview"
✅ Service "hybridnetwork" - Api Version "2021-05-01"
✅ Service "imagebuilder" - Api Version "2020-02-14"
✅ Service "intune" - Api Version "2015-01-14-privatepreview"
✅ Service "iotcentral" - Api Version "2018-09-01"
✅ Service "iotspaces" - Api Version "2017-10-01-preview"
✅ Service "labservices" - Api Version "2018-10-15"
✅ Service "logz" - Api Version "2020-10-01-preview"
✅ Service "machinelearning" - Api Version "2019-10-01"
✅ Service "machinelearningcompute" - Api Version "2017-08-01-preview"
✅ Service "machinelearningexperimentation" - Api Version "2017-05-01-preview"
✅ Service "maintenance" - Api Version "2021-05-01"
✅ Service "managednetwork" - Api Version "2019-06-01-preview"
✅ Service "managedservices" - Api Version "2020-02-01-preview"
✅ Service "managementgroups" - Api Version "2021-04-01"
✅ Service "managementpartner" - Api Version "2018-02-01"
✅ Service "maps" - Api Version "2021-07-01-preview"
✅ Service "mariadb" - Api Version "2020-01-01-privatepreview"
✅ Service "marketplace" - Api Version "2021-06-01"
✅ Service "marketplaceordering" - Api Version "2021-01-01"
✅ Service "migrate" - Api Version "2020-07-07"
✅ Service "mixedreality" - Api Version "2021-03-01-preview"
✅ Service "monitor" - Api Version "2021-05-01-preview"
✅ Service "msi" - Api Version "2018-11-30"
✅ Service "mysql" - Api Version "2021-05-01-preview"
✅ Service "network" - Api Version "2021-03-01-preview"
✅ Service "notificationhubs" - Api Version "2017-04-01"
✅ Service "operationalinsights" - Api Version "2021-06-01"
✅ Service "operationsmanagement" - Api Version "2015-11-01-preview"
✅ Service "portal" - Api Version "2020-09-01-preview"
✅ Service "postgresql" - Api Version "2021-06-15-privatepreview"
✅ Service "postgresqlhsc" - Api Version "2020-10-05-privatepreview"
✅ Service "powerbidedicated" - Api Version "2021-01-01"
✅ Service "powerbiembedded" - Api Version "2016-01-29"
✅ Service "powerbiprivatelinks" - Api Version "2020-06-01"
✅ Service "powerplatform" - Api Version "v1"
✅ Service "privatedns" - Api Version "2020-06-01"
✅ Service "purview" - Api Version "2021-07-01"
✅ Service "quantum" - Api Version "2019-11-04-preview"
✅ Service "quota" - Api Version "2021-03-15-preview"
✅ Service "recoveryservices" - Api Version "2021-06-01"
✅ Service "recoveryservicesbackup" - Api Version "2021-06-01"
✅ Service "recoveryservicessiterecovery" - Api Version "2021-06-01"
✅ Service "redisenterprise" - Api Version "2021-08-01"
✅ Service "relay" - Api Version "v1"
✅ Service "reservations" - Api Version "2020-11-15-preview"
✅ Service "resourcegraph" - Api Version "2021-06-01-preview"
✅ Service "resourcehealth" - Api Version "2018-08-01"
✅ Service "resourcemover" - Api Version "2021-01-01"
✅ Service "resources" - Api Version "2021-07-01"
✅ Service "scheduler" - Api Version "2016-03-01"
✅ Service "search" - Api Version "2021-04-01-preview"
✅ Service "securityinsights" - Api Version "2021-04-01"
✅ Service "serialconsole" - Api Version "2018-05-01"
✅ Service "servicebus" - Api Version "2021-06-01-preview"
✅ Service "signalr" - Api Version "2021-06-01-preview"
✅ Service "softwareplan" - Api Version "2019-12-01"
✅ Service "sqlvirtualmachine" - Api Version "2017-03-01-preview"
✅ Service "storSimple1200Series" - Api Version "2016-10-01"
✅ Service "storageimportexport" - Api Version "2021-01-01"
✅ Service "storagepool" - Api Version "2021-04-01-preview"
✅ Service "storagesync" - Api Version "2020-09-01"
✅ Service "storsimple8000series" - Api Version "2017-06-01"
✅ Service "streamanalytics" - Api Version "v1"
✅ Service "subscription" - Api Version "2020-09-01"
✅ Service "support" - Api Version "2021-06-01-preview"
✅ Service "visualstudio" - Api Version "2018-08-01-preview"
✅ Service "webpubsub" - Api Version "2021-09-01-preview"
✅ Service "windowsesu" - Api Version "2019-09-16-preview"
✅ Service "windowsiot" - Api Version "2019-06-01"
✅ Service "workloadmonitor" - Api Version "2020-01-13-preview"
```

# Issues

```
❌ Service "agrifood" - Api Version "2020-05-12-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Extensions": finding operations: parsing operation "ListByFarmBeats": building options for operation "ListByFarmBeats": determining field type for operation: unsupported field type "array"
❌ Service "apimanagement" - Api Version "2021-01-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Api": finding operations: parsing operation "ListByService": determining response operation for "ListByService" (method "GET" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/apis"): parsing model "ApiCollection" for list operation to find real model: determining models for model: finding models for "apiContract": finding models for "apiContractProperties": finding models for "apiVersionSetContractDetails": finding fields for "apiVersionSetContractDetails": mapping field "apiVersionSetContractDetails": parsing constant: reference was missing
❌ Service "applicationinsights" - Api Version "2021-03-08"
 💥 Error: parsing Swagger files: parsing definition: finding resources for tag "applicationinsights": finding operations: parsing operation "MyWorkbooks_ListByResourceGroup": determining response operation for "MyWorkbooks_ListByResourceGroup" (method "GET" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Insights/myWorkbooks"): parsing model "MyWorkbooksListResult" for list operation to find real model: determining models for model: finding models for "MyWorkbook": finding models for "MyWorkbookManagedIdentity": finding fields for "MyWorkbookManagedIdentity": mapping field "MyWorkbookManagedIdentity": parsing constant: reference was missing
❌ Service "appplatform" - Api Version "2021-06-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "AppPlatform": finding operations: parsing operation "Deployments_ListForCluster": building options for operation "Deployments_ListForCluster": determining field type for operation: unsupported field type "array"
❌ Service "azurearcdata" - Api Version "2021-08-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "SqlManagedInstances": finding operations: parsing operation "List": determining response operation for "List" (method "GET" / uri "/subscriptions/{subscriptionId}/providers/Microsoft.AzureArcData/sqlManagedInstances"): parsing model "SqlManagedInstanceListResult" for list operation to find real model: determining models for model: finding models for "SqlManagedInstance": finding models for "SqlManagedInstanceSku": finding fields for "SqlManagedInstanceSku": mapping field "SqlManagedInstanceSku": parsing constant: reference was missing
❌ Service "blueprint" - Api Version "2018-11-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Artifact": parsing operations: finding implementations of "Artifact" (discriminating on "kind"): parsing model "RoleAssignmentArtifact": determining models for model: finding models for "RoleAssignmentArtifactProperties": finding fields for "RoleAssignmentArtifactProperties": mapping field "RoleAssignmentArtifactProperties": the schema for the field "principalIds" is invalid
❌ Service "cdn" - Api Version "2020-09-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "LogAnalytics": finding operations: parsing operation "GetLogAnalyticsMetrics": building options for operation "GetLogAnalyticsMetrics": determining field type for operation: unsupported field type "array"
❌ Service "cosmos-db" - Api Version "2021-06-15"
  💥 Error: generating API Versions: generating Resource "Cosmosdb" (Namespace "Pandora.Definitions.ResourceManager.Cosmosdb.v2021_06_15.Cosmosdb"): generating code for model "Tags" in "Pandora.Definitions.ResourceManager.Cosmosdb.v2021_06_15.Cosmosdb": the model "Tags" in namespace "Pandora.Definitions.ResourceManager.Cosmosdb.v2021_06_15.Cosmosdb" has no fields
❌ Service "datafactory" - Api Version "2018-06-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "dataFlowDebugSession": parsing operations: parsing items from top-level model "DataFlowDebugPackage": determining models for model: finding models for "DatasetDebugResource": finding models for "dataset": finding models for "linkedServiceReference": finding fields for "linkedServiceReference": mapping field "linkedServiceReference": parsing constant: reference was missing
❌ Service "datalake-analytics" - Api Version "2016-11-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Accounts": parsing operations: parsing items from top-level model "CheckNameAvailabilityParameters": determining constants for model: finding nested constants within "type": parsing constant: reference was missing
❌ Service "datalake-store" - Api Version "2016-11-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Accounts": parsing operations: parsing items from top-level model "CheckNameAvailabilityParameters": determining constants for model: finding nested constants within "type": parsing constant: reference was missing
❌ Service "desktopvirtualization" - Api Version "2021-07-12"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "ScalingPlan": finding operations: parsing operation "ListBySubscription": determining response operation for "ListBySubscription" (method "GET" / uri "/subscriptions/{subscriptionId}/providers/Microsoft.DesktopVirtualization/scalingPlans"): parsing model "ScalingPlanList" for list operation to find real model: determining models for model: finding models for "ScalingPlan": finding models for "ScalingPlanProperties": finding models for "ScalingSchedule": finding fields for "ScalingSchedule": mapping field "ScalingSchedule": mapping array element of field ScalingSchedule.daysOfWeek: parsing constant: reference was missing
❌ Service "EnterpriseKnowledgeGraph" - Api Version "2018-12-03"
 💥 Error: parsing Swagger files: parsing definition: finding resources for tag "EnterpriseKnowledgeGraph": finding operations: parsing operation "ListByResourceGroup": determining response operation for "ListByResourceGroup" (method "GET" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EnterpriseKnowledgeGraph/services"): parsing model "EnterpriseKnowledgeGraphResponseList" for list operation to find real model: determining models for model: finding models for "EnterpriseKnowledgeGraph": finding models for "EnterpriseKnowledgeGraphProperties": finding fields for "EnterpriseKnowledgeGraphProperties": mapping field "EnterpriseKnowledgeGraphProperties": parsing constant: reference was missing
❌ Service "eventgrid" - Api Version "2021-06-01-preview"
   💥 Error: parsing Swagger files: parsing definition: finding resources for tag "PrivateEndpointConnections": finding operations: parsing operation "Update": parsing constants within operation parameters: mapping "parentType": reference was missing
❌ Service "hardwaresecuritymodules" - Api Version "2018-10-31-preview"
   💥 Error: parsing Swagger files: parsing definition: finding resources for tag "DedicatedHsms": finding operations: parsing operation "DedicatedHsm_ListByResourceGroup": determining response operation for "DedicatedHsm_ListByResourceGroup" (method "GET" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/dedicatedHSMs"): parsing model "DedicatedHsmListResult" for list operation to find real model: determining models for model: finding models for "DedicatedHsm": finding models for "Sku": finding fields for "Sku": mapping field "Sku": parsing constant: reference was missing
❌ Service "hdinsight" - Api Version "2018-06-01-preview"
  💥 Error: generating API Versions: generating Resource "Configurations" (Namespace "Pandora.Definitions.ResourceManager.Hdinsight.v2018_06_01_preview.Configurations"): generating code for model "ClusterConfiguration" in "Pandora.Definitions.ResourceManager.Hdinsight.v2018_06_01_preview.Configurations": the model "ClusterConfiguration" in namespace "Pandora.Definitions.ResourceManager.Hdinsight.v2018_06_01_preview.Configurations" has no fields
❌ Service "hybridcompute" - Api Version "2021-06-10-preview"
  💥 Error: generating API Versions: generating Resource "Machines" (Namespace "Pandora.Definitions.ResourceManager.Hybridcompute.v2021_06_10_preview.Machines"): generating code for model "DetectedProperties" in "Pandora.Definitions.ResourceManager.Hybridcompute.v2021_06_10_preview.Machines": the model "DetectedProperties" in namespace "Pandora.Definitions.ResourceManager.Hybridcompute.v2021_06_10_preview.Machines" has no fields
❌ Service "iothub" - Api Version "2021-07-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "DELETE": parsing operations: parsing items from top-level model "IotHubDescription": determining models for model: finding models for "IotHubProperties": finding models for "RoutingProperties": finding models for "RoutingEndpoints": finding models for "RoutingStorageContainerProperties": finding fields for "RoutingStorageContainerProperties": mapping field "RoutingStorageContainerProperties": parsing constant: reference was missing
❌ Service "iotsecurity" - Api Version "2021-09-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Sensors": finding operations: parsing operation "DownloadResetPassword": determining response operation for "DownloadResetPassword" (method "POST" / uri "/{scope}/providers/Microsoft.IoTSecurity/sensors/{sensorName}/downloadResetPassword"): response model must either be a reference or an inlined model but got neither
❌ Service "keyvault" - Api Version "2021-06-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Vaults": finding operations: parsing operation "List": parsing constants within operation parameters: mapping "$filter": reference was missing
❌ Service "kubernetesconfiguration" - Api Version "2021-05-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "kubernetesconfiguration": finding operations: parsing operation "ClusterExtensionType_Get": parsing constants within operation parameters: mapping "clusterRp": reference was missing
❌ Service "logic" - Api Version "2019-05-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "IntegrationAccountAssemblies": parsing operations: parsing items from top-level model "AssemblyCollection": determining models for model: finding models for "AssemblyDefinition": finding models for "AssemblyProperties": finding fields for "AssemblyProperties": retrieving fields for inherited type "ArtifactContentPropertiesDefinition": retrieving fields for inherited type "ArtifactProperties": mapping field "ArtifactProperties": the schema for the field "metadata" is invalid
❌ Service "m365securityandcompliance" - Api Version "2021-03-25-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Resource": parsing operations: parsing items from top-level model "OperationResultsDescription": determining fields for model: mapping field "OperationResultsDescription": the schema for the field "properties" is invalid
❌ Service "machinelearningservices" - Api Version "2021-07-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "MachineLearningComputes": finding operations: parsing operation "Compute_ListNodes": determining response operation for "Compute_ListNodes" (method "POST" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}/listNodes"): parsing model "AmlComputeNodesInformation" for list operation to find real model: model did not contain a field 'value'
❌ Service "marketplacenotifications" - Api Version "2021-03-03"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Notification": finding operations: duplicate operation ID "GetWithAuthorization" - first "GET" "/subscriptions/{subscription}/providers/Microsoft.MarketplaceNotifications/reviewsNotification/{notification}" - second "GET" "/subscriptions/{subscription}/providers/Microsoft.MarketplaceNotifications/reviewsNotifications"
❌ Service "mediaservices" - Api Version "2021-06-01"
  💥 Error: generating API Versions: generating Resource "Mediaservices" (Namespace "Pandora.Definitions.ResourceManager.Mediaservices.v2021_06_01.Mediaservices"): generating code for model "UserAssignedManagedIdentities" in "Pandora.Definitions.ResourceManager.Mediaservices.v2021_06_01.Mediaservices": the model "UserAssignedManagedIdentities" in namespace "Pandora.Definitions.ResourceManager.Mediaservices.v2021_06_01.Mediaservices" has no fields
❌ Service "migrateprojects" - Api Version "2018-09-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "MigrateProjects": parsing operations: parsing items from top-level model "MigrateProject": determining models for model: finding models for "MigrateProjectProperties": finding fields for "MigrateProjectProperties": mapping field "MigrateProjectProperties": parsing constant: reference was missing
❌ Service "netapp" - Api Version "2021-04-01-preview"
  💥 Error: generating API Versions: generating Resource "Backups" (Namespace "Pandora.Definitions.ResourceManager.Netapp.v2021_04_01_preview.Backups"): generating code for model "ResourceTags" in "Pandora.Definitions.ResourceManager.Netapp.v2021_04_01_preview.Backups": the model "ResourceTags" in namespace "Pandora.Definitions.ResourceManager.Netapp.v2021_04_01_preview.Backups" has no fields
❌ Service "notebooks" - Api Version "2019-10-11-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "NotebookProxy": finding operations: parsing operation "NotebookProxies_List": determining response operation for "NotebookProxies_List" (method "GET" / uri "/subscriptions/{subscriptionId}/providers/Microsoft.Notebooks/notebookProxies"): parsing model "NotebookProxyListResult" for list operation to find real model: determining models for model: finding models for "NotebookProxy": finding models for "NotebookResourceSystemData": finding fields for "NotebookResourceSystemData": mapping field "NotebookResourceSystemData": populating top level constant "IdentityType": reference was missing
❌ Service "peering" - Api Version "2021-06-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "CheckServiceProviderAvailability": finding operations: parsing operation "": determining response operation for "" (method "POST" / uri "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/checkServiceProviderAvailability"): parsing object from inlined response model "": determining constants for model: parsing constant: reference was missing
❌ Service "policyinsights" - Api Version "2021-01-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "policyinsights": finding resource ids: determining unique segment names: need a fourth unique identifier to make "/{resourceId}/providers/Microsoft.PolicyInsights/attestations/{attestationName}" unique
❌ Service "providerhub" - Api Version "2021-06-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "CustomRollouts": finding operations: parsing operation "ListByProviderRegistration": determining response operation for "ListByProviderRegistration" (method "GET" / uri "/subscriptions/{subscriptionId}/providers/Microsoft.ProviderHub/providerRegistrations/{providerNamespace}/customRollouts"): parsing model "CustomRolloutArrayResponseWithContinuation" for list operation to find real model: determining models for model: finding models for "CustomRollout": finding models for "CustomRolloutProperties": finding models for "CustomRolloutPropertiesSpecification": finding models for "CustomRolloutSpecificationProviderRegistration": finding models for "ProviderRegistrationProperties": finding fields for "ProviderRegistrationProperties": retrieving fields for inherited type "ProviderRegistrationProperties": retrieving fields for inherited type "ResourceProviderManifestProperties": mapping field "ResourceProviderManifestProperties": the schema for the field "metadata" is invalid
❌ Service "redhatopenshift" - Api Version "2020-04-30"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "OpenShiftClusters": finding operations: parsing operation "List": determining response operation for "List" (method "GET" / uri "/subscriptions/{subscriptionId}/providers/Microsoft.RedHatOpenShift/openShiftClusters"): parsing model "OpenShiftClusterList" for list operation to find real model: determining models for model: finding models for "OpenShiftCluster": finding models for "OpenShiftClusterProperties": finding fields for "OpenShiftClusterProperties": mapping field "OpenShiftClusterProperties": populating top level constant "ProvisioningState": reference was missing
❌ Service "redis" - Api Version "2020-12-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Redis": finding operations: parsing operation "ListUpgradeNotifications": building options for operation "ListUpgradeNotifications": determining field type for operation: unsupported field type "number"
❌ Service "saas" - Api Version "2018-03-01-beta"
  💥 Error: generating API Versions: generating Resource "SaaSResources" (Namespace "Pandora.Definitions.ResourceManager.Saas.v2018_03_01_beta.SaaSResources"): generating code for model "Tags" in "Pandora.Definitions.ResourceManager.Saas.v2018_03_01_beta.SaaSResources": the model "Tags" in namespace "Pandora.Definitions.ResourceManager.Saas.v2018_03_01_beta.SaaSResources" has no fields
❌ Service "security" - Api Version "2021-07-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Settings": finding operations: parsing operation "Update": parsing constants within operation parameters: mapping "settingName": reference was missing
❌ Service "securityandcompliance" - Api Version "2021-03-08"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Resource": parsing operations: parsing items from top-level model "OperationResultsDescription": determining fields for model: mapping field "OperationResultsDescription": the schema for the field "properties" is invalid
❌ Service "servicefabric" - Api Version "2021-06-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Cluster": parsing operations: parsing items from top-level model "Cluster": determining models for model: finding models for "ClusterProperties": finding fields for "ClusterProperties": mapping field "ClusterProperties": mapping array element of field ClusterProperties.addOnFeatures: populating top level constant "AddOnFeatures": reference was missing
❌ Service "servicefabricmanagedclusters" - Api Version "2021-07-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "ManagedCluster": finding operations: parsing operation "ListByResourceGroup": determining response operation for "ListByResourceGroup" (method "GET" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters"): parsing model "ManagedClusterListResult" for list operation to find real model: determining models for model: finding models for "ManagedCluster": finding models for "ManagedClusterProperties": finding fields for "ManagedClusterProperties": mapping field "ManagedClusterProperties": mapping array element of field ManagedClusterProperties.addonFeatures: populating top level constant "ManagedClusterAddOnFeature": reference was missing
❌ Service "servicefabricmesh" - Api Version "2018-09-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Applications": parsing operations: finding implementations of "DiagnosticsSinkProperties" (discriminating on "kind"): parsing model "AzureInternalMonitoringPipelineSinkDescription": determining fields for model: mapping field "AzureInternalMonitoringPipelineSinkDescription": the schema for the field "fluentdConfigUrl" is invalid
❌ Service "service-map" - Api Version "2015-11-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Client Groups": finding operations: parsing operation "ClientGroups_ListMembers": determining response operation for "ClientGroups_ListMembers" (method "GET" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/features/serviceMap/clientGroups/{clientGroupName}/members"): parsing model "ClientGroupMembersCollection" for list operation to find real model: determining models for model: finding models for "ClientGroupMember": finding models for "ClientGroupMemberProperties": finding models for "ProcessReference": finding fields for "ProcessReference": retrieving fields for inherited type "ResourceReference": mapping field "ResourceReference": parsing constant: reference was missing
❌ Service "sql" - Api Version "2021-02-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "BackupShortTermRetentionPolicies": finding operations: parsing operation "ListByDatabase": determining response operation for "ListByDatabase" (method "GET" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/backupShortTermRetentionPolicies"): parsing model "BackupShortTermRetentionPolicyListResult" for list operation to find real model: determining models for model: finding models for "BackupShortTermRetentionPolicy": finding models for "BackupShortTermRetentionPolicyProperties": finding fields for "BackupShortTermRetentionPolicyProperties": mapping field "BackupShortTermRetentionPolicyProperties": parsing constant: expected an integer but got 12 for the 0 value for "DiffBackupIntervalInHours"
❌ Service "storage" - Api Version "2021-04-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "BlobContainers": finding operations: parsing operation "DeleteImmutabilityPolicy": parsing constants within operation parameters: mapping "immutabilityPolicyName": reference was missing
❌ Service "storagecache" - Api Version "2021-05-01"
  💥 Error: generating API Versions: generating Resource "StorageTargets" (Namespace "Pandora.Definitions.ResourceManager.Storagecache.v2021_05_01.StorageTargets"): generating code for model "UnknownProperties" in "Pandora.Definitions.ResourceManager.Storagecache.v2021_05_01.StorageTargets": the model "UnknownProperties" in namespace "Pandora.Definitions.ResourceManager.Storagecache.v2021_05_01.StorageTargets" has no fields
❌ Service "synapse" - Api Version "2021-06-01-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "BigDataPools": finding operations: parsing operation "Delete": determining response operation for "Delete" (method "DELETE" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/bigDataPools/{bigDataPoolName}"): response model must either be a reference or an inlined model but got neither
❌ Service "testbase" - Api Version "2020-12-16-preview"
  💥 Error: generating API Versions: generating Resource "TestBaseAccount" (Namespace "Pandora.Definitions.ResourceManager.Testbase.v2020_12_16_preview.TestBaseAccount"): generating code for model "Tags" in "Pandora.Definitions.ResourceManager.Testbase.v2020_12_16_preview.TestBaseAccount": the model "Tags" in namespace "Pandora.Definitions.ResourceManager.Testbase.v2020_12_16_preview.TestBaseAccount" has no fields
❌ Service "timeseriesinsights" - Api Version "2021-06-30-preview"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Environments": parsing operations: parsing items from top-level model "EnvironmentListResponse": determining models for model: finding models for "EnvironmentResource": finding fields for "EnvironmentResource": mapping field "EnvironmentResource": parsing constant: reference was missing
❌ Service "trafficmanager" - Api Version "2018-08-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "HeatMaps": finding operations: parsing operation "HeatMap_Get": parsing constants within operation parameters: mapping "heatMapType": reference was missing
❌ Service "videoanalyzer" - Api Version "2021-05-01-preview"
  💥 Error: generating API Versions: generating Resource "Videoanalyzer" (Namespace "Pandora.Definitions.ResourceManager.Videoanalyzer.v2021_05_01_preview.Videoanalyzer"): generating code for model "UserAssignedManagedIdentities" in "Pandora.Definitions.ResourceManager.Videoanalyzer.v2021_05_01_preview.Videoanalyzer": the model "UserAssignedManagedIdentities" in namespace "Pandora.Definitions.ResourceManager.Videoanalyzer.v2021_05_01_preview.Videoanalyzer" has no fields
❌ Service "vmware" - Api Version "2021-06-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "Scripts": finding operations: parsing operation "ScriptExecutions_GetExecutionLogs": determining request operation for "ScriptExecutions_GetExecutionLogs" (method "POST" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/scriptExecutions/{scriptExecutionName}/getExecutionLogs"): request model must either be a reference or an inlined model but got neither
❌ Service "vmwarecloudsimple" - Api Version "2019-04-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "DedicatedCloudNodes": finding operations: parsing operation "ListByResourceGroup": determining response operation for "ListByResourceGroup" (method "GET" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VMwareCloudSimple/dedicatedCloudNodes"): parsing model "DedicatedCloudNodeListResponse" for list operation to find real model: determining models for model: finding models for "DedicatedCloudNode": finding models for "DedicatedCloudNodeProperties": finding fields for "DedicatedCloudNodeProperties": mapping field "DedicatedCloudNodeProperties": the schema for the field "created" is invalid
❌ Service "web" - Api Version "2021-02-01"
  💥 Error: parsing Swagger files: parsing definition: finding resources for tag "AppServiceEnvironments": finding operations: parsing operation "DeletePrivateEndpointConnection": determining response operation for "DeletePrivateEndpointConnection" (method "DELETE" / uri "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/privateEndpointConnections/{privateEndpointConnectionName}"): response model must either be a reference or an inlined model but got neither
```