### PR TITLE
tools/generator-terraform: scaffolding a prototype for documentation

### DIFF
--- a/tools/generator-terraform/generator/resource/docs/component_arguments.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments.go
@@ -1,0 +1,7 @@
+package docs
+
+import "github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+
+func codeForArgumentsReference(input models.ResourceInput) string {
+	return "TODO"
+}

--- a/tools/generator-terraform/generator/resource/docs/component_attributes.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes.go
@@ -1,0 +1,7 @@
+package docs
+
+import "github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+
+func codeForAttributesReference(input models.ResourceInput) string {
+	return "TODO"
+}

--- a/tools/generator-terraform/generator/resource/docs/component_example_usage.go
+++ b/tools/generator-terraform/generator/resource/docs/component_example_usage.go
@@ -1,0 +1,21 @@
+package docs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+)
+
+func codeForExampleUsage(input models.ResourceInput) string {
+	code := strings.TrimSpace(fmt.Sprintf(`
+## Example Usage
+
+'''hcl
+resource "%[1]s_%[2]s" "example" {
+  // TODO: example usage
+}
+'''
+`, input.ProviderPrefix, input.ResourceLabel))
+	return strings.ReplaceAll(code, "'", "`")
+}

--- a/tools/generator-terraform/generator/resource/docs/component_frontmatter.go
+++ b/tools/generator-terraform/generator/resource/docs/component_frontmatter.go
@@ -1,0 +1,20 @@
+package docs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+)
+
+func codeForYAMLFrontMatter(input models.ResourceInput) string {
+	return strings.TrimSpace(fmt.Sprintf(`
+---
+subcategory: "%[1]s"
+layout: "%[2]s"
+page_title: "%[5]s: %[2]s_%[3]s"
+description: |-
+  Manages an %[4]s.
+---
+`, "Connections", input.ProviderPrefix, input.ResourceLabel, input.Details.DisplayName, "Azure Resource Manager"))
+}

--- a/tools/generator-terraform/generator/resource/docs/component_imports.go
+++ b/tools/generator-terraform/generator/resource/docs/component_imports.go
@@ -1,0 +1,114 @@
+package docs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+func codeForImport(input models.ResourceInput) string {
+	resourceId, ok := input.ResourceIds[input.Details.ResourceIdName]
+	if !ok {
+		// TODO: error handling
+		panic(fmt.Sprintf("resource ID %q is used but was not defined", input.Details.ResourceIdName))
+	}
+
+	resourceIdDescriptionLines := make([]string, 0)
+	for _, value := range resourceId.Segments {
+		if value.Type == resourcemanager.ResourceProviderSegment || value.Type == resourcemanager.StaticSegment {
+			continue
+		}
+
+		description, err := descriptionsForSegment(value, resourceId, input.Details, input.Constants)
+		if err != nil {
+			// TODO: error handling
+			panic(fmt.Sprintf("building description for segment %q: %+v", value.Name, err))
+		}
+		line := fmt.Sprintf(`
+* Where '{%[1]s}' %[2]s
+`, value.Name, *description)
+		resourceIdDescriptionLines = append(resourceIdDescriptionLines, strings.TrimSpace(strings.ReplaceAll(line, "'", "`")))
+	}
+
+	importsCode := fmt.Sprintf(`
+## Import
+
+An existing %[1]s can be imported into Terraform using the 'resource id', e.g.
+
+'''shell
+terraform import %[2]s_%[3]s.example %[4]s
+'''
+
+%[5]s
+`, input.Details.DisplayName, input.ProviderPrefix, input.ResourceLabel, resourceId.Id, strings.Join(resourceIdDescriptionLines, "\n"))
+
+	return strings.TrimSpace(strings.ReplaceAll(importsCode, "'", "`"))
+}
+
+func descriptionsForSegment(segment resourcemanager.ResourceIdSegment, resourceId resourcemanager.ResourceIdDefinition, details resourcemanager.TerraformResourceDetails, constants map[string]resourcemanager.ConstantDetails) (*string, error) {
+	if segment.Type == resourcemanager.ResourceGroupSegment {
+		if isCommonResourceIdNamed("ResourceGroup", resourceId) {
+			out := fmt.Sprintf("is the name of this %[1]s. (For example '%[2]s').", details.DisplayName, segment.ExampleValue)
+			return &out, nil
+		}
+
+		out := fmt.Sprintf("is the name of Resource Group where this %[1]s exists. (For example '%[2]s').", details.DisplayName, segment.ExampleValue)
+		return &out, nil
+	}
+	if segment.Type == resourcemanager.SubscriptionIdSegment {
+		if isCommonResourceIdNamed("Subscription", resourceId) {
+			out := fmt.Sprintf("is the ID of this %[1]s. (For example '%[2]s').", details.DisplayName, segment.ExampleValue)
+			return &out, nil
+		}
+
+		out := fmt.Sprintf("is the ID of the Azure Subscription where the %[1]s exists. (For example '%[2]s').", details.DisplayName, segment.ExampleValue)
+		return &out, nil
+	}
+	if segment.Type == resourcemanager.ScopeSegment {
+		if isCommonResourceIdNamed("Scope", resourceId) {
+			out := fmt.Sprintf("is the Azure Resource Scope under which this %[1]s exists. (For example '%[2]s').", details.DisplayName, segment.ExampleValue)
+			return &out, nil
+		}
+
+		out := fmt.Sprintf("is the ID of the Azure Resource under which the %[1]s exists. (For example '%[2]s').", details.DisplayName, segment.ExampleValue)
+		return &out, nil
+	}
+
+	description := fmt.Sprintf("is the name of the %s", wordifySegmentName(segment.Name))
+
+	if segment.Type == resourcemanager.ConstantSegment {
+		if segment.ConstantReference == nil {
+			return nil, fmt.Errorf("segment is a constant without a reference")
+		}
+		constant, ok := constants[*segment.ConstantReference]
+		if !ok {
+			return nil, fmt.Errorf("segment referenced constant %q but it was not found", *segment.ConstantReference)
+		}
+
+		possibleValues := wordifyConstantValues(constant.Values)
+		description = fmt.Sprintf("%s. %s.", description, possibleValues)
+	}
+
+	if segment.Type == resourcemanager.UserSpecifiedSegment {
+		description = fmt.Sprintf("%s. For example `%s`.", description, segment.ExampleValue)
+	}
+
+	return &description, nil
+}
+
+func wordifyConstantValues(values map[string]string) string {
+	components := make([]string, 0)
+	for _, v := range values {
+		components = append(components, fmt.Sprintf("`%s`", v))
+	}
+	sort.Strings(components)
+
+	return fmt.Sprintf("Possible values are %s and %s", strings.Join(components[0:len(components)-1], ", "), components[len(components)-1])
+}
+
+func isCommonResourceIdNamed(name string, resourceId resourcemanager.ResourceIdDefinition) bool {
+	return resourceId.CommonAlias != nil && *resourceId.CommonAlias == name
+}

--- a/tools/generator-terraform/generator/resource/docs/component_summary.go
+++ b/tools/generator-terraform/generator/resource/docs/component_summary.go
@@ -1,0 +1,17 @@
+package docs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+)
+
+func codeForSummary(input models.ResourceInput) string {
+	// TODO: we should probably return a summary/description from the API? That'd allow us to inject notes etc
+	return strings.TrimSpace(fmt.Sprintf(`
+# %[1]s_%[2]s
+
+Manages an %[3]s.
+`, input.ProviderPrefix, input.ResourceLabel, input.Details.DisplayName))
+}

--- a/tools/generator-terraform/generator/resource/docs/component_timeouts.go
+++ b/tools/generator-terraform/generator/resource/docs/component_timeouts.go
@@ -1,0 +1,7 @@
+package docs
+
+import "github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+
+func codeForTimeouts(input models.ResourceInput) string {
+	return "TODO"
+}

--- a/tools/generator-terraform/generator/resource/docs/components.go
+++ b/tools/generator-terraform/generator/resource/docs/components.go
@@ -1,0 +1,15 @@
+package docs
+
+import "github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+
+func ComponentsForResource(input models.ResourceInput) []string {
+	return []string{
+		codeForYAMLFrontMatter(input),
+		codeForSummary(input),
+		codeForExampleUsage(input),
+		codeForArgumentsReference(input),
+		codeForAttributesReference(input),
+		codeForTimeouts(input),
+		codeForImport(input),
+	}
+}

--- a/tools/generator-terraform/generator/resource/docs/helpers.go
+++ b/tools/generator-terraform/generator/resource/docs/helpers.go
@@ -1,0 +1,21 @@
+package docs
+
+import "strings"
+
+// wordifySegmentName takes an input PascalCased string and converts it to a more human-friendly variant
+// e.g. `applicationGroupName` -> `Application Group`
+func wordifySegmentName(input string) string {
+	val := strings.Title(input)
+	val = strings.TrimSuffix(val, "Name")
+	output := ""
+
+	for _, c := range val {
+		character := string(c)
+		if strings.ToUpper(character) == character {
+			output += " "
+		}
+		output += character
+	}
+
+	return strings.TrimPrefix(output, " ")
+}

--- a/tools/generator-terraform/generator/resource/resource.go
+++ b/tools/generator-terraform/generator/resource/resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+	"github.com/hashicorp/pandora/tools/generator-terraform/generator/resource/docs"
 )
 
 func Resource(input models.ResourceInput) error {
@@ -20,6 +21,15 @@ func Resource(input models.ResourceInput) error {
 	os.Remove(resourceFilePath)
 	resourceComponents := componentsForResource(input)
 	writeToPath(resourceFilePath, strings.Join(resourceComponents, "\n"))
+
+	// then go generate the documentation
+	websiteResourcesDirectory := fmt.Sprintf("%s/website/r/", input.RootDirectory)
+	os.MkdirAll(websiteResourcesDirectory, 0755)
+	documentationFilePath := fmt.Sprintf("%s/%s.html.markdown", websiteResourcesDirectory, input.ResourceLabel)
+	// remove the file if it already exists
+	os.Remove(documentationFilePath)
+	documentationComponents := docs.ComponentsForResource(input)
+	writeToPath(documentationFilePath, strings.Join(documentationComponents, "\n\n"))
 
 	return nil
 }


### PR DESCRIPTION
Scaffolding the documentation based on the data within the Data API - this doesn't yet output fields, but instead focuses on the `import` section for now - updating this to make this more user friendly - example:

```
---
subcategory: "Connections"
layout: "azurerm"
page_title: "Azure Resource Manager: azurerm_virtual_machine_scale_set"
description: |-
  Manages an Virtual Machine Scale Set.
---

# azurerm_virtual_machine_scale_set

Manages an Virtual Machine Scale Set.

## Example Usage

'''hcl
resource "azurerm_virtual_machine_scale_set" "example" {
  // TODO: example usage
}
'''

TODO

TODO

TODO

## Import

An existing Virtual Machine Scale Set can be imported into Terraform using the `resource id`, e.g.

'''shell
terraform import azurerm_virtual_machine_scale_set.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}
'''

* Where `{subscriptionId}` is the ID of the Azure Subscription where the Virtual Machine Scale Set exists. (For example `12345678-1234-9876-4563-123456789012`).
* Where `{resourceGroupName}` is the name of Resource Group where this Virtual Machine Scale Set exists. (For example `example-resource-group`).
* Where `{virtualMachineScaleSetName}` is the name of the Virtual Machine Scale Set. Possible values are `Low`, `Regular` and `Spot`.
```