### PR TITLE
automation: fixing the step naming

### DIFF
--- a/.github/workflows/data-codegen-on-swagger-changes.yaml
+++ b/.github/workflows/data-codegen-on-swagger-changes.yaml
@@ -22,7 +22,7 @@ jobs:
           go-version: '1.16.x'
 
       - name: build and run version-bumper
-        id: generate
+        id: bump-versions
         run: |
           cd ./tools/version-bumper
           make tools
@@ -30,7 +30,7 @@ jobs:
           make run
 
       - name: then commit the diff
-        id: commit
+        id: commit-versions-config
         run: |
           git checkout -b data/regeneration-from-${{ github.sha }}
           git config user.name "GitHub Actions"
@@ -38,7 +38,7 @@ jobs:
           ./scripts/conditionally-commit-codegen-changes.sh "config: regenerating based on the latest Swagger"
 
       - name: build and run importer-rest-api-specs
-        id: generate
+        id: import-data
         run: |
           cd ./tools/importer-rest-api-specs
           make tools
@@ -46,7 +46,7 @@ jobs:
           make import
 
       - name: then commit the diff
-        id: commit
+        id: commit-imported-data
         run: |
           git checkout -b data/regeneration-from-${{ github.sha }}
           git config user.name "GitHub Actions"


### PR DESCRIPTION
There's duplicates so currently this errors with:

> The workflow is not valid. .github/workflows/data-codegen-on-swagger-changes.yaml (Line: 41, Col: 13): The identifier 'generate' may not be used more than once within the same scope. .github/workflows/data-codegen-on-swagger-changes.yaml (Line: 49, Col: 13): The identifier 'commit' may not be used more than once within the same scope.