### PR TITLE
tools/generator-go-sdk: discriminated models now output their parent fields

### DIFF
--- a/tools/generator-go-sdk/generator/stage_models.go
+++ b/tools/generator-go-sdk/generator/stage_models.go
@@ -104,7 +104,10 @@ func (c modelsTemplater) structCode(data ServiceGeneratorData) (*string, error) 
 	}
 
 	// then add any inherited fields
+	parentAssignmentInfo := ""
 	if c.model.ParentTypeName != nil {
+		parentAssignmentInfo = fmt.Sprintf("var _ %[1]s = %[2]s{}", *c.model.ParentTypeName, c.name)
+
 		parent, ok := data.models[*c.model.ParentTypeName]
 		if !ok {
 			return nil, fmt.Errorf("couldn't find Parent Model %q for Model %q", *c.model.ParentTypeName, c.name)
@@ -144,10 +147,11 @@ func (c modelsTemplater) structCode(data ServiceGeneratorData) (*string, error) 
 	}
 
 	out := fmt.Sprintf(`
+%[3]s
 type %[1]s struct {
 %[2]s
 }
-`, c.name, strings.Join(structLines, "\n"))
+`, c.name, strings.Join(structLines, "\n"), parentAssignmentInfo)
 	return &out, nil
 }
 


### PR DESCRIPTION
This PR fixes 3 issues spotted by @koikonom for Discriminated Types:

1. A Parent Type shouldn't have an unmarshal function (since it's represented an interface, which can have no fields)
2. Therefore an Implementation of that Parent Type must output any fields from the Parent as (struct) fields on the Implementation
3. UX: adding an explicit type assignment check that the Implementation implements the Parent Interface - whilst this'll always be true and such is a noop, it's helpful when reading the code.

