### PR TITLE
tools/importer-rest-api-specs: refactoring to use a single instance of parserData

### DIFF
--- a/tools/importer-rest-api-specs/differ/apply.go
+++ b/tools/importer-rest-api-specs/differ/apply.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/parser"
 )
 
-func (d Differ) ApplyFromExistingAPIDefinitions(existing []parser.ParsedData, parsed []parser.ParsedData) (*[]parser.ParsedData, error) {
+func (d Differ) ApplyFromExistingAPIDefinitions(existing []parser.ParsedData, parsed parser.ParsedData) (*parser.ParsedData, error) {
 	// we should work through and ensure that all Existing items are present within Parsed
 	// Each of the Stages to apply can be found in ApplyStages()
 

--- a/tools/importer-rest-api-specs/generate.go
+++ b/tools/importer-rest-api-specs/generate.go
@@ -5,82 +5,53 @@ import (
 	"log"
 	"os"
 	"path"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/generator"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/parser"
 )
 
-func generateTerraformDefinitions(input []parser.ParsedData, workingDirectory, rootNamespace string, resourceProvider, terraformPackageName *string, debug bool) error {
-	for _, item := range input {
-		containsTerraformResources := false
-		for _, v := range item.Resources {
-			if v.Terraform != nil {
-				containsTerraformResources = len(v.Terraform.DataSources) > 0 || len(v.Terraform.Resources) > 0
-			}
+func generateTerraformDefinitions(input parser.ParsedData, workingDirectory, rootNamespace string, resourceProvider, terraformPackageName *string, debug bool) error {
+	containsTerraformResources := false
+	for _, v := range input.Resources {
+		if v.Terraform != nil {
+			containsTerraformResources = len(v.Terraform.DataSources) > 0 || len(v.Terraform.Resources) > 0
 		}
-		if !containsTerraformResources {
-			// move along, nothing to see here.
+	}
+	if !containsTerraformResources {
+		// move along, nothing to see here.
+		return nil
+	}
+
+	data := generator.GenerationDataForServiceAndApiVersion(input.ServiceName, input.ApiVersion, workingDirectory, rootNamespace, resourceProvider, terraformPackageName)
+	generator := generator.NewPackageDefinitionGenerator(data, debug)
+
+	if err := generator.RecreateDirectory(data.WorkingDirectoryForTerraform, permissions); err != nil {
+		return fmt.Errorf("generating Terraform Definition for Namespace %q: %+v", data.NamespaceForTerraform, err)
+	}
+
+	for resourceName, resource := range input.Resources {
+		if resource.Terraform == nil {
 			continue
 		}
 
-		data := generator.GenerationDataForServiceAndApiVersion(item.ServiceName, item.ApiVersion, workingDirectory, rootNamespace, resourceProvider, terraformPackageName)
-		generator := generator.NewPackageDefinitionGenerator(data, debug)
+		// TODO: generate Data Sources
+		//for name, details := range resource.Terraform.DataSources {
+		//  fileName := path.Join(data.WorkingDirectoryForTerraform, fmt.Sprintf("%s-DataSource.cs", details.DataSourceName))
+		//	if debug {
+		//		log.Printf("Generating Data Source into %q", fileName)
+		//	}
+		//
+		//}
 
-		if err := generator.RecreateDirectory(data.WorkingDirectoryForTerraform, permissions); err != nil {
-			return fmt.Errorf("generating Terraform Definition for Namespace %q: %+v", data.NamespaceForTerraform, err)
-		}
-
-		for resourceName, resource := range item.Resources {
-			if resource.Terraform == nil {
-				continue
-			}
-
-			// TODO: generate Data Sources
-			//for name, details := range resource.Terraform.DataSources {
-			//  fileName := path.Join(data.WorkingDirectoryForTerraform, fmt.Sprintf("%s-DataSource.cs", details.DataSourceName))
-			//	if debug {
-			//		log.Printf("Generating Data Source into %q", fileName)
-			//	}
-			//
-			//}
-
-			for label, details := range resource.Terraform.Resources {
-				fileName := path.Join(data.WorkingDirectoryForTerraform, fmt.Sprintf("%s-Resource.cs", details.ResourceName))
-				if debug {
-					log.Printf("Generating Resource into %q", fileName)
-				}
-
-				if err := generator.GenerateTerraformResourceDefinition(fileName, data.NamespaceForTerraform, data.ApiVersionPackageName, data.PackageNameForResource(resourceName), label, details); err != nil {
-					return fmt.Errorf("generating Terraform Resource Definition for %q: %+v", label, err)
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func generateApiVersions(input []parser.ParsedData, workingDirectory, rootNamespace string, resourceProvider, terraformPackageName *string, debug bool) error {
-	for _, item := range input {
-		data := generator.GenerationDataForServiceAndApiVersion(item.ServiceName, item.ApiVersion, workingDirectory, rootNamespace, resourceProvider, terraformPackageName)
-		generator := generator.NewPackageDefinitionGenerator(data, debug)
-
-		os.MkdirAll(data.WorkingDirectoryForApiVersion, permissions)
-		if err := generator.GenerateVersionDefinitionAndRecreateDirectory(item.Resources, data.WorkingDirectoryForApiVersion, permissions); err != nil {
-			return fmt.Errorf("generating Version Definition for Namespace %q: %+v", data.NamespaceForApiVersion, err)
-		}
-
-		for resourceName, resource := range item.Resources {
+		for label, details := range resource.Terraform.Resources {
+			fileName := path.Join(data.WorkingDirectoryForTerraform, fmt.Sprintf("%s-Resource.cs", details.ResourceName))
 			if debug {
-				log.Printf("Generating Resource at %q", resourceName)
+				log.Printf("Generating Resource into %q", fileName)
 			}
-			outputDirectory := data.WorkingDirectoryForResource(resourceName)
-			os.MkdirAll(outputDirectory, permissions)
-			namespace := data.NamespaceForResource(resourceName)
-			if err := generator.GenerateResources(resourceName, namespace, resource, outputDirectory); err != nil {
-				return fmt.Errorf("generating Resource %q (Namespace %q): %+v", resourceName, namespace, err)
+
+			if err := generator.GenerateTerraformResourceDefinition(fileName, data.NamespaceForTerraform, data.ApiVersionPackageName, data.PackageNameForResource(resourceName), label, details); err != nil {
+				return fmt.Errorf("generating Terraform Resource Definition for %q: %+v", label, err)
 			}
 		}
 	}
@@ -88,42 +59,61 @@ func generateApiVersions(input []parser.ParsedData, workingDirectory, rootNamesp
 	return nil
 }
 
-func generateServiceDefinitions(input []parser.ParsedData, workingDirectory, rootNamespace string, resourceProvider, terraformPackageName *string, debug bool) error {
-	// the same service may appear multiple times, so we first need to Distinct them
-	serviceNames := distinctServiceNames(input)
+func generateApiVersions(input parser.ParsedData, workingDirectory, rootNamespace string, resourceProvider, terraformPackageName *string, debug bool) error {
+	data := generator.GenerationDataForServiceAndApiVersion(input.ServiceName, input.ApiVersion, workingDirectory, rootNamespace, resourceProvider, terraformPackageName)
+	generator := generator.NewPackageDefinitionGenerator(data, debug)
 
+	os.MkdirAll(data.WorkingDirectoryForApiVersion, permissions)
+	if err := generator.GenerateVersionDefinitionAndRecreateDirectory(input.Resources, data.WorkingDirectoryForApiVersion, permissions); err != nil {
+		return fmt.Errorf("generating Version Definition for Namespace %q: %+v", data.NamespaceForApiVersion, err)
+	}
+
+	for resourceName, resource := range input.Resources {
+		if debug {
+			log.Printf("Generating Resource at %q", resourceName)
+		}
+		outputDirectory := data.WorkingDirectoryForResource(resourceName)
+		os.MkdirAll(outputDirectory, permissions)
+		namespace := data.NamespaceForResource(resourceName)
+		if err := generator.GenerateResources(resourceName, namespace, resource, outputDirectory); err != nil {
+			return fmt.Errorf("generating Resource %q (Namespace %q): %+v", resourceName, namespace, err)
+		}
+	}
+
+	return nil
+}
+
+func generateServiceDefinitions(input parser.ParsedData, workingDirectory, rootNamespace string, resourceProvider, terraformPackageName *string, debug bool) error {
 	os.MkdirAll(workingDirectory, permissions)
 
-	for _, service := range serviceNames {
+	if debug {
+		log.Printf("[DEBUG] Processing Service %q..", input.ServiceName)
+	}
+	data := generator.GenerationDataForService(input.ServiceName, workingDirectory, rootNamespace, resourceProvider, terraformPackageName)
+	os.MkdirAll(data.WorkingDirectoryForService, permissions)
+
+	// clean up any files or directories which aren't on the exclude list
+	excludeList := []string{
+		// TODO: presumably we can remove this once https://github.com/hashicorp/pandora/issues/403
+		// is resolved
+		"ServiceDefinition-GenerationSetting.cs",
+	}
+	files, err := findFilesInDirectory(data.WorkingDirectoryForService, excludeList, debug)
+	if err != nil {
+		return fmt.Errorf("finding files in directory %q: %+v", data.WorkingDirectoryForService, err)
+	}
+
+	for _, name := range *files {
 		if debug {
-			log.Printf("[DEBUG] Processing Service %q..", service)
+			log.Printf("[DEBUG] Removing Path %q..", name)
 		}
-		data := generator.GenerationDataForService(service, workingDirectory, rootNamespace, resourceProvider, terraformPackageName)
-		os.MkdirAll(data.WorkingDirectoryForService, permissions)
+		os.RemoveAll(name)
+	}
 
-		// clean up any files or directories which aren't on the exclude list
-		excludeList := []string{
-			// TODO: presumably we can remove this once https://github.com/hashicorp/pandora/issues/403
-			// is resolved
-			"ServiceDefinition-GenerationSetting.cs",
-		}
-		files, err := findFilesInDirectory(data.WorkingDirectoryForService, excludeList, debug)
-		if err != nil {
-			return fmt.Errorf("finding files in directory %q: %+v", data.WorkingDirectoryForService, err)
-		}
-
-		for _, name := range *files {
-			if debug {
-				log.Printf("[DEBUG] Removing Path %q..", name)
-			}
-			os.RemoveAll(name)
-		}
-
-		// finally let's output the new Service Definition
-		generator := generator.NewPackageDefinitionGenerator(data, debug)
-		if err := generator.GenerateServiceDefinition(input); err != nil {
-			return fmt.Errorf("generating Service Definition for Namespace %q: %+v", data.NamespaceForService, err)
-		}
+	// finally let's output the new Service Definition
+	generator := generator.NewPackageDefinitionGenerator(data, debug)
+	if err := generator.GenerateServiceDefinition(input); err != nil {
+		return fmt.Errorf("generating Service Definition for Namespace %q: %+v", data.NamespaceForService, err)
 	}
 
 	return nil
@@ -166,26 +156,4 @@ func findFilesInDirectory(directory string, excludeList []string, debug bool) (*
 	}
 
 	return &files, nil
-}
-
-func distinctServiceNames(input []parser.ParsedData) []string {
-	distinctServiceNames := make(map[string]struct{})
-	apiVersionsForServices := make(map[string][]string)
-	for _, v := range input {
-		distinctServiceNames[v.ServiceName] = struct{}{}
-		versions, ok := apiVersionsForServices[v.ServiceName]
-		if !ok {
-			versions = make([]string, 0)
-		}
-		versions = append(versions, v.ApiVersion)
-		apiVersionsForServices[v.ServiceName] = versions
-	}
-
-	names := make([]string, 0)
-	for k := range distinctServiceNames {
-		names = append(names, k)
-	}
-	sort.Strings(names)
-
-	return names
 }

--- a/tools/importer-rest-api-specs/generator/definition_service.go
+++ b/tools/importer-rest-api-specs/generator/definition_service.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/cleanup"
 )
 
-func (g PandoraDefinitionGenerator) GenerateServiceDefinition(input []parser.ParsedData) error {
+func (g PandoraDefinitionGenerator) GenerateServiceDefinition(input parser.ParsedData) error {
 	serviceDefinitionFilePath := path.Join(g.data.WorkingDirectoryForService, "ServiceDefinition.cs")
 	if g.debugLog {
 		log.Printf("[DEBUG] Generating Service Definition into %q..", serviceDefinitionFilePath)

--- a/tools/importer-rest-api-specs/generator/package.go
+++ b/tools/importer-rest-api-specs/generator/package.go
@@ -126,18 +126,16 @@ func (g PandoraDefinitionGenerator) GenerateResources(resourceName, namespace st
 	return nil
 }
 
-func (g PandoraDefinitionGenerator) getTerraformResourceTypes(input []parser.ParsedData) []string {
+func (g PandoraDefinitionGenerator) getTerraformResourceTypes(input parser.ParsedData) []string {
 	out := make([]string, 0)
 
-	for _, item := range input {
-		for _, resource := range item.Resources {
-			if resource.Terraform == nil {
-				continue
-			}
+	for _, resource := range input.Resources {
+		if resource.Terraform == nil {
+			continue
+		}
 
-			for _, v := range resource.Terraform.Resources {
-				out = append(out, fmt.Sprintf("Terraform.%sResource", v.ResourceName))
-			}
+		for _, v := range resource.Terraform.Resources {
+			out = append(out, fmt.Sprintf("Terraform.%sResource", v.ResourceName))
 		}
 	}
 

--- a/tools/importer-rest-api-specs/import.go
+++ b/tools/importer-rest-api-specs/import.go
@@ -27,7 +27,7 @@ func importService(input RunInput, swaggerGitSha string, dataApiEndpoint *string
 	if err != nil {
 		return errWrap(fmt.Errorf("parsing Swagger files: %+v", err))
 	}
-	if data != nil && len(*data) == 0 {
+	if data == nil {
 		log.Printf("😵 Service %q / Api Version %q contains no resources, skipping.", input.ServiceName, input.ApiVersion)
 		return nil
 	}
@@ -117,36 +117,31 @@ func importService(input RunInput, swaggerGitSha string, dataApiEndpoint *string
 	return nil
 }
 
-func identifyCandidateTerraformResources(input *[]parser.ParsedData, terraformServiceDefinition definitions.ServiceDefinition) (*[]parser.ParsedData, error) {
+func identifyCandidateTerraformResources(input *parser.ParsedData, terraformServiceDefinition definitions.ServiceDefinition) (*parser.ParsedData, error) {
 	if input == nil {
 		return input, nil
 	}
 
-	out := make([]parser.ParsedData, 0)
+	parsedResources := make(map[string]models.AzureApiResource, 0)
 
-	for _, item := range *input {
-		parsedResources := make(map[string]models.AzureApiResource, 0)
-
-		for k, v := range item.Resources {
-			definitionsForThisResource := findResourceDefinitionsForResource(item.ApiVersion, k, terraformServiceDefinition)
-			if definitionsForThisResource != nil {
-				apiResource, err := transformer.ApiResourceFromModelResource(v)
-				if err != nil {
-					return nil, fmt.Errorf("mapping Resource %q from to an API Resource: %+v", k, err)
-				}
-
-				terraformDetails := resources.FindCandidates(*apiResource, *definitionsForThisResource, k)
-				v.Terraform = &terraformDetails
+	for k, v := range input.Resources {
+		definitionsForThisResource := findResourceDefinitionsForResource(input.ApiVersion, k, terraformServiceDefinition)
+		if definitionsForThisResource != nil {
+			apiResource, err := transformer.ApiResourceFromModelResource(v)
+			if err != nil {
+				return nil, fmt.Errorf("mapping Resource %q from to an API Resource: %+v", k, err)
 			}
 
-			parsedResources[k] = v
+			terraformDetails := resources.FindCandidates(*apiResource, *definitionsForThisResource, k)
+			v.Terraform = &terraformDetails
 		}
 
-		item.Resources = parsedResources
-		out = append(out, item)
+		parsedResources[k] = v
 	}
 
-	return &out, nil
+	input.Resources = parsedResources
+
+	return input, nil
 }
 
 func findResourceDefinitionsForResource(apiVersion, apiResource string, terraformServiceDefinitions definitions.ServiceDefinition) *map[string]definitions.ResourceDefinition {
@@ -163,25 +158,11 @@ func findResourceDefinitionsForResource(apiVersion, apiResource string, terrafor
 	return &forResource.Definitions
 }
 
-func parseSwaggerFiles(input RunInput, debug bool) (*[]parser.ParsedData, error) {
-	// TODO: shouldn't this be returning a single `parser.ParsedData` here?
+func parseSwaggerFiles(input RunInput, debug bool) (*parser.ParsedData, error) {
 	parseResult, err := parser.LoadAndParseFiles(input.SwaggerDirectory, input.SwaggerFiles, input.ServiceName, input.ApiVersion, debug)
 	if err != nil {
 		return nil, fmt.Errorf("parsing files in %q: %+v", input.SwaggerDirectory, err)
 	}
 
-	if parseResult == nil {
-		return nil, nil
-	}
-
-	if len(*parseResult) > 1 {
-		return nil, fmt.Errorf("internal-error: expected a single parseResult but got %d for Service %q / API Version %q", len(*parseResult), input.ServiceName, input.ApiVersion)
-	}
-
-	out := make([]parser.ParsedData, 0)
-	if len(*parseResult) == 1 {
-		// could be 0 after all
-		out = append(out, (*parseResult)[0])
-	}
-	return &out, nil
+	return parseResult, nil
 }

--- a/tools/importer-rest-api-specs/parser/load_and_parse.go
+++ b/tools/importer-rest-api-specs/parser/load_and_parse.go
@@ -9,14 +9,14 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/parser/resourceids"
 )
 
-func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVersion string, debugLogging bool) (*[]ParsedData, error) {
+func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVersion string, debugLogging bool) (*ParsedData, error) {
 	// Some Services have been deprecated or should otherwise be ignored - check before proceeding
 	if serviceShouldBeIgnored(serviceName) {
 		if debugLogging {
 			log.Printf("[DEBUG] Skipping service %q", serviceName)
 		}
 
-		return &[]ParsedData{}, nil
+		return &ParsedData{}, nil
 	}
 
 	logger := hclog.NewNullLogger()
@@ -85,7 +85,16 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 
 		out = append(out, v)
 	}
-	return &out, nil
+
+	if len(out) > 1 {
+		return nil, fmt.Errorf("internal-error:the Swagger files for Service %q / API Version %q contained multiple resources (%d total)", serviceName, apiVersion, len(out))
+	}
+
+	if len(out) == 1 {
+		return &out[0], nil
+	}
+
+	return nil, nil
 }
 
 func serviceShouldBeIgnored(name string) bool {

--- a/tools/importer-rest-api-specs/segments.go
+++ b/tools/importer-rest-api-specs/segments.go
@@ -68,21 +68,19 @@ func parseAndOutputSegments(swaggerDirectory string, debug bool) error {
 			log.Printf("     💥 Error: parsing Swagger files: %+v", err)
 			return err
 		}
-		if data != nil && len(*data) == 0 {
+		if data == nil {
 			log.Printf("😵 Service %q / Api Version %q contains no resources, skipping.", input.ServiceName, input.ApiVersion)
 			continue
 		}
 
-		for _, item := range *data {
-			for _, resource := range item.Resources {
-				for _, id := range resource.ResourceIds {
-					for _, segment := range id.Segments {
-						if segment.FixedValue == nil {
-							continue
-						}
-
-						fixedSegmentValues[*segment.FixedValue] = struct{}{}
+		for _, resource := range data.Resources {
+			for _, id := range resource.ResourceIds {
+				for _, segment := range id.Segments {
+					if segment.FixedValue == nil {
+						continue
 					}
+
+					fixedSegmentValues[*segment.FixedValue] = struct{}{}
 				}
 			}
 		}


### PR DESCRIPTION
Returning a slice of these was always unintentional, it was first intended to allow for multiple Services to be defined within a given API Version (as has happened in a handful of cases) - but importing everything it appears we only ever have an single returned - so we can instead change this from a slice -> a list to simplify the parsing.