### PR TITLE
dependabot: updating to be 7am UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+    time: "07:00"
+    timezone: "UTC"
   open-pull-requests-limit: 2


### PR DESCRIPTION
This allows us to catch these in EU mornings, rather than end-of-day