### PR TITLE
tools/generator-go-sdk: removing the import logic-gate for Services with ResourceID's we can't parse

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/hashicorp/pandora/tools/generator-go-sdk/generator"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
@@ -47,24 +46,6 @@ func run(input GeneratorInput) error {
 		log.Printf("[DEBUG] Service %q..", serviceName)
 		if !service.Details.Generate {
 			log.Printf("[DEBUG] .. is opted out of generation, skipping..")
-			continue
-		}
-
-		// temporarily until new Resource ID's are in
-		servicesToTemporarilyIgnore := []string{
-			"privateDns",
-			"dns",
-			"DataProtection",
-			"HDInsight",
-		}
-		skip := false
-		for _, serviceToIgnore := range servicesToTemporarilyIgnore {
-			if strings.EqualFold(serviceName, serviceToIgnore) {
-				skip = true
-				break
-			}
-		}
-		if skip {
 			continue
 		}
 


### PR DESCRIPTION
This is now instead handled inside of the importer so that logic is contained - as such this is fine to remove for now. (We're also looking to merge #272 today, which'll fix the root cause here).