### PR TITLE
tools/generator-terraform: outputting the website categories when generating the service registration

### DIFF
--- a/tools/generator-terraform/generator/definitions/template_service_registration.go
+++ b/tools/generator-terraform/generator/definitions/template_service_registration.go
@@ -21,6 +21,12 @@ func templateForServiceRegistration(input models.ServiceInput) string {
 	}
 	sort.Strings(codeForResources)
 
+	categories := make([]string, 0)
+	for _, v := range input.CategoryNames {
+		categories = append(categories, fmt.Sprintf("%q,", v))
+	}
+	sort.Strings(categories)
+
 	output := fmt.Sprintf(`
 package %[1]s
 
@@ -50,8 +56,10 @@ func (autoRegistration) Resources() []sdk.Resource {
 }
 
 func (autoRegistration) WebsiteCategories() []string {
-	return []string{}
+	return []string{
+		%[6]s
+	}
 }
-`, input.ServicePackageName, input.ServiceDisplayName, strings.Join(codeForDataSources, "\n"), strings.Join(codeForResources, "\n"), input.ProviderPrefix)
+`, input.ServicePackageName, input.ServiceDisplayName, strings.Join(codeForDataSources, "\n"), strings.Join(codeForResources, "\n"), input.ProviderPrefix, strings.Join(categories, "\n"))
 	return strings.TrimSpace(output)
 }

--- a/tools/generator-terraform/generator/definitions/template_service_registration_test.go
+++ b/tools/generator-terraform/generator/definitions/template_service_registration_test.go
@@ -43,7 +43,8 @@ func (autoRegistration) Resources() []sdk.Resource {
 }
 
 func (autoRegistration) WebsiteCategories() []string {
-	return []string{}
+	return []string{
+	}
 }
 `
 	assertTemplatedCodeMatches(t, expected, actual)
@@ -51,7 +52,10 @@ func (autoRegistration) WebsiteCategories() []string {
 
 func TestTemplateForServiceRegistration(t *testing.T) {
 	input := models.ServiceInput{
-		CategoryNames: []string{},
+		CategoryNames: []string{
+			"Category3",
+			"Category1",
+		},
 		DataSourceNames: []string{
 			// intentional to check ordering
 			"Example2",
@@ -102,7 +106,10 @@ func (autoRegistration) Resources() []sdk.Resource {
 }
 
 func (autoRegistration) WebsiteCategories() []string {
-	return []string{}
+	return []string{
+		"Category1",
+		"Category3",
+	}
 }
 `
 	assertTemplatedCodeMatches(t, expected, actual)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azurerm-private/runs/7689812605?check_suite_focus=true