### PR TITLE
tools/generator-go-sdk: fixing a bug where the error wasn't correctly formatted

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -602,7 +602,7 @@ func (c %[1]s) responderFor%[2]s(resp *http.Response) (result %[2]sOperationResp
 	result.HttpResponse = resp
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return result, fmt.Errorf("reading response body: %+v", err)
+		return result, fmt.Errorf("reading response body for %[4]q: %%+v", err)
 	}
 	model, err := unmarshal%[4]sImplementation(b)
 	if err != nil {

--- a/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
@@ -106,7 +106,7 @@ func TestTemplateMethodAutoRestDiscriminatedTypeResponder(t *testing.T) {
 		result.HttpResponse = resp
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return result, fmt.Errorf("reading response body: PandaPop", err)
+			return result, fmt.Errorf("reading response body for "PandaPop": %+v", err)
 		}
 		model, err := unmarshalPandaPopImplementation(b)
 		if err != nil {


### PR DESCRIPTION
This leads to a linting error since the Errorf statement has no arguments

@jackofallops FYI https://github.com/hashicorp/go-azure-sdk/blob/auto-pr/a9089c4/resource-manager/dataprotection/2022-04-01/dppfeaturesupport/method_dataprotectioncheckfeaturesupport_autorest.go#L70