### PR TITLE
tools/generator-terraform: outputting the name for the return types since the methods expect this

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -300,7 +300,7 @@ func (c %[1]s) %[2]sCompleteMatchingPredicate(ctx context.Context%[4]s, predicat
 	} else {
 		templated += fmt.Sprintf(`
 // %[2]sComplete retrieves all of the results into a single object
-func (c %[1]s) %[2]sComplete(ctx context.Context%[3]s) (%[2]sCompleteResult, error) {
+func (c %[1]s) %[2]sComplete(ctx context.Context%[3]s) (result %[2]sCompleteResult, err error) {
 	items := make([]%[5]s, 0)
 
 	page, err := c.%[2]s(ctx%[4]s)

--- a/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
@@ -200,7 +200,7 @@ func (c pandaClient) responderForList(resp *http.Response) (result ListOperation
 }
 
 // ListComplete retrieves all of the results into a single object
-func (c pandaClient) ListComplete(ctx context.Context, id PandaPop) (ListCompleteResult, error) {
+func (c pandaClient) ListComplete(ctx context.Context, id PandaPop) (result ListCompleteResult, err error) {
 	items := make([]string, 0)
 
 	page, err := c.List(ctx, id)


### PR DESCRIPTION
Fixes:

2022-08-09T05:39:01.6468229Z # github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskencryptionsets
2022-08-09T05:39:01.6549777Z ##[error]resource-manager/compute/2022-03-02/diskencryptionsets/method_listassociatedresources_autorest.go:151:3: not enough return values
2022-08-09T05:39:01.6567157Z 	have ()
2022-08-09T05:39:01.6567516Z 	want (ListAssociatedResourcesCompleteResult, error)
2022-08-09T05:39:01.6568739Z ##[error]resource-manager/compute/2022-03-02/diskencryptionsets/method_listassociatedresources_autorest.go:163:4: not enough return values
2022-08-09T05:39:01.6569455Z 	have ()
2022-08-09T05:39:01.6569753Z 	want (ListAssociatedResourcesCompleteResult, error)