### PR TITLE
automation: automatically regenerating the Config when the Swagger changes

### DIFF
--- a/.github/workflows/data-codegen-on-swagger-changes.yaml
+++ b/.github/workflows/data-codegen-on-swagger-changes.yaml
@@ -21,6 +21,22 @@ jobs:
         with:
           go-version: '1.16.x'
 
+      - name: build and run version-bumper
+        id: generate
+        run: |
+          cd ./tools/version-bumper
+          make tools
+          make build
+          make run
+
+      - name: then commit the diff
+        id: commit
+        run: |
+          git checkout -b data/regeneration-from-${{ github.sha }}
+          git config user.name "GitHub Actions"
+          git config user.email "<>"
+          ./scripts/conditionally-commit-codegen-changes.sh "config: regenerating based on the latest Swagger"
+
       - name: build and run importer-rest-api-specs
         id: generate
         run: |
@@ -35,7 +51,7 @@ jobs:
           git checkout -b data/regeneration-from-${{ github.sha }}
           git config user.name "GitHub Actions"
           git config user.email "<>"
-          ./scripts/conditionally-commit-codegen-changes.sh
+          ./scripts/conditionally-commit-codegen-changes.sh "data: regenerating based on the latest Swagger"
 
       - name: then conditionally push the branch
         id: push-branch

--- a/scripts/conditionally-commit-codegen-changes.sh
+++ b/scripts/conditionally-commit-codegen-changes.sh
@@ -2,7 +2,7 @@
 
 if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
   git add --all
-  git commit -m "data: regenerating based on the latest Swagger"
+  git commit -m "$1"
   echo "::set-output name=has_changes_to_push::true"
 else
   echo "::set-output name=has_changes_to_push::false"


### PR DESCRIPTION
This commit adds a step to regenerate the Config whenever changes to the Swagger data get merged - which means that we'll automatically generate new Versions and Services when the feature-flags in those tools are enabled.

Dependent on / must be rebased on top of #372