### PR TITLE
tools/importer-rest-api-specs: splitting the VCSRevision ID out to it's own file

### DIFF
--- a/tools/importer-rest-api-specs/generate.go
+++ b/tools/importer-rest-api-specs/generate.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/parser"
 )
 
-func generateApiVersions(input []parser.ParsedData, workingDirectory, rootNamespace, swaggerGitSha string, resourceProvider *string, debug bool) error {
+func generateApiVersions(input []parser.ParsedData, workingDirectory, rootNamespace string, resourceProvider *string, debug bool) error {
 	for _, item := range input {
-		data := generator.GenerationDataForServiceAndApiVersion(item.ServiceName, item.ApiVersion, workingDirectory, rootNamespace, swaggerGitSha, resourceProvider)
+		data := generator.GenerationDataForServiceAndApiVersion(item.ServiceName, item.ApiVersion, workingDirectory, rootNamespace, resourceProvider)
 		generator := generator.NewPackageDefinitionGenerator(data, debug)
 
 		os.MkdirAll(data.WorkingDirectoryForApiVersion, permissions)
@@ -38,7 +38,7 @@ func generateApiVersions(input []parser.ParsedData, workingDirectory, rootNamesp
 	return nil
 }
 
-func generateServiceDefinitions(input []parser.ParsedData, workingDirectory, rootNamespace, swaggerGitSha string, resourceProvider *string, debug bool) error {
+func generateServiceDefinitions(input []parser.ParsedData, workingDirectory, rootNamespace string, resourceProvider *string, debug bool) error {
 	// the same service may appear multiple times, so we first need to Distinct them
 	serviceNames := distinctServiceNames(input)
 
@@ -48,7 +48,7 @@ func generateServiceDefinitions(input []parser.ParsedData, workingDirectory, roo
 		if debug {
 			log.Printf("[DEBUG] Processing Service %q..", service)
 		}
-		data := generator.GenerationDataForService(service, workingDirectory, rootNamespace, swaggerGitSha, resourceProvider)
+		data := generator.GenerationDataForService(service, workingDirectory, rootNamespace, resourceProvider)
 		os.MkdirAll(data.WorkingDirectoryForService, permissions)
 
 		// clean up any files or directories which which aren't on the exclude list

--- a/tools/importer-rest-api-specs/generator/data.go
+++ b/tools/importer-rest-api-specs/generator/data.go
@@ -9,7 +9,6 @@ import (
 type GenerationData struct {
 	ServiceName   string
 	ApiVersion    string
-	SwaggerGitSha string
 
 	NamespaceForService    string
 	NamespaceForApiVersion string
@@ -19,7 +18,7 @@ type GenerationData struct {
 	ResourceProvider              *string
 }
 
-func GenerationDataForService(serviceName, rootDirectory, rootNamespace, swaggerGitSha string, resourceProvider *string) GenerationData {
+func GenerationDataForService(serviceName, rootDirectory, rootNamespace string, resourceProvider *string) GenerationData {
 	normalisedServiceName := strings.ReplaceAll(serviceName, "-", "")
 	serviceNamespace := fmt.Sprintf("%s.%s", rootNamespace, strings.Title(normalisedServiceName))
 	serviceWorkingDirectory := path.Join(rootDirectory, rootNamespace, strings.Title(normalisedServiceName))
@@ -28,14 +27,13 @@ func GenerationDataForService(serviceName, rootDirectory, rootNamespace, swagger
 		NamespaceForService:        serviceNamespace,
 		ResourceProvider:           resourceProvider,
 		ServiceName:                normalisedServiceName,
-		SwaggerGitSha:              swaggerGitSha,
 		WorkingDirectoryForService: serviceWorkingDirectory,
 	}
 }
 
-func GenerationDataForServiceAndApiVersion(serviceName, apiVersion, rootDirectory, rootNamespace, swaggerGitSha string, resourceProvider *string) GenerationData {
+func GenerationDataForServiceAndApiVersion(serviceName, apiVersion, rootDirectory, rootNamespace string, resourceProvider *string) GenerationData {
 	normalizedApiVersion := normalizeApiVersion(apiVersion)
-	data := GenerationDataForService(serviceName, rootDirectory, rootNamespace, swaggerGitSha, resourceProvider)
+	data := GenerationDataForService(serviceName, rootDirectory, rootNamespace, resourceProvider)
 	data.ApiVersion = apiVersion
 	data.NamespaceForApiVersion = fmt.Sprintf("%s.%s", data.NamespaceForService, normalizedApiVersion)
 	data.WorkingDirectoryForApiVersion = path.Join(data.WorkingDirectoryForService, normalizedApiVersion)

--- a/tools/importer-rest-api-specs/generator/definition_package.go
+++ b/tools/importer-rest-api-specs/generator/definition_package.go
@@ -27,8 +27,6 @@ namespace %[1]s
 {
 	internal class Definition : ApiDefinition
 	{
-		// Generated from Swagger revision %[5]q 
-
 		public string ApiVersion => "%[3]s";
 		public string Name => "%[2]s";
 		public IEnumerable<Interfaces.ApiOperation> Operations => new List<Interfaces.ApiOperation>
@@ -37,5 +35,5 @@ namespace %[1]s
 		};
 	}
 }
-`, namespace, resourceName, g.data.ApiVersion, strings.Join(lines, "\n"), g.data.SwaggerGitSha)
+`, namespace, resourceName, g.data.ApiVersion, strings.Join(lines, "\n"))
 }

--- a/tools/importer-rest-api-specs/generator/revision_id.go
+++ b/tools/importer-rest-api-specs/generator/revision_id.go
@@ -1,0 +1,23 @@
+package generator
+
+import (
+	"fmt"
+	"path"
+)
+
+func OutputRevisionId(workingDirectory, namespace, swaggerGitSha string) error {
+	revisionIdCode := codeForRevisionIdFile(namespace, swaggerGitSha)
+	revisionIdFileName := path.Join(workingDirectory, namespace, "SwaggerRevision.cs")
+	if err := writeToFile(revisionIdFileName, revisionIdCode); err != nil {
+		return fmt.Errorf("writing Swagger Revision ID for %q: %+v", revisionIdFileName, err)
+	}
+
+	return nil
+}
+
+func codeForRevisionIdFile(namespace, swaggerGitSha string) string {
+	return fmt.Sprintf(`namespace %[1]s
+{
+	// Generated from Swagger revision %[2]q
+}`, namespace, swaggerGitSha)
+}

--- a/tools/importer-rest-api-specs/main.go
+++ b/tools/importer-rest-api-specs/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/generator"
 	"log"
 	"os"
 	"strings"
@@ -93,16 +94,23 @@ func run(input RunInput, swaggerGitSha string, debug bool) error {
 	}
 
 	if debug {
+		log.Printf("[STAGE] Updating the Output Revision ID to %q", swaggerGitSha)
+	}
+	if err := generator.OutputRevisionId(input.OutputDirectory, input.RootNamespace, swaggerGitSha); err != nil {
+		return fmt.Errorf("outputting the Revision Id: %+v", err)
+	}
+
+	if debug {
 		log.Printf("[STAGE] Generating Swagger Definitions..")
 	}
-	if err := generateServiceDefinitions(*data, input.OutputDirectory, input.RootNamespace, swaggerGitSha, input.ResourceProvider, debug); err != nil {
+	if err := generateServiceDefinitions(*data, input.OutputDirectory, input.RootNamespace, input.ResourceProvider, debug); err != nil {
 		return errWrap(fmt.Errorf("generating Service Definitions: %+v", err))
 	}
 
 	if debug {
 		log.Printf("[STAGE] Generating API Definitions..")
 	}
-	if err := generateApiVersions(*data, input.OutputDirectory, input.RootNamespace, swaggerGitSha, input.ResourceProvider, debug); err != nil {
+	if err := generateApiVersions(*data, input.OutputDirectory, input.RootNamespace, input.ResourceProvider, debug); err != nil {
 		return errWrap(fmt.Errorf("generating API Versions: %+v", err))
 	}
 


### PR DESCRIPTION
Whilst at one point this was useful in each Service Definition, if we're importing everything every time these
show up as a diff when there's nothing notable to change - whilst it's not a big deal now, with all of the services
this'll become a lot of spurious diff's. Since this is purely for info moving this to a separate file as a comment
should suffice for now (it may become a field we expose, but there's no need at this time).