### PR TITLE
tools/importer-rest-api-specs: handling the UAI models having extra fields

### DIFF
--- a/tools/importer-rest-api-specs/parser/custom_field_identity_legacy_system_and_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/parser/custom_field_identity_legacy_system_and_user_assigned_map.go
@@ -83,8 +83,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) isMatch(field models.FieldD
 					continue
 				}
 
-				// if extra fields this can't be a match
-				return false
+				// if extra fields are returned within the UAI properties block then we ignore them for now
 			}
 
 			hasUserAssignedIdentities = innerHasClientId && innerHasPrincipalId

--- a/tools/importer-rest-api-specs/parser/custom_field_identity_system_and_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/parser/custom_field_identity_system_and_user_assigned_map.go
@@ -83,8 +83,7 @@ func (systemAndUserAssignedIdentityMapMatcher) isMatch(field models.FieldDetails
 					continue
 				}
 
-				// if extra fields this can't be a match
-				return false
+				// if extra fields are returned within the UAI properties block then we ignore them for now
 			}
 
 			hasUserAssignedIdentities = innerHasClientId && innerHasPrincipalId

--- a/tools/importer-rest-api-specs/parser/custom_field_identity_system_or_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/parser/custom_field_identity_system_or_user_assigned_map.go
@@ -83,8 +83,7 @@ func (systemOrUserAssignedIdentityMapMatcher) isMatch(_ models.FieldDetails, def
 					continue
 				}
 
-				// if extra fields this can't be a match
-				return false
+				// if extra fields are returned within the UAI properties block then we ignore them for now
 			}
 
 			hasUserAssignedIdentities = innerHasClientId && innerHasPrincipalId

--- a/tools/importer-rest-api-specs/parser/models_identity_test.go
+++ b/tools/importer-rest-api-specs/parser/models_identity_test.go
@@ -473,6 +473,196 @@ func TestModelsWithALegacySystemAndUserAssignedMapIdentity(t *testing.T) {
 	}
 }
 
+func TestModelsWithALegacySystemAndUserAssignedMapIdentityExtraFields(t *testing.T) {
+	// this handles the scenario of a System Assigned & User Assigned model having extra fields
+	// in the user assigned identity block (#1066) - for example an extra `appId`
+	result, err := ParseSwaggerFileForTesting(t, "model_legacy_system_and_user_assigned_map_extrafields.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "Example" {
+		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	exampleModel, ok := hello.Models["Example"]
+	if !ok {
+		t.Fatalf("expected there to be a model called Example")
+	}
+	if len(exampleModel.Fields) != 2 {
+		t.Fatalf("expected the model Example to have 2 field but got %d", len(exampleModel.Fields))
+	}
+	if _, ok := exampleModel.Fields["Name"]; !ok {
+		t.Fatalf("expected there to be a field called Name")
+	}
+	identityField, ok := exampleModel.Fields["Identity"]
+	if !ok {
+		t.Fatalf("expected there to be a field called Identity")
+	}
+	if identityField.CustomFieldType == nil {
+		t.Fatalf("expected the field Identity to have a CustomFieldType")
+	}
+	if *identityField.CustomFieldType != models.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap {
+		t.Fatalf("expected the field Identity to have a CustomFieldType of CustomFieldTypeLegacySystemAndUserAssignedIdentityMap")
+	}
+	if identityField.ObjectDefinition != nil {
+		t.Fatalf("expected the field Identity to have no ObjectDefinition")
+	}
+}
+
+func TestModelsWithALegacySystemAndUserAssignedMapIdentityExtraFieldsInlined(t *testing.T) {
+	// this handles the scenario of a System Assigned & User Assigned model having extra fields
+	// in the user assigned identity block (#1066) - for example an extra `appId`
+	result, err := ParseSwaggerFileForTesting(t, "model_legacy_system_and_user_assigned_map_extrafields_inlined.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "Example" {
+		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	exampleModel, ok := hello.Models["Example"]
+	if !ok {
+		t.Fatalf("expected there to be a model called Example")
+	}
+	if len(exampleModel.Fields) != 2 {
+		t.Fatalf("expected the model Example to have 2 field but got %d", len(exampleModel.Fields))
+	}
+	if _, ok := exampleModel.Fields["Name"]; !ok {
+		t.Fatalf("expected there to be a field called Name")
+	}
+	identityField, ok := exampleModel.Fields["Identity"]
+	if !ok {
+		t.Fatalf("expected there to be a field called Identity")
+	}
+	if identityField.CustomFieldType == nil {
+		t.Fatalf("expected the field Identity to have a CustomFieldType")
+	}
+	if *identityField.CustomFieldType != models.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap {
+		t.Fatalf("expected the field Identity to have a CustomFieldType of CustomFieldTypeLegacySystemAndUserAssignedIdentityMap")
+	}
+	if identityField.ObjectDefinition != nil {
+		t.Fatalf("expected the field Identity to have no ObjectDefinition")
+	}
+}
+
 func TestModelsWithALegacySystemAndUserAssignedMapIdentityInlined(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "model_legacy_system_and_user_assigned_map_inlined.json")
 	if err != nil {
@@ -845,6 +1035,196 @@ func TestModelsWithASystemAndUserAssignedMapIdentity(t *testing.T) {
 	}
 }
 
+func TestModelsWithASystemAndUserAssignedMapIdentityExtraFields(t *testing.T) {
+	// this handles the scenario of a System Assigned & User Assigned model having extra fields
+	// in the user assigned identity block (#1066) - for example an extra `appId`
+	result, err := ParseSwaggerFileForTesting(t, "model_system_and_user_assigned_map_extrafields.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "Example" {
+		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	exampleModel, ok := hello.Models["Example"]
+	if !ok {
+		t.Fatalf("expected there to be a model called Example")
+	}
+	if len(exampleModel.Fields) != 2 {
+		t.Fatalf("expected the model Example to have 2 field but got %d", len(exampleModel.Fields))
+	}
+	if _, ok := exampleModel.Fields["Name"]; !ok {
+		t.Fatalf("expected there to be a field called Name")
+	}
+	identityField, ok := exampleModel.Fields["Identity"]
+	if !ok {
+		t.Fatalf("expected there to be a field called Identity")
+	}
+	if identityField.CustomFieldType == nil {
+		t.Fatalf("expected the field Identity to have a CustomFieldType")
+	}
+	if *identityField.CustomFieldType != models.CustomFieldTypeSystemAndUserAssignedIdentityMap {
+		t.Fatalf("expected the field Identity to have a CustomFieldType of CustomFieldTypeSystemAndUserAssignedIdentityMap")
+	}
+	if identityField.ObjectDefinition != nil {
+		t.Fatalf("expected the field Identity to have no ObjectDefinition")
+	}
+}
+
+func TestModelsWithASystemAndUserAssignedMapIdentityExtraFieldsInlined(t *testing.T) {
+	// this handles the scenario of a System Assigned & User Assigned model having extra fields
+	// in the user assigned identity block (#1066) - for example an extra `appId`
+	result, err := ParseSwaggerFileForTesting(t, "model_system_and_user_assigned_map_extrafields_inlined.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "Example" {
+		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	exampleModel, ok := hello.Models["Example"]
+	if !ok {
+		t.Fatalf("expected there to be a model called Example")
+	}
+	if len(exampleModel.Fields) != 2 {
+		t.Fatalf("expected the model Example to have 2 field but got %d", len(exampleModel.Fields))
+	}
+	if _, ok := exampleModel.Fields["Name"]; !ok {
+		t.Fatalf("expected there to be a field called Name")
+	}
+	identityField, ok := exampleModel.Fields["Identity"]
+	if !ok {
+		t.Fatalf("expected there to be a field called Identity")
+	}
+	if identityField.CustomFieldType == nil {
+		t.Fatalf("expected the field Identity to have a CustomFieldType")
+	}
+	if *identityField.CustomFieldType != models.CustomFieldTypeSystemAndUserAssignedIdentityMap {
+		t.Fatalf("expected the field Identity to have a CustomFieldType of CustomFieldTypeSystemAndUserAssignedIdentityMap")
+	}
+	if identityField.ObjectDefinition != nil {
+		t.Fatalf("expected the field Identity to have no ObjectDefinition")
+	}
+}
+
 func TestModelsWithASystemAndUserAssignedMapIdentityInlined(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "model_system_and_user_assigned_map_inlined.json")
 	if err != nil {
@@ -1211,6 +1591,196 @@ func TestModelsWithASystemOrUserAssignedMapIdentity(t *testing.T) {
 	}
 	if *identityField.CustomFieldType != models.CustomFieldTypeSystemOrUserAssignedIdentityMap {
 		t.Fatalf("expected the field Identity to have a CustomFieldType of SystemOrUserAssignedIdentityMap")
+	}
+	if identityField.ObjectDefinition != nil {
+		t.Fatalf("expected the field Identity to have no ObjectDefinition")
+	}
+}
+
+func TestModelsWithASystemOrUserAssignedMapIdentityExtraFields(t *testing.T) {
+	// this handles the scenario of a System Assigned & User Assigned model having extra fields
+	// in the user assigned identity block (#1066) - for example an extra `appId`
+	result, err := ParseSwaggerFileForTesting(t, "model_system_or_user_assigned_map_extrafields.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "Example" {
+		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	exampleModel, ok := hello.Models["Example"]
+	if !ok {
+		t.Fatalf("expected there to be a model called Example")
+	}
+	if len(exampleModel.Fields) != 2 {
+		t.Fatalf("expected the model Example to have 2 field but got %d", len(exampleModel.Fields))
+	}
+	if _, ok := exampleModel.Fields["Name"]; !ok {
+		t.Fatalf("expected there to be a field called Name")
+	}
+	identityField, ok := exampleModel.Fields["Identity"]
+	if !ok {
+		t.Fatalf("expected there to be a field called Identity")
+	}
+	if identityField.CustomFieldType == nil {
+		t.Fatalf("expected the field Identity to have a CustomFieldType")
+	}
+	if *identityField.CustomFieldType != models.CustomFieldTypeSystemOrUserAssignedIdentityMap {
+		t.Fatalf("expected the field Identity to have a CustomFieldType of CustomFieldTypeSystemOrUserAssignedIdentityMap")
+	}
+	if identityField.ObjectDefinition != nil {
+		t.Fatalf("expected the field Identity to have no ObjectDefinition")
+	}
+}
+
+func TestModelsWithASystemOrUserAssignedMapIdentityExtraFieldsInlined(t *testing.T) {
+	// this handles the scenario of a System Assigned & User Assigned model having extra fields
+	// in the user assigned identity block (#1066) - for example an extra `appId`
+	result, err := ParseSwaggerFileForTesting(t, "model_system_or_user_assigned_map_extrafields_inlined.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "Example" {
+		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	exampleModel, ok := hello.Models["Example"]
+	if !ok {
+		t.Fatalf("expected there to be a model called Example")
+	}
+	if len(exampleModel.Fields) != 2 {
+		t.Fatalf("expected the model Example to have 2 field but got %d", len(exampleModel.Fields))
+	}
+	if _, ok := exampleModel.Fields["Name"]; !ok {
+		t.Fatalf("expected there to be a field called Name")
+	}
+	identityField, ok := exampleModel.Fields["Identity"]
+	if !ok {
+		t.Fatalf("expected there to be a field called Identity")
+	}
+	if identityField.CustomFieldType == nil {
+		t.Fatalf("expected the field Identity to have a CustomFieldType")
+	}
+	if *identityField.CustomFieldType != models.CustomFieldTypeSystemOrUserAssignedIdentityMap {
+		t.Fatalf("expected the field Identity to have a CustomFieldType of CustomFieldTypeSystemOrUserAssignedIdentityMap")
 	}
 	if identityField.ObjectDefinition != nil {
 		t.Fatalf("expected the field Identity to have no ObjectDefinition")

--- a/tools/importer-rest-api-specs/parser/testdata/model_legacy_system_and_user_assigned_map_extrafields.json
+++ b/tools/importer-rest-api-specs/parser/testdata/model_legacy_system_and_user_assigned_map_extrafields.json
@@ -1,0 +1,107 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identity": {
+          "$ref": "#/definitions/SystemAssignedUserAssignedIdentity"
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    },
+    "SystemAssignedUserAssignedIdentity": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned",
+            "SystemAssigned,UserAssigned"
+          ],
+          "x-ms-enum": {
+            "name": "IdentityType1",
+            "modelAsString": true
+          }
+        },
+        "principalId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "userAssignedIdentities": {
+          "description": "dictionary containing all the user assigned identities, with resourceId of the UAI as key.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        }
+      }
+    },
+    "UserAssignedIdentity": {
+      "description": "User Assigned Identity",
+      "properties": {
+        "principalId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The principal ID of the user assigned identity."
+        },
+        "tenantId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The tenant ID of the user assigned identity."
+        },
+        "clientId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The clientId(aka appId) of the user assigned identity."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/parser/testdata/model_legacy_system_and_user_assigned_map_extrafields_inlined.json
+++ b/tools/importer-rest-api-specs/parser/testdata/model_legacy_system_and_user_assigned_map_extrafields_inlined.json
@@ -1,0 +1,100 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identity": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "None",
+                "SystemAssigned",
+                "UserAssigned",
+                "SystemAssigned,UserAssigned"
+              ],
+              "x-ms-enum": {
+                "name": "IdentityType1",
+                "modelAsString": true
+              }
+            },
+            "principalId": {
+              "type": "string",
+              "readOnly": true
+            },
+            "tenantId": {
+              "type": "string",
+              "readOnly": true
+            },
+            "userAssignedIdentities": {
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "principalId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The principal ID of the user assigned identity."
+                  },
+                  "tenantId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The tenant ID of the user assigned identity."
+                  },
+                  "clientId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The clientId(aka appId) of the user assigned identity."
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    }
+  },
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/parser/testdata/model_system_and_user_assigned_map_extrafields.json
+++ b/tools/importer-rest-api-specs/parser/testdata/model_system_and_user_assigned_map_extrafields.json
@@ -1,0 +1,107 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identity": {
+          "$ref": "#/definitions/SystemAssignedUserAssignedIdentity"
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    },
+    "SystemAssignedUserAssignedIdentity": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned",
+            "SystemAssigned, UserAssigned"
+          ],
+          "x-ms-enum": {
+            "name": "IdentityType1",
+            "modelAsString": true
+          }
+        },
+        "principalId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "userAssignedIdentities": {
+          "description": "dictionary containing all the user assigned identities, with resourceId of the UAI as key.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        }
+      }
+    },
+    "UserAssignedIdentity": {
+      "description": "User Assigned Identity",
+      "properties": {
+        "principalId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The principal ID of the user assigned identity."
+        },
+        "tenantId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The tenant ID of the user assigned identity."
+        },
+        "clientId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The clientId(aka appId) of the user assigned identity."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/parser/testdata/model_system_and_user_assigned_map_extrafields_inlined.json
+++ b/tools/importer-rest-api-specs/parser/testdata/model_system_and_user_assigned_map_extrafields_inlined.json
@@ -1,0 +1,100 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identity": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "None",
+                "SystemAssigned",
+                "UserAssigned",
+                "SystemAssigned, UserAssigned"
+              ],
+              "x-ms-enum": {
+                "name": "IdentityType1",
+                "modelAsString": true
+              }
+            },
+            "principalId": {
+              "type": "string",
+              "readOnly": true
+            },
+            "tenantId": {
+              "type": "string",
+              "readOnly": true
+            },
+            "userAssignedIdentities": {
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "principalId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The principal ID of the user assigned identity."
+                  },
+                  "tenantId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The tenant ID of the user assigned identity."
+                  },
+                  "clientId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The clientId(aka appId) of the user assigned identity."
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    }
+  },
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/parser/testdata/model_system_or_user_assigned_map_extrafields.json
+++ b/tools/importer-rest-api-specs/parser/testdata/model_system_or_user_assigned_map_extrafields.json
@@ -1,0 +1,106 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identity": {
+          "$ref": "#/definitions/SystemAssignedUserAssignedIdentity"
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    },
+    "SystemAssignedUserAssignedIdentity": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned"
+          ],
+          "x-ms-enum": {
+            "name": "IdentityType1",
+            "modelAsString": true
+          }
+        },
+        "principalId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "userAssignedIdentities": {
+          "description": "dictionary containing all the user assigned identities, with resourceId of the UAI as key.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        }
+      }
+    },
+    "UserAssignedIdentity": {
+      "description": "User Assigned Identity",
+      "properties": {
+        "principalId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The principal ID of the user assigned identity."
+        },
+        "tenantId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The tenant ID of the user assigned identity."
+        },
+        "clientId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The clientId(aka appId) of the user assigned identity."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/parser/testdata/model_system_or_user_assigned_map_extrafields_inlined.json
+++ b/tools/importer-rest-api-specs/parser/testdata/model_system_or_user_assigned_map_extrafields_inlined.json
@@ -1,0 +1,99 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identity": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "None",
+                "SystemAssigned",
+                "UserAssigned"
+              ],
+              "x-ms-enum": {
+                "name": "IdentityType1",
+                "modelAsString": true
+              }
+            },
+            "principalId": {
+              "type": "string",
+              "readOnly": true
+            },
+            "tenantId": {
+              "type": "string",
+              "readOnly": true
+            },
+            "userAssignedIdentities": {
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "principalId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The principal ID of the user assigned identity."
+                  },
+                  "tenantId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The tenant ID of the user assigned identity."
+                  },
+                  "clientId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "The clientId(aka appId) of the user assigned identity."
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
Whilst these values maybe useful in the future, at this point in time we're not outputting them as such it's more valuable to have these converted into the common models than outputting a new identity type for each package.

Fixes #1066