### PR TITLE
importer: Discover swagger spec recursively

### DIFF
--- a/tools/importer-rest-api-specs/parser/discovery.go
+++ b/tools/importer-rest-api-specs/parser/discovery.go
@@ -109,7 +109,7 @@ func SwaggerFilesInDirectory(directory string) (*[]string, error) {
 			return err
 		}
 		name := filepath.Base(path)
-		if name == "examples" {
+		if strings.EqualsFold(name, "examples") {
 			return fs.SkipDir
 		}
 


### PR DESCRIPTION
Some RP (e.g. Compute since 2022-01-03) has nested folder to hold the swagger specs. Therefore, we should recursively walk the specification folder to collect them.

Fix #914 
Fix #858 