### PR TITLE
tools/generator-go-sdk: allowing for specifying the arguments

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/pandora/tools/generator-go-sdk/generator"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
@@ -33,7 +34,7 @@ func main() {
 
 	if input.outputDirectory == "" {
 		homeDir, _ := os.UserHomeDir()
-		input.outputDirectory = homeDir + "/Desktop/generated-sdk-dev"
+		input.outputDirectory = filepath.Join(homeDir, "/Desktop/generated-sdk-dev")
 	}
 
 	if err := run(input); err != nil {


### PR DESCRIPTION
This enables us to specify a custom server location and output directory - which we'll need to generate the Go SDK into it's own directory

For now I've intentionally left the Transport out of this, since we're using the Track1 base layer for now