### PR TITLE
generator-go-sdk: import strings in generated constants.go

### DIFF
--- a/tools/generator-go-sdk/generator/stage_constants.go
+++ b/tools/generator-go-sdk/generator/stage_constants.go
@@ -44,6 +44,8 @@ func (c constantsTemplater) template(data ServiceGeneratorData) (*string, error)
 
 	template := fmt.Sprintf(`package %[1]s
 
+import "strings"
+
 %s`, data.packageName, strings.Join(lines, "\n"))
 	return &template, nil
 }


### PR DESCRIPTION
Fixes #695