### PR TITLE
tooling: using a service account when creating the PR

### DIFF
--- a/.github/workflows/data-codegen-on-swagger-changes.yaml
+++ b/.github/workflows/data-codegen-on-swagger-changes.yaml
@@ -12,11 +12,8 @@ on:
 jobs:
   regenerate-api-data:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v2
         with:
@@ -67,12 +64,12 @@ jobs:
           git push origin data/regeneration-from-${{ github.sha }}
 
       - name: then conditionally open a pull request
-        uses: repo-sync/pull-request@v2
         id: open-pr
         if: ${{ steps.commit-versions-config.outputs.has_changes_to_push == 'true' || steps.commit-imported-data.outputs.has_changes_to_push == 'true' }}
-        with:
-          source_branch: "data/regeneration-from-${{ github.sha }}"
-          destination_branch: "main"
-          pr_title: "Data: regenerating based on ${{ github.sha }}"
-          pr_body: "This PR is automatically generated based on the commit ${{ github.sha }}"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr create --title $PR_TITLE --body $PR_BODY -H $PR_SOURCE -B $PR_TARGET
+          env:
+            PR_TITLE: "Data: regenerating based on ${{ github.sha }}"
+            PR_BODY: "This PR is automatically generated based on the commit ${{ github.sha }}"
+            PR_SOURCE: "data/regeneration-from-${{ github.sha }}"
+            PR_TARGET: "main"
+            GITHUB_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PANDORA_TOKEN }}


### PR DESCRIPTION
This commit switches to using a Service Account to create the PR rather than making use of the GitHub Actions write token, due to permissions changes.