### PR TITLE
data: scaffolding the Terraform Resource Definition based on the fields we currently support

### DIFF
--- a/data/Pandora.Definitions.ResourceManager/Resources/Terraform/ResourceGroup-Resource.cs
+++ b/data/Pandora.Definitions.ResourceManager/Resources/Terraform/ResourceGroup-Resource.cs
@@ -1,0 +1,21 @@
+using Pandora.Definitions.Interfaces;
+
+namespace Pandora.Definitions.ResourceManager.Resources.Terraform;
+
+public class ResourceGroupResource : TerraformResourceDefinition
+{
+    public string DisplayName => "Resource Group";
+    public ResourceID ResourceId => new v2020_06_01.ResourceGroups.ResourceGroupId();
+    public string ResourceLabel => "resource_group";
+    public string ResourceName => "ResourceGroup";
+    
+    public bool GenerateIDValidationFunction => true;
+    public bool GenerateSchema => true;
+
+    public MethodDefinition DeleteMethod => new MethodDefinition
+    {
+        Generate = true,
+        Method = typeof(v2020_06_01.ResourceGroups.DeleteOperation),
+        TimeoutInMinutes = 30,
+    };
+}

--- a/data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/ApiVersionDefinition.cs
+++ b/data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/ApiVersionDefinition.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Pandora.Definitions.Interfaces;
+using Pandora.Definitions.ResourceManager.Resources.Terraform;
 
 namespace Pandora.Definitions.ResourceManager.Resources.v2020_06_01;
 public partial class Definition : ApiVersionDefinition
@@ -14,5 +15,10 @@ public partial class Definition : ApiVersionDefinition
         new Providers.Definition(),
         new ResourceGroups.Definition(),
         new Resources.Definition(),
+    };
+
+    public IEnumerable<TerraformResourceDefinition> TerraformResources => new List<TerraformResourceDefinition>
+    {
+        new ResourceGroupResource(),
     };
 }

--- a/data/Pandora.Definitions/Interfaces/MethodDefinition.cs
+++ b/data/Pandora.Definitions/Interfaces/MethodDefinition.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Pandora.Definitions.Interfaces;
+
+public class MethodDefinition
+{
+    /// <summary>
+    /// Generate specifies whether this method should be generated or not.
+    /// </summary>
+    public bool Generate { get; set; }
+
+    /// <summary>
+    /// Method defines the SDK Method which should be called in this Terraform method.
+    /// </summary>
+    public Type Method { get; set; }
+    
+    /// <summary>
+    /// TimeoutInMinutes defines the Terraform Resource Timeout in minutes for this method.
+    /// </summary>
+    public int TimeoutInMinutes { get; set; }
+}

--- a/data/Pandora.Definitions/Interfaces/TerraformResourceDefinition.cs
+++ b/data/Pandora.Definitions/Interfaces/TerraformResourceDefinition.cs
@@ -1,0 +1,44 @@
+namespace Pandora.Definitions.Interfaces;
+
+public interface TerraformResourceDefinition
+{
+    /// <summary>
+    /// DeleteMethod defines the Delete Method associated with this Resource, both for whether this
+    /// should be generated and determining which SDK methods which should be called.
+    /// </summary>
+    public MethodDefinition DeleteMethod { get; }
+    
+    /// <summary>
+    /// DisplayName is the human readable name for this Resource, used in the Documentation.
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// GenerateIDValidationFunction specifies whether an ID Validation Function should be generated
+    /// for this Resource.
+    /// </summary>
+    public bool GenerateIDValidationFunction { get; }
+
+    /// <summary>
+    /// GenerateSchema specifies whether the Schema should be generated for this Resource.
+    /// </summary>
+    public bool GenerateSchema { get; }
+    
+    /// <summary>
+    /// ResourceId specifies the Resource ID associated with this Terraform Resource.
+    /// </summary>
+    public ResourceID ResourceId { get; }
+    
+    /// <summary>
+    /// ResourceLabel is the Terraform Resource Label which should be used for this Resource
+    /// **without** the Provider Prefix (e.g. `resource_group` rather than `azurerm_resource_group`).
+    /// </summary>
+    public string ResourceLabel { get; }
+    
+    /// <summary>
+    /// ResourceName is the name which should be used for this Resource.
+    /// This should be a valid Go Type Name as it's used for as the name of the Struct
+    /// for this resource.
+    /// </summary>
+    public string ResourceName { get; }
+}


### PR DESCRIPTION
This is going to need to be a 3-part switch since we need to add `TerraformResources` to the `ApiVersionDefinition`
implementations and then add it to the interface.