### PR TITLE
data: disabling the generation of Go SDKs for the existing services temporarily

### DIFF
--- a/data/Pandora.Definitions.HandDefined/AADB2C/ServiceDefinition.cs
+++ b/data/Pandora.Definitions.HandDefined/AADB2C/ServiceDefinition.cs
@@ -6,5 +6,5 @@ public class Service : ServiceDefinition
 {
     public string Name => "AADB2C";
     public string? ResourceProvider => "Microsoft.AzureActiveDirectory";
-    public bool Generate => true;
+    public bool Generate => false;
 }

--- a/data/Pandora.Definitions.ResourceManager/AlertsManagement/ServiceDefinition-GenerationSettings.cs
+++ b/data/Pandora.Definitions.ResourceManager/AlertsManagement/ServiceDefinition-GenerationSettings.cs
@@ -2,5 +2,5 @@ namespace Pandora.Definitions.ResourceManager.AlertsManagement;
 
 public partial class Service
 {
-    public bool Generate => true;
+    public bool Generate => false;
 }

--- a/data/Pandora.Definitions.ResourceManager/ContainerApps/ServiceDefinition-GenerationSettings.cs
+++ b/data/Pandora.Definitions.ResourceManager/ContainerApps/ServiceDefinition-GenerationSettings.cs
@@ -2,5 +2,5 @@ namespace Pandora.Definitions.ResourceManager.ContainerApps;
 
 public partial class Service
 {
-    public bool Generate => true;
+    public bool Generate => false;
 }

--- a/data/Pandora.Definitions.ResourceManager/IotCentral/ServiceDefinition-GenerationSettings.cs
+++ b/data/Pandora.Definitions.ResourceManager/IotCentral/ServiceDefinition-GenerationSettings.cs
@@ -2,5 +2,5 @@ namespace Pandora.Definitions.ResourceManager.IotCentral;
 
 public partial class Service
 {
-    public bool Generate => true;
+    public bool Generate => false;
 }

--- a/data/Pandora.Definitions.ResourceManager/MixedReality/ServiceDefinition-GenerationSettings.cs
+++ b/data/Pandora.Definitions.ResourceManager/MixedReality/ServiceDefinition-GenerationSettings.cs
@@ -2,5 +2,5 @@ namespace Pandora.Definitions.ResourceManager.MixedReality;
 
 public partial class Service
 {
-    public bool Generate => true;
+    public bool Generate => false;
 }

--- a/data/Pandora.Definitions.ResourceManager/NotificationHubs/ServiceDefinition-GenerationSettings.cs
+++ b/data/Pandora.Definitions.ResourceManager/NotificationHubs/ServiceDefinition-GenerationSettings.cs
@@ -2,5 +2,5 @@ namespace Pandora.Definitions.ResourceManager.NotificationHubs;
 
 public partial class Service
 {
-    public bool Generate => true;
+    public bool Generate => false;
 }

--- a/data/Pandora.Definitions.ResourceManager/Portal/ServiceDefinition-GenerationSettings.cs
+++ b/data/Pandora.Definitions.ResourceManager/Portal/ServiceDefinition-GenerationSettings.cs
@@ -2,5 +2,5 @@ namespace Pandora.Definitions.ResourceManager.Portal;
 
 public partial class Service
 {
-    public bool Generate => true;
+    public bool Generate => false;
 }

--- a/data/Pandora.Definitions.ResourceManager/ServiceBus/ServiceDefinition-GenerationSettings.cs
+++ b/data/Pandora.Definitions.ResourceManager/ServiceBus/ServiceDefinition-GenerationSettings.cs
@@ -2,5 +2,5 @@ namespace Pandora.Definitions.ResourceManager.ServiceBus;
 
 public partial class Service
 {
-    public bool Generate => true;
+    public bool Generate => false;
 }

--- a/data/Pandora.Definitions.ResourceManager/ServiceLinker/ServiceDefinition-GenerationSettings.cs
+++ b/data/Pandora.Definitions.ResourceManager/ServiceLinker/ServiceDefinition-GenerationSettings.cs
@@ -2,5 +2,5 @@ namespace Pandora.Definitions.ResourceManager.ServiceLinker;
 
 public partial class Service
 {
-    public bool Generate => true;
+    public bool Generate => false;
 }


### PR DESCRIPTION
Recreating the Go SDK repository, so we may as well remove all existing content too and then onboard each service