### PR TITLE
tools/generator-go-sdk: outputting a Meta Client for each API Version

### DIFF
--- a/tools/generator-go-sdk/generator/data.go
+++ b/tools/generator-go-sdk/generator/data.go
@@ -21,7 +21,7 @@ type ServiceGeneratorData struct {
 
 	// This is the working directory where files should be output for this specific service
 	// for example {workingDir}/service/version/resource
-	outputPath string
+	resourceOutputPath string
 
 	// constants is a map of key (constant name) to value (ConstantDetails) describing
 	// the constants and their values used in this Resource
@@ -58,8 +58,9 @@ func (i ServiceGeneratorInput) generatorData() ServiceGeneratorData {
 	versionPackageName := strings.ToLower(i.VersionName)
 	// TODO: it'd be nice to make these snake_case but that's a problem for another day
 	resourcePackageName := strings.ToLower(i.ResourceName)
-	outputPath := filepath.Join(i.OutputDirectory, servicePackageName, versionPackageName, resourcePackageName)
-	idsPath := filepath.Join(i.OutputDirectory, servicePackageName, versionPackageName, "ids")
+	versionOutputPath := filepath.Join(i.OutputDirectory, servicePackageName, versionPackageName)
+	resourceOutputPath := filepath.Join(versionOutputPath, resourcePackageName)
+	idsPath := filepath.Join(versionOutputPath, "ids")
 
 	return ServiceGeneratorData{
 		apiVersion:         i.VersionName,
@@ -67,7 +68,7 @@ func (i ServiceGeneratorInput) generatorData() ServiceGeneratorData {
 		idsOutputPath:      idsPath,
 		models:             i.ResourceDetails.Schema.Models,
 		operations:         i.ResourceDetails.Operations.Operations,
-		outputPath:         outputPath,
+		resourceOutputPath: resourceOutputPath,
 		packageName:        resourcePackageName,
 		resourceIds:        i.ResourceDetails.Schema.ResourceIds,
 		serviceClientName:  fmt.Sprintf("%sClient", strings.Title(i.ResourceName)),

--- a/tools/generator-go-sdk/generator/meta_client.go
+++ b/tools/generator-go-sdk/generator/meta_client.go
@@ -1,0 +1,23 @@
+package generator
+
+import (
+	"fmt"
+)
+
+func (s *ServiceGenerator) metaClient(data VersionInput, versionDirectory string) error {
+	if len(data.Resources) == 0 {
+		return nil
+	}
+
+	templater := metaClientTemplater{
+		serviceName: data.ServiceName,
+		apiVersion:  data.VersionName,
+		resources:   data.Resources,
+		source:      data.Source,
+	}
+	if err := s.writeToPathForVersion(versionDirectory, "client.go", templater); err != nil {
+		return fmt.Errorf("templating meta client for API Version %q / Service %q: %+v", data.VersionName, data.ServiceName, err)
+	}
+
+	return nil
+}

--- a/tools/generator-go-sdk/generator/service.go
+++ b/tools/generator-go-sdk/generator/service.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 
@@ -35,8 +37,8 @@ type ServiceGeneratorInput struct {
 func (s *ServiceGenerator) Generate(input ServiceGeneratorInput) error {
 	data := input.generatorData()
 
-	if err := cleanAndRecreateWorkingDirectory(data.outputPath); err != nil {
-		return fmt.Errorf("cleaning/recreating working directory %q: %+v", data.outputPath, err)
+	if err := cleanAndRecreateWorkingDirectory(data.resourceOutputPath); err != nil {
+		return fmt.Errorf("cleaning/recreating working directory %q: %+v", data.resourceOutputPath, err)
 	}
 	if data.useIdAliases {
 		if err := ensureWorkingDirectoryExists(data.idsOutputPath); err != nil {
@@ -61,9 +63,37 @@ func (s *ServiceGenerator) Generate(input ServiceGeneratorInput) error {
 		}
 	}
 
-	runGoFmt(data.outputPath)
-	runGoImports(data.outputPath)
+	runGoFmt(data.resourceOutputPath)
+	runGoImports(data.resourceOutputPath)
 
+	return nil
+}
+
+type VersionInput struct {
+	OutputDirectory string
+	Resources       map[string]services.Resource
+	ServiceName     string
+	Source          resourcemanager.ApiDefinitionsSource
+	VersionName     string
+}
+
+func (s *ServiceGenerator) GenerateForVersion(data VersionInput) error {
+	data.ServiceName = strings.ToLower(data.ServiceName)
+	data.VersionName = strings.ToLower(data.VersionName)
+	versionDirectory := filepath.Join(data.OutputDirectory, data.ServiceName, data.VersionName)
+
+	stages := map[string]func(data VersionInput, versionDirectory string) error{
+		"metaClient": s.metaClient,
+	}
+	for name, stage := range stages {
+		log.Printf("[DEBUG] Running Stage %q..", name)
+		if err := stage(data, versionDirectory); err != nil {
+			return fmt.Errorf("generating %s: %+v", name, err)
+		}
+	}
+
+	runGoFmt(versionDirectory)
+	runGoImports(versionDirectory)
 	return nil
 }
 

--- a/tools/generator-go-sdk/generator/stage_clients_autorest.go
+++ b/tools/generator-go-sdk/generator/stage_clients_autorest.go
@@ -3,7 +3,7 @@ package generator
 import "fmt"
 
 func (s *ServiceGenerator) clients(data ServiceGeneratorData) error {
-	if err := s.writeToPath(data.outputPath, "client.go", clientsAutoRestTemplater{}, data); err != nil {
+	if err := s.writeToPathForResource(data.resourceOutputPath, "client.go", clientsAutoRestTemplater{}, data); err != nil {
 		return fmt.Errorf("templating client: %+v", err)
 	}
 

--- a/tools/generator-go-sdk/generator/stage_constants.go
+++ b/tools/generator-go-sdk/generator/stage_constants.go
@@ -12,7 +12,7 @@ func (s *ServiceGenerator) constants(data ServiceGeneratorData) error {
 	t := constantsTemplater{
 		constantTemplateFunc: templateForConstant,
 	}
-	if err := s.writeToPath(data.outputPath, "constants.go", t, data); err != nil {
+	if err := s.writeToPathForResource(data.resourceOutputPath, "constants.go", t, data); err != nil {
 		return fmt.Errorf("templating constants: %+v", err)
 	}
 

--- a/tools/generator-go-sdk/generator/stage_ids.go
+++ b/tools/generator-go-sdk/generator/stage_ids.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *ServiceGenerator) ids(data ServiceGeneratorData) error {
-	outputDirectory := data.outputPath
+	outputDirectory := data.resourceOutputPath
 
 	for idName, resourceData := range data.resourceIds {
 		if resourceData.CommonAlias != nil || len(resourceData.Segments) == 0 {
@@ -20,7 +20,7 @@ func (s *ServiceGenerator) ids(data ServiceGeneratorData) error {
 			resource:        resourceData,
 			constantDetails: data.constants,
 		}
-		if err := s.writeToPath(outputDirectory, fmt.Sprintf("id_%s.go", fileNamePrefix), pt, data); err != nil {
+		if err := s.writeToPathForResource(outputDirectory, fmt.Sprintf("id_%s.go", fileNamePrefix), pt, data); err != nil {
 			return fmt.Errorf("templating ids: %+v", err)
 		}
 
@@ -29,7 +29,7 @@ func (s *ServiceGenerator) ids(data ServiceGeneratorData) error {
 			resourceData:    resourceData,
 			constantDetails: data.constants,
 		}
-		if err := s.writeToPath(outputDirectory, fmt.Sprintf("id_%s_test.go", fileNamePrefix), tpt, data); err != nil {
+		if err := s.writeToPathForResource(outputDirectory, fmt.Sprintf("id_%s_test.go", fileNamePrefix), tpt, data); err != nil {
 			return fmt.Errorf("templating tests for id: %+v", err)
 		}
 	}

--- a/tools/generator-go-sdk/generator/stage_methods.go
+++ b/tools/generator-go-sdk/generator/stage_methods.go
@@ -17,7 +17,7 @@ func (s *ServiceGenerator) methods(data ServiceGeneratorData) error {
 			operation:     operation,
 			constants:     data.constants,
 		}
-		if err := s.writeToPath(data.outputPath, fileName, gen, data); err != nil {
+		if err := s.writeToPathForResource(data.resourceOutputPath, fileName, gen, data); err != nil {
 			return fmt.Errorf("templating methods (using autorest): %+v", err)
 		}
 	}

--- a/tools/generator-go-sdk/generator/stage_models.go
+++ b/tools/generator-go-sdk/generator/stage_models.go
@@ -18,7 +18,7 @@ func (s *ServiceGenerator) models(data ServiceGeneratorData) error {
 			name:  modelName,
 			model: model,
 		}
-		if err := s.writeToPath(data.outputPath, fileName, gen, data); err != nil {
+		if err := s.writeToPathForResource(data.resourceOutputPath, fileName, gen, data); err != nil {
 			return fmt.Errorf("templating model for %q: %+v", modelName, err)
 		}
 	}

--- a/tools/generator-go-sdk/generator/stage_predicates.go
+++ b/tools/generator-go-sdk/generator/stage_predicates.go
@@ -37,7 +37,7 @@ func (s *ServiceGenerator) predicates(data ServiceGeneratorData) error {
 		sortedModelNames: sortedModelNames,
 		models:           data.models,
 	}
-	if err := s.writeToPath(data.outputPath, "predicates.go", templater, data); err != nil {
+	if err := s.writeToPathForResource(data.resourceOutputPath, "predicates.go", templater, data); err != nil {
 		return fmt.Errorf("templating predicate models: %+v", err)
 	}
 

--- a/tools/generator-go-sdk/generator/stage_readme.go
+++ b/tools/generator-go-sdk/generator/stage_readme.go
@@ -20,7 +20,7 @@ func (s *ServiceGenerator) readmeFile(data ServiceGeneratorData) error {
 		sortedOperationNames: sortedOperationNames,
 		operations:           data.operations,
 	}
-	if err := s.writeToPath(data.outputPath, "README.md", t, data); err != nil {
+	if err := s.writeToPathForResource(data.resourceOutputPath, "README.md", t, data); err != nil {
 		return fmt.Errorf("templating README file: %+v", err)
 	}
 

--- a/tools/generator-go-sdk/generator/stage_version.go
+++ b/tools/generator-go-sdk/generator/stage_version.go
@@ -3,7 +3,7 @@ package generator
 import "fmt"
 
 func (s *ServiceGenerator) version(data ServiceGeneratorData) error {
-	if err := s.writeToPath(data.outputPath, "version.go", versionTemplater{}, data); err != nil {
+	if err := s.writeToPathForResource(data.resourceOutputPath, "version.go", versionTemplater{}, data); err != nil {
 		return fmt.Errorf("templating version: %+v", err)
 	}
 

--- a/tools/generator-go-sdk/generator/templater.go
+++ b/tools/generator-go-sdk/generator/templater.go
@@ -6,12 +6,36 @@ import (
 	"path/filepath"
 )
 
-type templater interface {
+type templaterForResource interface {
 	template(data ServiceGeneratorData) (*string, error)
 }
 
-func (s *ServiceGenerator) writeToPath(directory, filePath string, templater templater, data ServiceGeneratorData) error {
+type templaterForVersion interface {
+	template() (*string, error)
+}
+
+func (s *ServiceGenerator) writeToPathForResource(directory, filePath string, templater templaterForResource, data ServiceGeneratorData) error {
 	fileContents, err := templater.template(data)
+	if err != nil {
+		return fmt.Errorf("templating: %+v", err)
+	}
+
+	fullFilePath := filepath.Join(directory, filePath)
+
+	// remove any existing file if it exists
+	_ = os.Remove(fullFilePath)
+	file, err := os.Create(fullFilePath)
+	defer file.Close()
+	if err != nil {
+		return fmt.Errorf("opening %q: %+v", fullFilePath, err)
+	}
+
+	_, _ = file.WriteString(*fileContents)
+	return nil
+}
+
+func (s *ServiceGenerator) writeToPathForVersion(directory, filePath string, templater templaterForVersion) error {
+	fileContents, err := templater.template()
 	if err != nil {
 		return fmt.Errorf("templating: %+v", err)
 	}

--- a/tools/generator-go-sdk/generator/templater_clients_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_clients_autorest.go
@@ -2,7 +2,7 @@ package generator
 
 import "fmt"
 
-var _ templater = clientsAutoRestTemplater{}
+var _ templaterForResource = clientsAutoRestTemplater{}
 
 type clientsAutoRestTemplater struct {
 }

--- a/tools/generator-go-sdk/generator/templater_constants.go
+++ b/tools/generator-go-sdk/generator/templater_constants.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-var _ templater = constantsTemplater{}
+var _ templaterForResource = constantsTemplater{}
 
 type constantsTemplater struct {
 	constantTemplateFunc func(name string, details resourcemanager.ConstantDetails) (*string, error)

--- a/tools/generator-go-sdk/generator/templater_id_parser.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser.go
@@ -10,7 +10,7 @@ import (
 
 // TODO: add unit tests covering this
 
-var _ templater = resourceIdTemplater{}
+var _ templaterForResource = resourceIdTemplater{}
 
 type resourceIdTemplater struct {
 	name            string

--- a/tools/generator-go-sdk/generator/templater_id_parser_tests.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser_tests.go
@@ -10,7 +10,7 @@ import (
 
 // TODO: add unit tests covering this
 
-var _ templater = resourceIdTestsTemplater{}
+var _ templaterForResource = resourceIdTestsTemplater{}
 
 type resourceIdTestsTemplater struct {
 	resourceName    string

--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -1,0 +1,69 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/hashicorp/pandora/tools/sdk/services"
+)
+
+type metaClientTemplater struct {
+	serviceName string
+	apiVersion  string
+	resources   map[string]services.Resource
+	source      resourcemanager.ApiDefinitionsSource
+}
+
+func (m metaClientTemplater) template() (*string, error) {
+	resourceNames := make([]string, 0)
+	for k := range m.resources {
+		resourceNames = append(resourceNames, k)
+	}
+	sort.Strings(resourceNames)
+
+	imports := make([]string, 0)
+	clientInitialization := make([]string, 0)
+	fields := make([]string, 0)
+	assignments := make([]string, 0)
+	for _, resourceName := range resourceNames {
+		variableName := fmt.Sprintf("%s%sClient", strings.ToLower(string(resourceName[0])), resourceName[1:])
+
+		imports = append(imports, fmt.Sprintf(`"github.com/hashicorp/go-azure-sdk/resource-manager/%s/%s/%s"`, strings.ToLower(m.serviceName), m.apiVersion, strings.ToLower(resourceName)))
+		fields = append(fields, fmt.Sprintf("%[1]s *%[2]s.%[1]sClient", resourceName, strings.ToLower(resourceName)))
+		clientInitializationTemplate := fmt.Sprintf(`
+%[1]s := %[2]s.New%[3]sClientWithBaseURI(endpoint)
+configureAuthFunc(&%[1]s.Client)
+`, variableName, strings.ToLower(resourceName), resourceName)
+		clientInitialization = append(clientInitialization, clientInitializationTemplate)
+		assignments = append(assignments, fmt.Sprintf("%[1]s: &%[2]s,", resourceName, variableName))
+	}
+
+	sort.Strings(assignments)
+	sort.Strings(clientInitialization)
+	sort.Strings(fields)
+	sort.Strings(imports)
+
+	packageName := fmt.Sprintf("v%s", strings.ReplaceAll(m.apiVersion, "-", "_"))
+
+	out := fmt.Sprintf(`package %[1]s
+
+import (
+	%[2]s
+)
+
+type Client struct {
+	%[3]s
+}
+
+func NewClientWithBaseURI(endpoint string, configureAuthFunc func(c *autorest.Client)) Client {
+	%[4]s
+
+	return Client{
+		%[5]s
+	}
+}
+`, packageName, strings.Join(imports, "\n"), strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
+	return &out, nil
+}

--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -12,7 +12,7 @@ import (
 // TODO: implement predicates
 // TODO: add unit tests covering this
 
-var _ templater = methodsAutoRestTemplater{}
+var _ templaterForResource = methodsAutoRestTemplater{}
 
 type methodsAutoRestTemplater struct {
 	operation     resourcemanager.ApiOperation

--- a/tools/generator-go-sdk/generator/templater_models.go
+++ b/tools/generator-go-sdk/generator/templater_models.go
@@ -12,7 +12,7 @@ import (
 
 // TODO: add unit tests covering this
 
-var _ templater = modelsTemplater{}
+var _ templaterForResource = modelsTemplater{}
 
 type modelsTemplater struct {
 	name  string

--- a/tools/generator-go-sdk/generator/templater_version.go
+++ b/tools/generator-go-sdk/generator/templater_version.go
@@ -2,7 +2,7 @@ package generator
 
 import "fmt"
 
-var _ templater = versionTemplater{}
+var _ templaterForResource = versionTemplater{}
 
 type versionTemplater struct {
 }

--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -87,6 +87,20 @@ func run(input GeneratorInput) error {
 				}
 				log.Printf("[DEBUG] Generated Service %q / Version %q / Resource %q..", serviceName, versionNumber, resourceName)
 			}
+
+			// then output the Meta Client
+			generatorData := generator.VersionInput{
+				OutputDirectory: input.outputDirectory,
+				ServiceName:     serviceName,
+				VersionName:     versionNumber,
+				Resources:       versionDetails.Resources,
+				Source:          versionDetails.Details.Source,
+			}
+			log.Printf("[DEBUG] Generating Service %q / Version %q..", serviceName, versionNumber)
+			if err := generatorService.GenerateForVersion(generatorData); err != nil {
+				return fmt.Errorf("generating Service %q / Version %q: %+v", serviceName, versionNumber, err)
+			}
+			log.Printf("[DEBUG] Generated Service %q / Version %q..", serviceName, versionNumber)
 		}
 	}
 


### PR DESCRIPTION
This allows the Terraform Generator to depend on the existence of the Meta Client when generating Resources

Example output:

```go
package v2021_11_01

import (
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/availabilitysets"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/capacityreservation"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/capacityreservationgroups"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/capacityreservations"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/compute"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhost"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhosts"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/images"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/loganalytics"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/proximityplacementgroups"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/restorepointcollections"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/sshpublickeys"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachineextensionimages"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachineextensions"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachineimages"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachineruncommands"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachinescalesetextensions"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachinescalesetrollingupgrades"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachinescalesets"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachinescalesetvmextensions"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachinescalesetvmruncommands"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachinescalesetvms"
	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachinesizes"
)

type Client struct {
	AvailabilitySets                      *availabilitysets.AvailabilitySetsClient
	CapacityReservation                   *capacityreservation.CapacityReservationClient
	CapacityReservationGroups             *capacityreservationgroups.CapacityReservationGroupsClient
	CapacityReservations                  *capacityreservations.CapacityReservationsClient
	Compute                               *compute.ComputeClient
	DedicatedHost                         *dedicatedhost.DedicatedHostClient
	DedicatedHostGroups                   *dedicatedhostgroups.DedicatedHostGroupsClient
	DedicatedHosts                        *dedicatedhosts.DedicatedHostsClient
	Images                                *images.ImagesClient
	LogAnalytics                          *loganalytics.LogAnalyticsClient
	ProximityPlacementGroups              *proximityplacementgroups.ProximityPlacementGroupsClient
	RestorePointCollections               *restorepointcollections.RestorePointCollectionsClient
	SshPublicKeys                         *sshpublickeys.SshPublicKeysClient
	VirtualMachineExtensionImages         *virtualmachineextensionimages.VirtualMachineExtensionImagesClient
	VirtualMachineExtensions              *virtualmachineextensions.VirtualMachineExtensionsClient
	VirtualMachineImages                  *virtualmachineimages.VirtualMachineImagesClient
	VirtualMachineRunCommands             *virtualmachineruncommands.VirtualMachineRunCommandsClient
	VirtualMachineScaleSetExtensions      *virtualmachinescalesetextensions.VirtualMachineScaleSetExtensionsClient
	VirtualMachineScaleSetRollingUpgrades *virtualmachinescalesetrollingupgrades.VirtualMachineScaleSetRollingUpgradesClient
	VirtualMachineScaleSetVMExtensions    *virtualmachinescalesetvmextensions.VirtualMachineScaleSetVMExtensionsClient
	VirtualMachineScaleSetVMRunCommands   *virtualmachinescalesetvmruncommands.VirtualMachineScaleSetVMRunCommandsClient
	VirtualMachineScaleSetVMs             *virtualmachinescalesetvms.VirtualMachineScaleSetVMsClient
	VirtualMachineScaleSets               *virtualmachinescalesets.VirtualMachineScaleSetsClient
	VirtualMachineSizes                   *virtualmachinesizes.VirtualMachineSizesClient
	VirtualMachines                       *virtualmachines.VirtualMachinesClient
}

func NewClientWithBaseURI(endpoint string, configureAuthFunc func(c *autorest.Client)) Client {

	availabilitySetsClient := availabilitysets.NewAvailabilitySetsClientWithBaseURI(endpoint)
	configureAuthFunc(&availabilitySetsClient.Client)

	capacityReservationClient := capacityreservation.NewCapacityReservationClientWithBaseURI(endpoint)
	configureAuthFunc(&capacityReservationClient.Client)

	capacityReservationGroupsClient := capacityreservationgroups.NewCapacityReservationGroupsClientWithBaseURI(endpoint)
	configureAuthFunc(&capacityReservationGroupsClient.Client)

	capacityReservationsClient := capacityreservations.NewCapacityReservationsClientWithBaseURI(endpoint)
	configureAuthFunc(&capacityReservationsClient.Client)

	computeClient := compute.NewComputeClientWithBaseURI(endpoint)
	configureAuthFunc(&computeClient.Client)

	dedicatedHostClient := dedicatedhost.NewDedicatedHostClientWithBaseURI(endpoint)
	configureAuthFunc(&dedicatedHostClient.Client)

	dedicatedHostGroupsClient := dedicatedhostgroups.NewDedicatedHostGroupsClientWithBaseURI(endpoint)
	configureAuthFunc(&dedicatedHostGroupsClient.Client)

	dedicatedHostsClient := dedicatedhosts.NewDedicatedHostsClientWithBaseURI(endpoint)
	configureAuthFunc(&dedicatedHostsClient.Client)

	imagesClient := images.NewImagesClientWithBaseURI(endpoint)
	configureAuthFunc(&imagesClient.Client)

	logAnalyticsClient := loganalytics.NewLogAnalyticsClientWithBaseURI(endpoint)
	configureAuthFunc(&logAnalyticsClient.Client)

	proximityPlacementGroupsClient := proximityplacementgroups.NewProximityPlacementGroupsClientWithBaseURI(endpoint)
	configureAuthFunc(&proximityPlacementGroupsClient.Client)

	restorePointCollectionsClient := restorepointcollections.NewRestorePointCollectionsClientWithBaseURI(endpoint)
	configureAuthFunc(&restorePointCollectionsClient.Client)

	sshPublicKeysClient := sshpublickeys.NewSshPublicKeysClientWithBaseURI(endpoint)
	configureAuthFunc(&sshPublicKeysClient.Client)

	virtualMachineExtensionImagesClient := virtualmachineextensionimages.NewVirtualMachineExtensionImagesClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineExtensionImagesClient.Client)

	virtualMachineExtensionsClient := virtualmachineextensions.NewVirtualMachineExtensionsClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineExtensionsClient.Client)

	virtualMachineImagesClient := virtualmachineimages.NewVirtualMachineImagesClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineImagesClient.Client)

	virtualMachineRunCommandsClient := virtualmachineruncommands.NewVirtualMachineRunCommandsClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineRunCommandsClient.Client)

	virtualMachineScaleSetExtensionsClient := virtualmachinescalesetextensions.NewVirtualMachineScaleSetExtensionsClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineScaleSetExtensionsClient.Client)

	virtualMachineScaleSetRollingUpgradesClient := virtualmachinescalesetrollingupgrades.NewVirtualMachineScaleSetRollingUpgradesClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineScaleSetRollingUpgradesClient.Client)

	virtualMachineScaleSetVMExtensionsClient := virtualmachinescalesetvmextensions.NewVirtualMachineScaleSetVMExtensionsClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineScaleSetVMExtensionsClient.Client)

	virtualMachineScaleSetVMRunCommandsClient := virtualmachinescalesetvmruncommands.NewVirtualMachineScaleSetVMRunCommandsClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineScaleSetVMRunCommandsClient.Client)

	virtualMachineScaleSetVMsClient := virtualmachinescalesetvms.NewVirtualMachineScaleSetVMsClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineScaleSetVMsClient.Client)

	virtualMachineScaleSetsClient := virtualmachinescalesets.NewVirtualMachineScaleSetsClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineScaleSetsClient.Client)

	virtualMachineSizesClient := virtualmachinesizes.NewVirtualMachineSizesClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachineSizesClient.Client)

	virtualMachinesClient := virtualmachines.NewVirtualMachinesClientWithBaseURI(endpoint)
	configureAuthFunc(&virtualMachinesClient.Client)

	return Client{
		AvailabilitySets:                      &availabilitySetsClient,
		CapacityReservation:                   &capacityReservationClient,
		CapacityReservationGroups:             &capacityReservationGroupsClient,
		CapacityReservations:                  &capacityReservationsClient,
		Compute:                               &computeClient,
		DedicatedHost:                         &dedicatedHostClient,
		DedicatedHostGroups:                   &dedicatedHostGroupsClient,
		DedicatedHosts:                        &dedicatedHostsClient,
		Images:                                &imagesClient,
		LogAnalytics:                          &logAnalyticsClient,
		ProximityPlacementGroups:              &proximityPlacementGroupsClient,
		RestorePointCollections:               &restorePointCollectionsClient,
		SshPublicKeys:                         &sshPublicKeysClient,
		VirtualMachineExtensionImages:         &virtualMachineExtensionImagesClient,
		VirtualMachineExtensions:              &virtualMachineExtensionsClient,
		VirtualMachineImages:                  &virtualMachineImagesClient,
		VirtualMachineRunCommands:             &virtualMachineRunCommandsClient,
		VirtualMachineScaleSetExtensions:      &virtualMachineScaleSetExtensionsClient,
		VirtualMachineScaleSetRollingUpgrades: &virtualMachineScaleSetRollingUpgradesClient,
		VirtualMachineScaleSetVMExtensions:    &virtualMachineScaleSetVMExtensionsClient,
		VirtualMachineScaleSetVMRunCommands:   &virtualMachineScaleSetVMRunCommandsClient,
		VirtualMachineScaleSetVMs:             &virtualMachineScaleSetVMsClient,
		VirtualMachineScaleSets:               &virtualMachineScaleSetsClient,
		VirtualMachineSizes:                   &virtualMachineSizesClient,
		VirtualMachines:                       &virtualMachinesClient,
	}
}
```