### PR TITLE
add naming corrections for names incorporating 'ip' in various casings

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
+++ b/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
@@ -53,6 +53,7 @@ func RemoveInvalidCharacters(input string, titleCaseSegments bool) string {
 func NormalizeName(input string) string {
 	output := input
 	output = wordifyFirstCharacter(output)
+	output = NormalizeCanonicalisation(output)
 	output = RemoveInvalidCharacters(output, true)
 	output = NormalizeSegment(output, false)
 	output = strings.Title(output)
@@ -516,4 +517,28 @@ func wordifyFirstCharacter(input string) string {
 		return output
 	}
 	return input
+}
+
+func NormalizeCanonicalisation(input string) string {
+	output := input
+
+	// Some IP references have 'ip' as a prefix
+	if strings.HasPrefix(output, "ip") {
+		output = strings.Replace(output, "ip", "IP", 1)
+	}
+
+	if strings.EqualFold(output, "Publicipaddress") {
+		// This is an explicit force for broken data in `Network`
+		output = "PublicIPAddress"
+	}
+
+	if strings.EqualFold(output, "IPconfiguration") {
+		// This is an explicit force for broken data in `Network`
+		output = "IPConfiguration"
+	}
+
+	// intentionally case-sensitive
+	output = strings.ReplaceAll(output, "Ip", "IP")
+
+	return output
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
@@ -114,7 +114,7 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, log hclog.Logg
 	// now we have unique ID's, we should go through and suffix `Id` onto the end of each of them
 	outputNamesToUris := make(map[string]models.ParsedResourceId)
 	for k, v := range candidateNamesToUris {
-		key := fmt.Sprintf("%sId", k)
+		key := fmt.Sprintf("%sId", cleanup.NormalizeName(k))
 		outputNamesToUris[key] = v
 	}
 


### PR DESCRIPTION
supersedes #989 
Fixes #793 