### PR TITLE
data: Delete operations should default to JSON

### DIFF
--- a/data/Pandora.Definitions/Operations/DeleteOperation.cs
+++ b/data/Pandora.Definitions/Operations/DeleteOperation.cs
@@ -10,7 +10,7 @@ namespace Pandora.Definitions.Operations
     {
         public virtual string? ContentType()
         {
-            return null;
+            return "application/json; charset=utf-8";
         }
 
         public virtual IEnumerable<HttpStatusCode> ExpectedStatusCodes()


### PR DESCRIPTION
The importer assumes that these are defaulted to JSON like the other operation types and so won't output/override a content type if it's JSON.

Fixes #563
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/14866