### PR TITLE
resource-manager: importing `applicationinsights`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -9,7 +9,7 @@ service "appconfiguration" {
 }
 service "applicationinsights" {
   name = "ApplicationInsights"
-  available = ["2020-02-02"]
+  available = ["2015-05-01", "2020-02-02"]
 }
 service "attestation" {
   name      = "Attestation"


### PR DESCRIPTION
This requires both `2020-02-02` and `2015-05-01` as `2020-02-02` is a composite package in the Swagger today

https://github.com/Azure/azure-rest-api-specs/blob/da8f07c9714d12730503976d23d94e16cb77d8dd/specification/applicationinsights/resource-manager/readme.md?plain=1#L366-L386