### PR TITLE
tools/importer-rest-api-specs: the ResourceProvider segment is a special kind of Static segment

### DIFF
--- a/tools/importer-rest-api-specs/models/resource_ids.go
+++ b/tools/importer-rest-api-specs/models/resource_ids.go
@@ -41,7 +41,7 @@ func (pri ParsedResourceId) SegmentsAvailableForNaming() []string {
 	if len(segmentsWithoutScope)%2 == 0 && len(segmentsWithoutScope) > 0 {
 		availableSegments := make([]string, 0)
 		for _, segment := range segmentsWithoutScope {
-			if segment.Type == ConstantSegment || segment.Type == StaticSegment {
+			if segment.Type == ConstantSegment || segment.Type == ResourceProviderSegment || segment.Type == StaticSegment {
 				normalized := cleanup.NormalizeSegmentName(segment.Name)
 				availableSegments = append(availableSegments, normalized)
 			}
@@ -77,7 +77,7 @@ func (pri ParsedResourceId) NormalizedResourceManagerResourceId() string {
 	lastUserValueSegment := -1
 	for i, segment := range segments {
 		// everything else technically is a user configurable component
-		if segment.Type != StaticSegment {
+		if segment.Type != StaticSegment && segment.Type != ResourceProviderSegment {
 			lastUserValueSegment = i
 		}
 	}

--- a/tools/importer-rest-api-specs/parser/parser_resource_ids.go
+++ b/tools/importer-rest-api-specs/parser/parser_resource_ids.go
@@ -230,7 +230,7 @@ func (d *SwaggerDefinition) parseResourceIdFromOperation(uri string, operationDe
 	lastUserValueSegment := -1
 	for i, segment := range segments {
 		// everything else technically is a user configurable component
-		if segment.Type != models.StaticSegment {
+		if segment.Type != models.StaticSegment && segment.Type != models.ResourceProviderSegment {
 			lastUserValueSegment = i
 		}
 	}
@@ -247,7 +247,7 @@ func (d *SwaggerDefinition) parseResourceIdFromOperation(uri string, operationDe
 
 	allSegmentsAreStatic := true
 	for _, segment := range segments {
-		if segment.Type != models.StaticSegment {
+		if segment.Type != models.StaticSegment && segment.Type != models.ResourceProviderSegment {
 			allSegmentsAreStatic = false
 			break
 		}


### PR DESCRIPTION
Resource Provider segments are a Static segment with a different name, so also need to be taken into account when naming, this fixes https://github.com/hashicorp/pandora/pull/331#pullrequestreview-773604390