### PR TITLE
tools/generator-go-sdk: skipping outputting the headers for second pages of lists

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -446,7 +446,6 @@ func (c methodsAutoRestTemplater) preparerTemplate(data ServiceGeneratorData) (*
 		queryParameters[k] = autorest.Encode("query", v)
 	}`
 		steps = append(steps, "autorest.WithHeaders(options.toHeaders())")
-		listSteps = append(listSteps, "autorest.WithHeaders(options.toHeaders())")
 	}
 
 	if c.operation.UriSuffix != nil {


### PR DESCRIPTION
This shouldn't be necessary since the request uri to poll on should contain all of the items