### PR TITLE
tools/generator-terraform: adding a short-term hack implementing all of the methods

### DIFF
--- a/tools/generator-terraform/generator/component_shorttermhack.go
+++ b/tools/generator-terraform/generator/component_shorttermhack.go
@@ -1,0 +1,26 @@
+package generator
+
+func methodsYetToBeImplementedForResource() string {
+	return `
+// TODO: the methods below this point are yet to be implemented
+// but are output purely to keep the compiler for happy in the short-term
+// by ensuring that this Resource correctly implements 'sdk.Resource'
+
+func ModelObject() interface{
+	// TODO: implement me in the generator
+	return nil
+}
+func ResourceType() string {
+	// TODO: implement me in the generator
+	return nil
+}
+func Create() sdk.ResourceFunc {
+	// TODO: implement me in the generator
+	return sdk.ResourceFunc{}
+}
+func Read() sdk.ResourceFunc {
+	// TODO: implement me in the generator
+	return sdk.ResourceFunc{}
+}
+`
+}

--- a/tools/generator-terraform/generator/resource.go
+++ b/tools/generator-terraform/generator/resource.go
@@ -35,6 +35,7 @@ func Resource(input ResourceInput) error {
 		// TODO: Schema
 		// TODO: Typed Model & Model func.
 		// TODO: Update
+		methodsYetToBeImplementedForResource(),
 	}
 	writeToPath(filePath, strings.Join(components, "\n"))
 	return nil


### PR DESCRIPTION
This allows us to ensure that the generated resource compiles, whilst it doesn't yet function it's nice to be able to try the bits that do.

Whilst this may seem like an odd choice, this means it's possible to confirm that everything else around this resource (e.g. the clients) works as we're expecting.