### PR TITLE
github: regenerating when pushing to main

### DIFF
--- a/.github/workflows/data-codegen-on-swagger-changes.yaml
+++ b/.github/workflows/data-codegen-on-swagger-changes.yaml
@@ -1,12 +1,17 @@
 name: Regenerate API Data with New Changes after PR Merge
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - 'config/**'
+      - 'swagger'
+      - 'tools/importer-rest-api-specs/**'
 
 jobs:
   regenerate-api-data:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     strategy:
       fail-fast: true
     permissions:


### PR DESCRIPTION
This handles PRs from Fork's where GHA doesn't trigger for security reasons, so the regeneration only happens
on the next maintainer PR into main.

Since this triggers both for PR merges and pushes to main - this should capture both maintainer PR's being merged and collaborator PR's once merged/pushed to main