### PR TITLE
Common IDs: updating the segment name for the Resource Group ID to match the Common ID

### DIFF
--- a/config/resources/resources.hcl
+++ b/config/resources/resources.hcl
@@ -4,7 +4,7 @@ service "Resources" {
   api "2020-06-01" {
     package "ResourceGroups" {
       definition "resource_group" {
-        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}"
+        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}"
         display_name = "Resource Group"
       }
     }

--- a/data/Pandora.Api/V1/ResourceManager/Terraform.cs
+++ b/data/Pandora.Api/V1/ResourceManager/Terraform.cs
@@ -102,7 +102,7 @@ resource 'example_resource' 'example' {
                             },
                             Mappings = new TerraformSchemaMappingDefinition
                             {
-                                ResourceIdSegment = "resourceGroup"
+                                ResourceIdSegment = "resourceGroupName"
                             },
                         }},
                         {"Location", new TerraformSchemaFieldDefinition

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group.go
@@ -18,7 +18,7 @@ func (commonIdResourceGroupMatcher) id() models.ParsedResourceId {
 			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			models.SubscriptionIDResourceIDSegment("subscriptionId"),
 			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroup"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
@@ -14,7 +14,7 @@ func TestCommonResourceID_ResourceGroup(t *testing.T) {
 			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			models.SubscriptionIDResourceIDSegment("subscriptionId"),
 			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroup"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
 		},
 	}
 	invalid := models.ParsedResourceId{
@@ -23,7 +23,7 @@ func TestCommonResourceID_ResourceGroup(t *testing.T) {
 			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			models.SubscriptionIDResourceIDSegment("subscriptionId"),
 			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroup"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
 			models.StaticResourceIDSegment("someResource", "someResource"),
 			models.UserSpecifiedResourceIDSegment("resourceName"),
 		},


### PR DESCRIPTION
This fixes a compilation issue upstream