### PR TITLE
config: adding `compute` @ `2021-11-01` and `2021-08-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -47,6 +47,10 @@ service "communication" {
   name      = "Communication"
   available = ["2020-08-20"]
 }
+service "compute" {
+  name = "Compute"
+  available = ["2021-08-01", "2021-11-01"]
+}
 service "confidentialledger" {
   name      = "ConfidentialLedger"
   available = ["2022-05-13"]


### PR DESCRIPTION
This intentionally includes 2 different versions due to this being a composite tag: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/compute/resource-manager#tag-package-2021-11-01

Whilst we _may_ need to include more in the future (and disable the output of the Resources within the older API Version), this is fine for now.