### PR TITLE
data: adding a project for definitions written by hand

### DIFF
--- a/data/Pandora.Data/Pandora.Data.csproj
+++ b/data/Pandora.Data/Pandora.Data.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Pandora.Definitions.DataPlane\Pandora.Definitions.DataPlane.csproj" />
+      <ProjectReference Include="..\Pandora.Definitions.HandDefined\Pandora.Definitions.HandDefined.csproj" />
       <ProjectReference Include="..\Pandora.Definitions.ResourceManager\Pandora.Definitions.ResourceManager.csproj" />
       <ProjectReference Include="..\Pandora.Definitions.TestData\Pandora.Definitions.TestData.csproj" />
       <ProjectReference Include="..\Pandora.Definitions\Pandora.Definitions.csproj" />

--- a/data/Pandora.Data/ServiceDefinitions.cs
+++ b/data/Pandora.Data/ServiceDefinitions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Pandora.Definitions.DataPlane;
+using Pandora.Definitions.HandDefined;
 using Pandora.Definitions.Interfaces;
 using Pandora.Definitions.ResourceManager;
 using Pandora.Definitions.TestData;
@@ -13,6 +14,7 @@ namespace Pandora.Data
         {
             var servicesDefinitions = new List<ServicesDefinition>{
                 new DataPlaneServices(),
+                new HandDefinedServices(),
                 new ResourceManagerServices(),
                 
                 // NOTE: this can be useful during development for example scenarios so is intentionally commented out here

--- a/data/Pandora.Data/ServiceDefinitionsTests.cs
+++ b/data/Pandora.Data/ServiceDefinitionsTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NUnit.Framework;
 using Pandora.Data.Repositories;
 using Pandora.Definitions.DataPlane;
+using Pandora.Definitions.HandDefined;
 using Pandora.Definitions.Interfaces;
 using Pandora.Definitions.ResourceManager;
 using Pandora.Definitions.TestData;
@@ -16,6 +17,12 @@ namespace Pandora.Data
         public void ValidateDataPlaneServiceDefinitions()
         {
             ValidateAssemblyContainingServiceDefinitions(new DataPlaneServices());
+        }
+
+        [TestCase]
+        public void ValidateHandDefinedServiceDefinitions()
+        {
+            ValidateAssemblyContainingServiceDefinitions(new HandDefinedServices());
         }
 
         [TestCase]

--- a/data/Pandora.Definitions.HandDefined/HandDefinedServices.cs
+++ b/data/Pandora.Definitions.HandDefined/HandDefinedServices.cs
@@ -1,0 +1,8 @@
+﻿using Pandora.Definitions.Interfaces;
+
+namespace Pandora.Definitions.HandDefined
+{
+    public class HandDefinedServices : ServicesDefinition
+    {
+    }
+}

--- a/data/Pandora.Definitions.HandDefined/Pandora.Definitions.HandDefined.csproj
+++ b/data/Pandora.Definitions.HandDefined/Pandora.Definitions.HandDefined.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <UseSharedCompilation>false</UseSharedCompilation>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Pandora.Definitions\Pandora.Definitions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/data/Pandora.sln
+++ b/data/Pandora.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pandora.Definitions.DataPla
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pandora.Definitions.TestData", "Pandora.Definitions.TestData\Pandora.Definitions.TestData.csproj", "{067B0180-506F-426A-803A-0FC1B52861AB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pandora.Definitions.HandDefined", "Pandora.Definitions.HandDefined\Pandora.Definitions.HandDefined.csproj", "{31ADFADD-5682-4C2C-A171-375ACA210A59}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,5 +44,9 @@ Global
 		{067B0180-506F-426A-803A-0FC1B52861AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{067B0180-506F-426A-803A-0FC1B52861AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{067B0180-506F-426A-803A-0FC1B52861AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31ADFADD-5682-4C2C-A171-375ACA210A59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31ADFADD-5682-4C2C-A171-375ACA210A59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31ADFADD-5682-4C2C-A171-375ACA210A59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31ADFADD-5682-4C2C-A171-375ACA210A59}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Whilst this isn't something we plan to use all of the time, it's needed for AzureADB2C