### PR TITLE
don't add `extra` test when the final segment of the ID is a `scope` type

### DIFF
--- a/tools/generator-go-sdk/generator/templater_id_parser_tests.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser_tests.go
@@ -246,6 +246,7 @@ func (i resourceIdTestsTemplater) getTestCases(caseSensitive bool) (*string, err
 	}
 
 	isSingleSegmentOnly := len(i.resourceData.Segments) == 1 && i.resourceData.Segments[0].Type == resourcemanager.ScopeSegment
+	idEndsInScopeSegment := len(i.resourceData.Segments) > 1 && i.resourceData.Segments[len(i.resourceData.Segments)-1].Type == resourcemanager.ScopeSegment
 	fullUrl := urlFromSegments(urlVals)
 	cases = append(cases, fmt.Sprintf(`{
 		// Valid URI
@@ -254,7 +255,7 @@ func (i resourceIdTestsTemplater) getTestCases(caseSensitive bool) (*string, err
 			%s
 		},
 	},`, fullUrl, i.resourceName, strings.Join(structMap, "\n")))
-	if !isSingleSegmentOnly {
+	if !isSingleSegmentOnly && !idEndsInScopeSegment {
 		cases = append(cases, fmt.Sprintf(`{
 		// Invalid (Valid Uri with Extra segment) 
 		Input: "%s/extra",
@@ -271,7 +272,7 @@ func (i resourceIdTestsTemplater) getTestCases(caseSensitive bool) (*string, err
 			%s
 		},
 	},`, fullUrl, i.resourceName, strings.Join(caseInsensitiveStructMap, "\n")))
-		if !isSingleSegmentOnly {
+		if !isSingleSegmentOnly && !idEndsInScopeSegment {
 			cases = append(cases, fmt.Sprintf(`{
 		// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
 		Input: "%s/extra",


### PR DESCRIPTION
Fixes #1156 
