### PR TITLE
tools/generator-go-sdk: ensuring that types hidden within parent types are unmarshalled/assigned as required

### DIFF
--- a/tools/generator-go-sdk/generator/templater_models.go
+++ b/tools/generator-go-sdk/generator/templater_models.go
@@ -479,6 +479,32 @@ func (c modelsTemplater) codeForUnmarshalStructFunction(data ServiceGeneratorDat
 
 		fieldsRequiringAssignment = append(fieldsRequiringAssignment, fieldName)
 	}
+	if c.model.ParentTypeName != nil {
+		parent, ok := data.models[*c.model.ParentTypeName]
+		if !ok {
+			return nil, fmt.Errorf("Parent Model %q (for Model %q) was not found", *c.model.ParentTypeName, c.name)
+		}
+		for fieldName, fieldDetails := range parent.Fields {
+			// also double-check if the parent has any fields matching the same conditions
+			topLevelObject := topLevelObjectDefinition(fieldDetails.ObjectDefinition)
+			if topLevelObject.Type == resourcemanager.ReferenceApiObjectDefinitionType {
+				model, ok := data.models[*topLevelObject.ReferenceName]
+				if ok && model.TypeHintIn != nil {
+					fieldsRequiringUnmarshalling = append(fieldsRequiringUnmarshalling, fieldName)
+					continue
+				}
+			}
+
+			// however specifically for the parent we don't want to assign the `type` field since we don't output it
+			// so check the implementation model to determine which field the `type` is in, and assign if they
+			// don't match
+			//
+			// at this point since we know there's a parent-implementation relationship, there's no need to nil-check
+			if *c.model.TypeHintIn != fieldName {
+				fieldsRequiringAssignment = append(fieldsRequiringAssignment, fieldName)
+			}
+		}
+	}
 
 	// we only need a custom unmarshal function when there's something needing unmarshaling
 	// else the default unmarshaler will be fine
@@ -512,7 +538,20 @@ func (s *%[1]s) UnmarshalJSON(bytes []byte) error {`, c.name))
 
 		sort.Strings(fieldsRequiringUnmarshalling)
 		for _, fieldName := range fieldsRequiringUnmarshalling {
-			fieldDetails := c.model.Fields[fieldName]
+			fieldDetails, ok := c.model.Fields[fieldName]
+			if !ok {
+				if c.model.ParentTypeName == nil {
+					return nil, fmt.Errorf("field %q was not found on Model %q which has no Parent", fieldName, c.name)
+				}
+				parent, ok := data.models[*c.model.ParentTypeName]
+				if !ok {
+					return nil, fmt.Errorf("parent model %q was not found", *c.model.ParentTypeName)
+				}
+				fieldDetails, ok = parent.Fields[fieldName]
+				if !ok {
+					return nil, fmt.Errorf("field %q was not found on Model %q or Parent %q", fieldName, c.name, *c.model.ParentTypeName)
+				}
+			}
 			topLevelObjectDef := topLevelObjectDefinition(fieldDetails.ObjectDefinition)
 
 			supportedDiscriminatorWrappers := map[resourcemanager.ApiObjectDefinitionType]struct{}{

--- a/tools/generator-go-sdk/generator/templater_models_discriminators_test.go
+++ b/tools/generator-go-sdk/generator/templater_models_discriminators_test.go
@@ -236,3 +236,151 @@ func (s Train) MarshalJSON() ([]byte, error) {
 `, "''", "`")
 	assertTemplatedCodeMatches(t, expected, *actual)
 }
+
+func TestTemplaterModelsImplementationInheritedFromParentType(t *testing.T) {
+	actual, err := modelsTemplater{
+		name: "FirstImplementation",
+		model: resourcemanager.ModelDetails{
+			Fields: map[string]resourcemanager.FieldDetails{
+				"Serialization": {
+					Required: true,
+					JsonName: "serialization",
+					ObjectDefinition: resourcemanager.ApiObjectDefinition{
+						Type:          resourcemanager.ReferenceApiObjectDefinitionType,
+						ReferenceName: stringPointer("Serialization"),
+					},
+				},
+			},
+			ParentTypeName: stringPointer("First"),
+			TypeHintIn:     stringPointer("Type"),
+			TypeHintValue:  stringPointer("first"),
+		},
+	}.template(ServiceGeneratorData{
+		packageName: "somepackage",
+		models: map[string]resourcemanager.ModelDetails{
+			"First": {
+				Fields: map[string]resourcemanager.FieldDetails{
+					"Type": {
+						Required: true,
+						JsonName: "type",
+						ObjectDefinition: resourcemanager.ApiObjectDefinition{
+							Type: resourcemanager.StringApiObjectDefinitionType,
+						},
+					},
+				},
+			},
+			"FirstImplementation": {
+				Fields: map[string]resourcemanager.FieldDetails{
+					"Serialization": {
+						Required: true,
+						JsonName: "serialization",
+						ObjectDefinition: resourcemanager.ApiObjectDefinition{
+							Type:          resourcemanager.ReferenceApiObjectDefinitionType,
+							ReferenceName: stringPointer("Serialization"),
+						},
+					},
+				},
+				ParentTypeName: stringPointer("First"),
+				TypeHintIn:     stringPointer("Type"),
+				TypeHintValue:  stringPointer("first"),
+			},
+			"Serialization": {
+				Fields: map[string]resourcemanager.FieldDetails{
+					"Type": {
+						Required: true,
+						JsonName: "type",
+						ObjectDefinition: resourcemanager.ApiObjectDefinition{
+							Type: resourcemanager.StringApiObjectDefinitionType,
+						},
+					},
+				},
+				TypeHintIn: stringPointer("Type"),
+			},
+			"JsonSerialization": {
+				Fields: map[string]resourcemanager.FieldDetails{
+					"Example": {
+						Required: true,
+						JsonName: "example",
+						ObjectDefinition: resourcemanager.ApiObjectDefinition{
+							Type: resourcemanager.StringApiObjectDefinitionType,
+						},
+					},
+				},
+				ParentTypeName: stringPointer("Serialization"),
+				TypeHintIn:     stringPointer("Type"),
+				TypeHintValue:  stringPointer("json"),
+			},
+		},
+		source: AccTestLicenceType,
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	expected := strings.ReplaceAll(`package somepackage
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// acctests licence placeholder
+
+var _ First = FirstImplementation{}
+
+type FirstImplementation struct {
+	Serialization Serialization ''json:"serialization"''
+
+	// Fields inherited from First
+}
+
+var _ json.Marshaler = FirstImplementation{}
+
+func (s FirstImplementation) MarshalJSON() ([]byte, error) {
+	type wrapper FirstImplementation
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling FirstImplementation: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling FirstImplementation: %+v", err)
+	}
+	decoded["type"] = "first"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling FirstImplementation: %+v", err)
+	}
+
+	return encoded, nil
+}
+
+var _ json.Unmarshaler = &FirstImplementation{}
+
+func (s *FirstImplementation) UnmarshalJSON(bytes []byte) error {
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling FirstImplementation into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["serialization"]; ok {
+		impl, err := unmarshalSerializationImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'Serialization' for 'FirstImplementation': %+v", err)
+		}
+		s.Serialization = impl
+	}
+
+	return nil
+}
+`, "''", "`")
+	assertTemplatedCodeMatches(t, expected, *actual)
+}


### PR DESCRIPTION
This commit fixes an issue where fields within a Parent Type wouldn't be either Assigned or Unmarshalled into the correct Implementation - by checking for fields within the Parents as required.

Fixes #884