### PR TITLE
tools/importer-rest-api-specs: updating vmName -> virtualMachineName

### DIFF
--- a/config/resources/compute.hcl
+++ b/config/resources/compute.hcl
@@ -4,7 +4,7 @@ service "Compute" {
   api "2021-11-01" {
     package "VirtualMachines" {
       definition "virtual_machine" {
-        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}"
+        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}"
         display_name = "Virtual Machine"
       }
     }

--- a/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
+++ b/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
@@ -154,6 +154,7 @@ func NormalizeSegment(input string, camelCase bool) string {
 		"vaultstorageconfig":                      "vaultStorageConfig",
 		"virtualnetworks":                         "virtualNetworks",
 		"virtualmachines":                         "virtualMachines",
+		"vmname":                                  "virtualMachineName",         // inconsistency in Compute
 		"vmscalesetname":                          "virtualMachineScaleSetName", // inconsistency in Compute (#1204)
 		"vcenters":                                "vCenters",
 		"vmwaresites":                             "vmwareSites",


### PR DESCRIPTION
This'll ultimately want to be a CommonID, but for now this works around outputting this as `vm` in the docs when `virtual machine` would make more sense