### PR TITLE
tools/generator-go-sdk: fixing the ordering of test assertions

### DIFF
--- a/tools/generator-go-sdk/generator/templater_clients_autorest_test.go
+++ b/tools/generator-go-sdk/generator/templater_clients_autorest_test.go
@@ -33,5 +33,5 @@ func NewExampleClientWithBaseURI(endpoint string) ExampleClient {
 		baseUri: endpoint,
 	}
 }`
-	assertTemplatedCodeMatches(t, *actual, expected)
+	assertTemplatedCodeMatches(t, expected, *actual)
 }

--- a/tools/generator-go-sdk/generator/templater_constant_test.go
+++ b/tools/generator-go-sdk/generator/templater_constant_test.go
@@ -46,7 +46,7 @@ func parseMyConstant(input float64) (*MyConstant, error) {
 	return &out, nil
 }
 `
-	assertTemplatedCodeMatches(t, *actual, expected)
+	assertTemplatedCodeMatches(t, expected, *actual)
 }
 
 func TestTemplateIntegerConstant(t *testing.T) {
@@ -93,7 +93,7 @@ func parseMamboNumber(input int64) (*MamboNumber, error) {
 	return &out, nil
 }
 `
-	assertTemplatedCodeMatches(t, *actual, expected)
+	assertTemplatedCodeMatches(t, expected, *actual)
 }
 
 func TestTemplateStringConstant(t *testing.T) {
@@ -140,5 +140,5 @@ func parseCapital(input string) (*Capital, error) {
 	return &out, nil
 }
 `
-	assertTemplatedCodeMatches(t, *actual, expected)
+	assertTemplatedCodeMatches(t, expected, *actual)
 }

--- a/tools/generator-go-sdk/generator/templater_readme_test.go
+++ b/tools/generator-go-sdk/generator/templater_readme_test.go
@@ -41,7 +41,7 @@ client.Client.Authorizer = authorizer
 	if err != nil {
 		t.Fatalf("generating readme: %+v", err)
 	}
-	assertTemplatedCodeMatches(t, *actual, expected)
+	assertTemplatedCodeMatches(t, expected, *actual)
 }
 
 func TestReadmeTemplater_GetOperationWithResourceID(t *testing.T) {

--- a/tools/generator-go-sdk/generator/templater_version_test.go
+++ b/tools/generator-go-sdk/generator/templater_version_test.go
@@ -27,5 +27,5 @@ const defaultApiVersion = "2022-02-01"
 func userAgent() string {
 	return fmt.Sprintf("hashicorp/go-azure-sdk/somepackage/%s", defaultApiVersion)
 }`
-	assertTemplatedCodeMatches(t, *actual, expected)
+	assertTemplatedCodeMatches(t, expected, *actual)
 }


### PR DESCRIPTION
These should be (t, expected, actual)