### PR TITLE
tools/generator-go-sdk: adding an import for autorest

### DIFF
--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -50,6 +50,7 @@ configureAuthFunc(&%[1]s.Client)
 	out := fmt.Sprintf(`package %[1]s
 
 import (
+	"github.com/Azure/go-autorest/autorest"
 	%[2]s
 )
 


### PR DESCRIPTION
Missed this in local testing since I ran `goimports`

Fixes: https://github.com/hashicorp/go-azure-sdk/runs/7356573397?check_suite_focus=true#step:4:14608