### PR TITLE
generator-go-sdk: add unmarshalling for top level discriminated types

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -602,7 +602,7 @@ func (c %[1]s) responderFor%[2]s(resp *http.Response) (result %[2]sOperationResp
 	result.HttpResponse = resp
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return result, fmt.Errorf("reading response body: %+v", err )
+		return result, fmt.Errorf("reading response body: %+v", err)
 	}
 	model, err := unmarshalDataConnectorImplementation(b)
 	if err != nil {

--- a/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
@@ -106,7 +106,7 @@ func TestTemplateMethodAutoRestDiscriminatedTypeResponder(t *testing.T) {
 		result.HttpResponse = resp
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return result, fmt.Errorf("reading response body: PandaPop", err )
+			return result, fmt.Errorf("reading response body: PandaPop", err)
 		}
 		model, err := unmarshalDataConnectorImplementation(b)
 		if err != nil {


### PR DESCRIPTION
Closes #73 
