### PR TITLE
tools/generator-go-sdk: removing dead code

### DIFF
--- a/tools/generator-go-sdk/generator/service.go
+++ b/tools/generator-go-sdk/generator/service.go
@@ -45,7 +45,6 @@ func (s *ServiceGenerator) Generate(input ServiceGeneratorInput) error {
 		"clients":    s.clients,
 		"constants":  s.constants,
 		"ids":        s.ids,
-		"id-aliases": s.idAliases,
 		"methods":    s.methods,
 		"models":     s.models,
 		"predicates": s.predicates,


### PR DESCRIPTION
Looks like we may need to add a GHA to ensure each of these tools compiles, I guess we're just doing that for the importer now