### PR TITLE
tools/importer-rest-api-specs: ignoring async operations

### DIFF
--- a/tools/importer-rest-api-specs/parser/helpers.go
+++ b/tools/importer-rest-api-specs/parser/helpers.go
@@ -57,6 +57,9 @@ func operationShouldBeIgnored(operationUri string) bool {
 	}
 
 	// LRO's shouldn't be directly exposed
+	if strings.Contains(strings.ToLower(operationUri), "/azureasyncoperations/") {
+		return true
+	}
 	if strings.Contains(strings.ToLower(operationUri), "/operationresults/") {
 		return true
 	}


### PR DESCRIPTION
We parse the LRO's directly, so there's no point exposing these

Fixes #367