### PR TITLE
data: re-introducing `deviceprovisioningservices` @ `2022-02-05`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -87,6 +87,10 @@ service "desktopvirtualization" {
   name      = "DesktopVirtualization"
   available = ["2021-09-03-preview", "2022-02-10-preview"]
 }
+service "deviceprovisioningservices" {
+  name      = "DeviceProvisioningServices"
+  available = ["2022-02-05"]
+}
 service "digitaltwins" {
   name      = "DigitalTwins"
   available = ["2020-12-01"]


### PR DESCRIPTION
The upstream Swagger PR has been merged so we can re-enable this

cc @myc2h6o - this re-enables #1249 now that the Swagger PR has been merged/vendored