### PR TITLE
remove redis due to pluralisation bug dropping the 's' from Redis

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -247,10 +247,6 @@ service "purview" {
   name      = "Purview"
   available = ["2020-12-01-preview", "2021-07-01"]
 }
-service "redis" {
-  name      = "Redis"
-  available = ["2021-06-01"]
-}
 service "redisenterprise" {
   name      = "RedisEnterprise"
   available = ["2021-08-01", "2022-01-01"]


### PR DESCRIPTION
<img width="613" alt="image" src="https://user-images.githubusercontent.com/11830746/187141602-8c621376-7368-4db9-8172-d357ab0a1657.png">
