### PR TITLE
skip pluralising for 'Cosmos-Db'

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
+++ b/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
@@ -566,6 +566,7 @@ func PluraliseName(input string) string {
 	skipnames := []string{
 		"Compute",
 		"ContainerInstance",
+		"Cosmos-Db",
 		"Kusto",
 		"PowerBIDedicated",
 		"ServiceLinker",


### PR DESCRIPTION
fixes namespace and path renaming.
e.g.

```csharp
namespace Pandora.Definitions.ResourceManager.CosmosDB.v2022_05_15.CosmosDbs;
```

to 
```csharp
namespace Pandora.Definitions.ResourceManager.CosmosDB.v2022_05_15.CosmosDB;
```