### PR TITLE
tools/importer-rest-api-specs: ignoring status codes with `x-ms-error-response: true`

### DIFF
--- a/tools/importer-rest-api-specs/parser/operations_test.go
+++ b/tools/importer-rest-api-specs/parser/operations_test.go
@@ -1315,6 +1315,76 @@ func TestParseOperationSingleReturningAString(t *testing.T) {
 	}
 }
 
+func TestParseOperationSingleReturningAnErrorStatusCode(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_error_status_code.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 0 {
+		t.Fatalf("expected No Models but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GimmeAString"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GimmeAString")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	// the 401 should be ignored
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatalf("expected a response object but got none")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionString {
+		t.Fatalf("expected the response object to be a string but got %q", string(world.ResponseObject.Type))
+	}
+	if world.ResponseObject.ReferenceName != nil {
+		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/worlds/favourite" {
+		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+}
+
 func TestParseOperationSingleReturningATopLevelRawObject(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_top_level_raw_object.json")
 	if err != nil {

--- a/tools/importer-rest-api-specs/parser/testdata/operations_single_returning_an_error_status_code.json
+++ b/tools/importer-rest-api-specs/parser/testdata/operations_single_returning_an_error_status_code.json
@@ -1,0 +1,63 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/worlds/favourite": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "summary": "Returns a string value from the API",
+        "description": "Description for returns a string value from the API.",
+        "operationId": "Hello_GimmeAString",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "x-ms-error-response": true
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
We intentionally ignore the RP specific errors since the base layer is expected to be able to handle these, whilst this doesn't handle all cases today (which is consistent with Track1) - it will in future - so this is fine for now.

Fixes #395