### PR TITLE
config: adding `web` @ 2016-06-01 to Resource Manager

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -135,3 +135,7 @@ service "vmware" {
   name      = "VMware"
   available = ["2020-03-20"]
 }
+service "web" {
+  name      = "Web"
+  available = ["2016-06-01"]
+}


### PR DESCRIPTION
This unblocks https://github.com/hashicorp/terraform-provider-azurerm/issues/1691 as the upstream issue hasn't been resolved https://github.com/Azure/azure-sdk-for-go/issues/9393

Upstream branch: https://github.com/hashicorp/terraform-provider-azurerm/compare/f/connections