### PR TITLE
tools/generator-terraform: ignoring the return object when a non-LRO method is called for Create/Update/Delete

### DIFF
--- a/tools/generator-terraform/generator/resource/component_create_func.go
+++ b/tools/generator-terraform/generator/resource/component_create_func.go
@@ -105,11 +105,16 @@ func (r %[1]sResource) Create() sdk.ResourceFunc {
 func (h createFunctionComponents) create() (*string, error) {
 	methodName := methodNameToCallForOperation(h.createMethod, h.createMethodName)
 	methodArguments := argumentsForApiOperationMethod(h.createMethod, h.sdkResourceNameLowered, h.createMethodName, false)
+	variablesForMethod := "err"
+	if !h.createMethod.LongRunning {
+		variablesForMethod = "_, err"
+	}
+
 	output := fmt.Sprintf(`
-			if err := client.%[1]s(%[2]s); err != nil {
+			if %[3]s := client.%[1]s(%[2]s); err != nil {
 				return fmt.Errorf("creating %%s: %%+v", id, err)
 			}
-`, methodName, methodArguments)
+`, methodName, methodArguments, variablesForMethod)
 	return &output, nil
 }
 

--- a/tools/generator-terraform/generator/resource/component_create_func_test.go
+++ b/tools/generator-terraform/generator/resource/component_create_func_test.go
@@ -286,7 +286,7 @@ func TestComponentCreate_CreateFunc_Immediate_PayloadResourceIdNoOptions(t *test
 		t.Fatalf("error: %+v", err)
 	}
 	expected := `
-			if err := client.CreateThing(ctx, id, payload); err != nil {
+			if _, err := client.CreateThing(ctx, id, payload); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 `
@@ -311,7 +311,7 @@ func TestComponentCreate_CreateFunc_Immediate_PayloadResourceIdOptions(t *testin
 		t.Fatalf("error: %+v", err)
 	}
 	expected := `
-			if err := client.CreateThing(ctx, id, payload, sdkresource.DefaultCreateThingOperationOptions()); err != nil {
+			if _, err := client.CreateThing(ctx, id, payload, sdkresource.DefaultCreateThingOperationOptions()); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 `

--- a/tools/generator-terraform/generator/resource/component_delete_func.go
+++ b/tools/generator-terraform/generator/resource/component_delete_func.go
@@ -23,6 +23,10 @@ func deleteFunctionForResource(input models.ResourceInput) (*string, error) {
 
 	methodArguments := argumentsForApiOperationMethod(deleteOperation, input.SdkResourceName, input.Details.DeleteMethod.MethodName, true)
 	deleteMethodName := methodNameToCallForOperation(deleteOperation, input.Details.DeleteMethod.MethodName)
+	variablesForMethod := "err"
+	if !deleteOperation.LongRunning {
+		variablesForMethod = "_, err"
+	}
 
 	output := fmt.Sprintf(`
 func (r %[1]sResource) Delete() sdk.ResourceFunc {
@@ -36,7 +40,7 @@ func (r %[1]sResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			if err := client.%[6]s(%[7]s); err != nil {
+			if %[8]s := client.%[6]s(%[7]s); err != nil {
 				return fmt.Errorf("deleting %%s: %%+v", *id, err)
 			}
 
@@ -44,6 +48,6 @@ func (r %[1]sResource) Delete() sdk.ResourceFunc {
 		},
 	}
 }
-`, input.ResourceTypeName, input.Details.DeleteMethod.TimeoutInMinutes, input.ServiceName, input.SdkResourceName, *idParseLine, deleteMethodName, methodArguments)
+`, input.ResourceTypeName, input.Details.DeleteMethod.TimeoutInMinutes, input.ServiceName, input.SdkResourceName, *idParseLine, deleteMethodName, methodArguments, variablesForMethod)
 	return &output, nil
 }

--- a/tools/generator-terraform/generator/resource/component_delete_func_test.go
+++ b/tools/generator-terraform/generator/resource/component_delete_func_test.go
@@ -114,7 +114,7 @@ func (r ExampleResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			if err := client.PewPew(ctx, *id); err != nil {
+			if _, err := client.PewPew(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 			return nil
@@ -174,7 +174,7 @@ func (r ExampleResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			if err := client.PewPew(ctx, *id, sdkresource.DefaultPewPewOperationOptions()); err != nil {
+			if _, err := client.PewPew(ctx, *id, sdkresource.DefaultPewPewOperationOptions()); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 			return nil
@@ -224,7 +224,7 @@ func (r ExampleResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			if err := client.PewPew(ctx, *id); err != nil {
+			if _, err := client.PewPew(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 			return nil
@@ -284,7 +284,7 @@ func (r ExampleResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			if err := client.PewPew(ctx, *id, sdkresource.DefaultPewPewOperationOptions()); err != nil {
+			if _, err := client.PewPew(ctx, *id, sdkresource.DefaultPewPewOperationOptions()); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 			return nil

--- a/tools/generator-terraform/generator/resource/component_update_func.go
+++ b/tools/generator-terraform/generator/resource/component_update_func.go
@@ -163,10 +163,15 @@ func (h updateFuncHelpers) resourceIdParser() (*string, error) {
 func (h updateFuncHelpers) update() (*string, error) {
 	methodName := methodNameToCallForOperation(h.updateMethod, h.updateMethodName)
 	methodArguments := argumentsForApiOperationMethod(h.updateMethod, h.sdkResourceNameLowered, h.updateMethodName, true)
+	variablesForMethod := "err"
+	if !h.createMethod.LongRunning {
+		variablesForMethod = "_, err"
+	}
+
 	output := fmt.Sprintf(`
-			if err := client.%[1]s(%[2]s); err != nil {
+			if %[3]s := client.%[1]s(%[2]s); err != nil {
 				return fmt.Errorf("updating %%s: %%+v", *id, err)
 			}
-`, methodName, methodArguments)
+`, methodName, methodArguments, variablesForMethod)
 	return &output, nil
 }

--- a/tools/generator-terraform/generator/resource/component_update_func_test.go
+++ b/tools/generator-terraform/generator/resource/component_update_func_test.go
@@ -145,7 +145,7 @@ func TestComponentUpdate_HappyPathEnabled_CommonId_SharedModels(t *testing.T) {
 				}
 				payload := *existing.Model
 				// TODO: mapping from the Schema -> Payload
-				if err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
+				if _, err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
 					return fmt.Errorf("updating %s: %+v", *id, err)
 				}
 				return nil
@@ -270,7 +270,7 @@ func TestComponentUpdate_HappyPathEnabled_CommonId_UniqueModels(t *testing.T) {
 				}
 				payload := sdkresource.UpdatePayload{}
 				// TODO: mapping from the Schema -> Payload
-				if err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
+				if _, err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
 					return fmt.Errorf("updating %s: %+v", *id, err)
 				}
 				return nil
@@ -392,7 +392,7 @@ func TestComponentUpdate_HappyPathEnabled_RegularResourceID_SharedModels(t *test
 				}
 				payload := *existing.Model
 				// TODO: mapping from the Schema -> Payload
-				if err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
+				if _, err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
 					return fmt.Errorf("updating %s: %+v", *id, err)
 				}
 				return nil
@@ -517,7 +517,7 @@ func TestComponentUpdate_HappyPathEnabled_RegularResourceID_UniqueModels(t *test
 				}
 				payload := sdkresource.UpdatePayload{}
 				// TODO: mapping from the Schema -> Payload
-				if err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
+				if _, err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
 					return fmt.Errorf("updating %s: %+v", *id, err)
 				}
 				return nil
@@ -723,7 +723,7 @@ func TestComponentUpdate_UpdateFunc_Immediate_PayloadResourceIdNoOptions(t *test
 		t.Fatalf("error: %+v", err)
 	}
 	expected := `
-			if err := client.UpdateThing(ctx, *id, payload); err != nil {
+			if _, err := client.UpdateThing(ctx, *id, payload); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 `
@@ -748,7 +748,7 @@ func TestComponentUpdate_UpdateFunc_Immediate_PayloadResourceIdOptions(t *testin
 		t.Fatalf("error: %+v", err)
 	}
 	expected := `
-			if err := client.UpdateThing(ctx, *id, payload, sdkresource.DefaultUpdateThingOperationOptions()); err != nil {
+			if _, err := client.UpdateThing(ctx, *id, payload, sdkresource.DefaultUpdateThingOperationOptions()); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 `
@@ -770,7 +770,7 @@ func TestComponentUpdate_UpdateFunc_LongRunning_PayloadResourceIdNoOptions(t *te
 		t.Fatalf("error: %+v", err)
 	}
 	expected := `
-			if err := client.UpdateThingThenPoll(ctx, *id, payload); err != nil {
+			if _, err := client.UpdateThingThenPoll(ctx, *id, payload); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 `
@@ -795,7 +795,7 @@ func TestComponentUpdate_UpdateFunc_LongRunning_PayloadResourceIdOptions(t *test
 		t.Fatalf("error: %+v", err)
 	}
 	expected := `
-			if err := client.UpdateThingThenPoll(ctx, *id, payload, sdkresource.DefaultUpdateThingOperationOptions()); err != nil {
+			if _, err := client.UpdateThingThenPoll(ctx, *id, payload, sdkresource.DefaultUpdateThingOperationOptions()); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 `


### PR DESCRIPTION
Automated methods should be happy-path, so aren't concerned with these.