### PR TITLE
enable service list in makefile

### DIFF
--- a/tools/importer-rest-api-specs/GNUmakefile
+++ b/tools/importer-rest-api-specs/GNUmakefile
@@ -7,7 +7,11 @@ fmt:
 	find . -name '*.go' | grep -v vendor | xargs gofmt -s -w
 
 import: build
-	./importer-rest-api-specs import
+	if [ -z "$(SERVICES)" ]; then \
+		./importer-rest-api-specs import; \
+	else \
+		./importer-rest-api-specs import -services=$(SERVICES); \
+	fi
 	# note we're intentionally only using whitespace here since the others try
 	# to fix design issues, which are actually issues in the API Data
 	dotnet format whitespace --verbosity quiet ../../data/Pandora.sln


### PR DESCRIPTION
enables specific service generation via makefile
e.g. 
```shell
SERVICES=Resources,Compute make import
```