### PR TITLE
tools/importer-rest-api-specs: Floats and Integer Constants should ignore modelAsString

### DIFF
--- a/tools/importer-rest-api-specs/parser/constants.go
+++ b/tools/importer-rest-api-specs/parser/constants.go
@@ -14,8 +14,7 @@ import (
 )
 
 type constantExtension struct {
-	name          string
-	modelAsString bool
+	name string
 }
 
 type parsedConstant struct {
@@ -119,7 +118,7 @@ func mapConstant(typeVal spec.StringOrArray, fieldName string, values []interfac
 	}
 
 	// allows us to parse out the actual types above then force a string here if needed
-	if constExtension == nil || constExtension.modelAsString {
+	if constExtension == nil {
 		constantType = models.StringConstant
 	}
 
@@ -145,7 +144,6 @@ func parseConstantExtensionFromExtension(field spec.Extensions) (*constantExtens
 	}
 
 	var enumName *string
-	modelAsString := true // assuming this can be omitted
 	for k, v := range enumDetails {
 		// presume inconsistencies in the data
 		if strings.EqualFold(k, "name") {
@@ -153,21 +151,17 @@ func parseConstantExtensionFromExtension(field spec.Extensions) (*constantExtens
 			enumName = &normalizedEnumName
 		}
 
-		if strings.EqualFold(k, "modelAsString") {
-			val, ok := v.(bool)
-			if !ok {
-				return nil, fmt.Errorf("expected a bool for `modelAsString` but got %+v", v)
-			}
-			modelAsString = val
-		}
+		// NOTE: the Swagger Extension defines `modelAsString` which is used to define whether
+		// this should be output as a fixed set of values (e.g. a constant) or an extendable
+		// list of strings (e.g. a set of possible string values with other values possible)
+		// however we're not concerned with the difference - so we ignore this.
 	}
 	if enumName == nil {
 		return nil, fmt.Errorf("enum details are missing a `name`")
 	}
 
 	return &constantExtension{
-		name:          *enumName,
-		modelAsString: modelAsString,
+		name: *enumName,
 	}, nil
 }
 

--- a/tools/importer-rest-api-specs/parser/constants_test.go
+++ b/tools/importer-rest-api-specs/parser/constants_test.go
@@ -108,7 +108,7 @@ func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 }
 
 func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
-	// Enums can either be modelled as strings or not.. this is an Int that's output as a String.
+	// Tests an Integer Constant with modelAsString, which is bad data / should be ignored
 	result, err := ParseSwaggerFileForTesting(t, "constants_integers_as_strings.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
@@ -172,8 +172,8 @@ func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 	if !ok {
 		t.Fatalf("resource.Constants['FavouriteTable'] was not found")
 	}
-	if favouriteTable.FieldType != models.StringConstant {
-		t.Fatalf("expected resource.Constants['TableNumber'].FieldType to be 'String' but got %q", favouriteTable.FieldType)
+	if favouriteTable.FieldType != models.IntegerConstant {
+		t.Fatalf("expected resource.Constants['TableNumber'].FieldType to be 'Integer' but got %q", favouriteTable.FieldType)
 	}
 	if len(favouriteTable.Values) != 3 {
 		t.Fatalf("expected resource.Constants['TableNumber'] to have 3 values but got %d", len(favouriteTable.Values))
@@ -296,7 +296,7 @@ func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 }
 
 func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
-	// Enums can either be modelled as strings or not.. this is an Int that's output as a String.
+	// Tests an Integer Constant defined Inline with modelAsString, which is bad data / should be ignored
 	result, err := ParseSwaggerFileForTesting(t, "constants_integers_as_strings_inlined.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
@@ -360,8 +360,8 @@ func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 	if !ok {
 		t.Fatalf("resource.Constants['TableNumber'] was not found")
 	}
-	if favouriteTable.FieldType != models.StringConstant {
-		t.Fatalf("expected resource.Constants['TableNumber'].FieldType to be 'String' but got %q", favouriteTable.FieldType)
+	if favouriteTable.FieldType != models.IntegerConstant {
+		t.Fatalf("expected resource.Constants['TableNumber'].FieldType to be 'Integer' but got %q", favouriteTable.FieldType)
 	}
 	if len(favouriteTable.Values) != 3 {
 		t.Fatalf("expected resource.Constants['TableNumber'] to have 3 values but got %d", len(favouriteTable.Values))
@@ -672,7 +672,7 @@ func TestParseConstantsStringsInlinedContainingFloats(t *testing.T) {
 }
 
 func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
-	// Enums can either be modelled as strings or not.. this is an Float that's output as a String.
+	// Tests an Float Constant with modelAsString, which is bad data / should be ignored
 	result, err := ParseSwaggerFileForTesting(t, "constants_floats_as_strings.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
@@ -736,8 +736,8 @@ func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
 	if !ok {
 		t.Fatalf("resource.Constants['TableNumber'] was not found")
 	}
-	if favouriteTable.FieldType != models.StringConstant {
-		t.Fatalf("expected resource.Constants['TableNumber'].FieldType to be 'String' but got %q", favouriteTable.FieldType)
+	if favouriteTable.FieldType != models.FloatConstant {
+		t.Fatalf("expected resource.Constants['TableNumber'].FieldType to be 'Float' but got %q", favouriteTable.FieldType)
 	}
 	if len(favouriteTable.Values) != 3 {
 		t.Fatalf("expected resource.Constants['TableNumber'] to have 3 values but got %d", len(favouriteTable.Values))
@@ -860,7 +860,7 @@ func TestParseConstantsFloatsInlinedAsFloats(t *testing.T) {
 }
 
 func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
-	// Enums can either be modelled as strings or not.. this is an Float that's output as a String.
+	// Tests an Float Constant defined inline with modelAsString, which is bad data / should be ignored
 	result, err := ParseSwaggerFileForTesting(t, "constants_floats_as_strings_inlined.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
@@ -924,8 +924,8 @@ func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
 	if !ok {
 		t.Fatalf("resource.Constants['TableNumber'] was not found")
 	}
-	if favouriteTable.FieldType != models.StringConstant {
-		t.Fatalf("expected resource.Constants['TableNumber'].FieldType to be 'String' but got %q", favouriteTable.FieldType)
+	if favouriteTable.FieldType != models.FloatConstant {
+		t.Fatalf("expected resource.Constants['TableNumber'].FieldType to be 'Float' but got %q", favouriteTable.FieldType)
 	}
 	if len(favouriteTable.Values) != 3 {
 		t.Fatalf("expected resource.Constants['TableNumber'] to have 3 values but got %d", len(favouriteTable.Values))


### PR DESCRIPTION
This is misleadingly named, and is instead used to define that the Constant should be output as an Extendable Type (e.g. a set of String values) rather than a set of Fixed Values (e.g. Constants/Enums) depending on the output language - however this limitation isn't needed in our setup.

Fixes #792