### PR TITLE
automation: running the swagger validator when the config changes

### DIFF
--- a/.github/workflows/rest-api-specs-importer-go-test.yaml
+++ b/.github/workflows/rest-api-specs-importer-go-test.yaml
@@ -5,6 +5,7 @@ on:
     types: ['opened', 'synchronize']
     paths:
       - '.github/workflows/**'
+      - 'config/**'
       - 'swagger'
       - 'tools/importer-rest-api-specs/**'
 


### PR DESCRIPTION
This ensures that when we add a new version to the config that we can validate it

Noticed that #402 wasn't running the Github Action, but it should be