### PR TITLE
tools/importer-rest-api-specs: services failing should now raise an error

### DIFF
--- a/tools/importer-rest-api-specs/main.go
+++ b/tools/importer-rest-api-specs/main.go
@@ -78,6 +78,7 @@ func runImporter(configFilePath string, dataApiEndpoint *string, debug bool) err
 			if err := importService(v, *swaggerGitSha, dataApiEndpoint, debug); err != nil {
 				log.Printf("importing Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err)
 				wg.Done()
+				os.Exit(1)
 				return
 			}
 


### PR DESCRIPTION
During development it was useful to allow skipping failed services and importing the lot but this is no longer necessary and masks data errors.

Should fix why #1072 / #1074 weren't caught by returning an exit code.