### PR TITLE
tools/importer-rest-api-specs: checking all ApiVersions when outputting the Terraform DataSources/Resources for a given Service

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigenerator/definition_service.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/definition_service.go
@@ -3,13 +3,15 @@ package dataapigenerator
 import (
 	"fmt"
 	"path"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (s Service) generateServiceDefinition() error {
+func (s Generator) generateServiceDefinition(apiVersions []models.AzureApiDefinition) error {
 	serviceDefinitionFilePath := path.Join(s.workingDirectoryForService, "ServiceDefinition.cs")
 	s.logger.Debug(fmt.Sprintf("Generating Service Definition into %q..", serviceDefinitionFilePath))
 
-	code := codeForServiceDefinition(s.namespaceForService, s.data.ServiceName, s.resourceProvider, s.terraformPackageName, s.data)
+	code := codeForServiceDefinition(s.namespaceForService, s.serviceName, s.resourceProvider, s.terraformPackageName, apiVersions)
 	if err := writeToFile(serviceDefinitionFilePath, code); err != nil {
 		return fmt.Errorf("generating Service Definition into %q: %+v", serviceDefinitionFilePath, err)
 	}
@@ -26,7 +28,7 @@ func (s Service) generateServiceDefinition() error {
 	}
 
 	s.logger.Debug(fmt.Sprintf("Creating Service Definition Generation Settings at %q", generationSettingsFilePath))
-	code = codeForServiceDefinitionGenerationSettings(s.namespaceForService, s.data.ServiceName)
+	code = codeForServiceDefinitionGenerationSettings(s.namespaceForService, s.serviceName)
 	if err := writeToFile(generationSettingsFilePath, code); err != nil {
 		return fmt.Errorf("generating Service Definition Generation Settings into %q: %+v", generationSettingsFilePath, err)
 	}

--- a/tools/importer-rest-api-specs/components/dataapigenerator/definition_version.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/definition_version.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"path"
 	"strings"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (s Service) generateVersionDefinition() error {
+func (s Generator) generateVersionDefinition(apiVersion models.AzureApiDefinition) error {
 	s.logger.Debug("Checking for an existing Generation Settings file..")
 
 	// recreate the directory
@@ -19,9 +21,9 @@ func (s Service) generateVersionDefinition() error {
 
 	// then generate the files
 	s.logger.Debug("Generating Api Version Definition..")
-	isPreview := strings.Contains(strings.ToLower(s.data.ApiVersion), "preview")
+	isPreview := strings.Contains(strings.ToLower(apiVersion.ApiVersion), "preview")
 	definitionFilePath := path.Join(s.workingDirectoryForApiVersion, "ApiVersionDefinition.cs")
-	if err := writeToFile(definitionFilePath, codeForApiVersionDefinition(s.namespaceForApiVersion, s.data.ApiVersion, isPreview, s.data.Resources)); err != nil {
+	if err := writeToFile(definitionFilePath, codeForApiVersionDefinition(s.namespaceForApiVersion, apiVersion.ApiVersion, isPreview, apiVersion.Resources)); err != nil {
 		return fmt.Errorf("writing Api Version Definition to %q: %+v", definitionFilePath, err)
 	}
 

--- a/tools/importer-rest-api-specs/components/dataapigenerator/generate_api_versions.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/generate_api_versions.go
@@ -2,14 +2,16 @@ package dataapigenerator
 
 import (
 	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (s Service) generateApiVersions() error {
-	if err := s.generateVersionDefinition(); err != nil {
+func (s Generator) generateApiVersions(apiVersion models.AzureApiDefinition) error {
+	if err := s.generateVersionDefinition(apiVersion); err != nil {
 		return fmt.Errorf("generating Version Definition for Namespace %q: %+v", s.namespaceForApiVersion, err)
 	}
 
-	for resourceName, resource := range s.data.Resources {
+	for resourceName, resource := range apiVersion.Resources {
 		s.logger.Trace(fmt.Sprintf("Generating Resource %q for API Version %q", resourceName, s.namespaceForApiVersion))
 		outputDirectory := s.workingDirectoryForResource(resourceName)
 		namespace := s.namespaceForResource(resourceName)

--- a/tools/importer-rest-api-specs/components/dataapigenerator/generate_service.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/generate_service.go
@@ -2,10 +2,12 @@ package dataapigenerator
 
 import (
 	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (s Service) generateServiceDefinitions() error {
-	s.logger.Debug(fmt.Sprintf("Processing Service %q..", s.data.ServiceName))
+func (s Generator) generateServiceDefinitions(apiVersions []models.AzureApiDefinition) error {
+	s.logger.Debug(fmt.Sprintf("Processing Service %q..", s.serviceName))
 
 	excludeList := []string{
 		// TODO: presumably we can remove this once https://github.com/hashicorp/pandora/issues/403
@@ -17,7 +19,7 @@ func (s Service) generateServiceDefinitions() error {
 	}
 
 	// finally let's output the new Service Definition
-	if err := s.generateServiceDefinition(); err != nil {
+	if err := s.generateServiceDefinition(apiVersions); err != nil {
 		return fmt.Errorf("generating Service Definition for Namespace %q: %+v", s.namespaceForService, err)
 	}
 

--- a/tools/importer-rest-api-specs/components/dataapigenerator/generate_terraform.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/generate_terraform.go
@@ -3,11 +3,13 @@ package dataapigenerator
 import (
 	"fmt"
 	"path"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (s Service) generateTerraformDefinitions() error {
+func (s Generator) generateTerraformDefinitions(apiVersion models.AzureApiDefinition) error {
 	containsTerraformResources := false
-	for _, v := range s.data.Resources {
+	for _, v := range apiVersion.Resources {
 		if v.Terraform != nil {
 			containsTerraformResources = len(v.Terraform.DataSources) > 0 || len(v.Terraform.Resources) > 0
 		}
@@ -21,7 +23,7 @@ func (s Service) generateTerraformDefinitions() error {
 		return fmt.Errorf("generating Terraform Definition for Namespace %q: %+v", s.namespaceForTerraform, err)
 	}
 
-	for resourceName, resource := range s.data.Resources {
+	for resourceName, resource := range apiVersion.Resources {
 		if resource.Terraform == nil {
 			continue
 		}

--- a/tools/importer-rest-api-specs/components/dataapigenerator/helpers.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/helpers.go
@@ -14,15 +14,15 @@ const restApiSpecsLicence = `
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 `
 
-func (s Service) namespaceForResource(resourceName string) string {
+func (s Generator) namespaceForResource(resourceName string) string {
 	return fmt.Sprintf("%s.%s", s.namespaceForApiVersion, s.packageNameForResource(resourceName))
 }
 
-func (s Service) packageNameForResource(resourceName string) string {
+func (s Generator) packageNameForResource(resourceName string) string {
 	return strings.Title(resourceName)
 }
 
-func (s Service) workingDirectoryForResource(resource string) string {
+func (s Generator) workingDirectoryForResource(resource string) string {
 	dir := s.workingDirectoryForApiVersion
 	return path.Join(dir, resource)
 }

--- a/tools/importer-rest-api-specs/components/dataapigenerator/interface.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/interface.go
@@ -2,12 +2,10 @@ package dataapigenerator
 
 import (
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-type Service struct {
+type Generator struct {
 	apiVersionPackageName         string
-	data                          models.AzureApiDefinition
 	logger                        hclog.Logger
 	namespaceForService           string
 	namespaceForApiVersion        string
@@ -15,6 +13,7 @@ type Service struct {
 	outputDirectory               string
 	resourceProvider              *string
 	rootNamespace                 string
+	serviceName                   string
 	swaggerGitSha                 string
 	terraformPackageName          *string
 	workingDirectoryForService    string

--- a/tools/importer-rest-api-specs/components/dataapigenerator/package.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/package.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (s Service) generateResources(resourceName, namespace string, resource models.AzureApiResource, workingDirectory string) error {
+func (s Generator) generateResources(resourceName, namespace string, resource models.AzureApiResource, workingDirectory string) error {
 	s.logger.Debug(fmt.Sprintf("Generating %q (Resource %q)..", namespace, resourceName))
 
 	if err := recreateDirectory(workingDirectory, s.logger); err != nil {

--- a/tools/importer-rest-api-specs/components/dataapigenerator/service.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/service.go
@@ -10,51 +10,64 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-func NewService(data models.AzureApiDefinition, outputDirectory, rootNamespace, swaggerGitSha string, resourceProvider, terraformPackageName *string, logger hclog.Logger) *Service {
-	normalisedServiceName := strings.ReplaceAll(data.ServiceName, "-", "")
+func NewForService(serviceName, outputDirectory, rootNamespace, swaggerGitSha string, resourceProvider, terraformPackageName *string, logger hclog.Logger) *Generator {
+	normalisedServiceName := strings.ReplaceAll(serviceName, "-", "")
 	serviceNamespace := fmt.Sprintf("%s.%s", rootNamespace, strings.Title(normalisedServiceName))
 	serviceWorkingDirectory := path.Join(outputDirectory, rootNamespace, strings.Title(normalisedServiceName))
 	terraformNamespace := fmt.Sprintf("%s.Terraform", serviceNamespace)
 	terraformWorkingDirectory := path.Join(serviceWorkingDirectory, "Terraform")
-	normalizedApiVersion := normalizeApiVersion(data.ApiVersion)
 
-	return &Service{
-		apiVersionPackageName:         normalizedApiVersion,
-		data:                          data,
-		logger:                        logger,
-		namespaceForApiVersion:        fmt.Sprintf("%s.%s", serviceNamespace, normalizedApiVersion),
-		namespaceForService:           serviceNamespace,
-		namespaceForTerraform:         terraformNamespace,
-		outputDirectory:               outputDirectory,
-		resourceProvider:              resourceProvider,
-		rootNamespace:                 rootNamespace,
-		swaggerGitSha:                 swaggerGitSha,
-		terraformPackageName:          terraformPackageName,
-		workingDirectoryForService:    serviceWorkingDirectory,
-		workingDirectoryForTerraform:  terraformWorkingDirectory,
-		workingDirectoryForApiVersion: path.Join(serviceWorkingDirectory, normalizedApiVersion),
+	return &Generator{
+		logger:                       logger,
+		namespaceForService:          serviceNamespace,
+		namespaceForTerraform:        terraformNamespace,
+		outputDirectory:              outputDirectory,
+		resourceProvider:             resourceProvider,
+		rootNamespace:                rootNamespace,
+		serviceName:                  serviceName,
+		swaggerGitSha:                swaggerGitSha,
+		terraformPackageName:         terraformPackageName,
+		workingDirectoryForService:   serviceWorkingDirectory,
+		workingDirectoryForTerraform: terraformWorkingDirectory,
 	}
 }
 
-func (s *Service) Generate() error {
+func NewForApiVersion(serviceName, apiVersion, outputDirectory, rootNamespace, swaggerGitSha string, resourceProvider, terraformPackageName *string, logger hclog.Logger) *Generator {
+	service := NewForService(serviceName, outputDirectory, rootNamespace, swaggerGitSha, resourceProvider, terraformPackageName, logger)
+
+	normalizedApiVersion := normalizeApiVersion(apiVersion)
+
+	service.apiVersionPackageName = normalizedApiVersion
+	service.namespaceForApiVersion = fmt.Sprintf("%s.%s", service.namespaceForService, normalizedApiVersion)
+	service.workingDirectoryForApiVersion = path.Join(service.workingDirectoryForService, normalizedApiVersion)
+
+	return service
+}
+
+func (s *Generator) GenerateForService(apiVersions []models.AzureApiDefinition) error {
 	s.logger.Debug(fmt.Sprintf("[STAGE] Updating the Output Revision ID to %q", s.swaggerGitSha))
 	if err := outputRevisionId(s.outputDirectory, s.rootNamespace, s.swaggerGitSha); err != nil {
 		return fmt.Errorf("outputting the Revision Id: %+v", err)
 	}
 
-	if err := s.generateServiceDefinitions(); err != nil {
+	s.logger.Debug(fmt.Sprintf("[STAGE] Generating the Service Definitions.."))
+	if err := s.generateServiceDefinitions(apiVersions); err != nil {
 		return fmt.Errorf("generating Service Definitions: %+v", err)
 	}
 
+	return nil
+}
+
+func (s *Generator) GenerateForApiVersion(apiVersion models.AzureApiDefinition) error {
 	s.logger.Debug("[STAGE] Generating API Definitions..")
-	if err := s.generateApiVersions(); err != nil {
+	if err := s.generateApiVersions(apiVersion); err != nil {
 		return fmt.Errorf("generating API Versions: %+v", err)
 	}
 
 	if s.terraformPackageName != nil {
 		s.logger.Debug("Generating Terraform Definitions")
 
-		if err := s.generateTerraformDefinitions(); err != nil {
+		if err := s.generateTerraformDefinitions(apiVersion); err != nil {
 			return fmt.Errorf("generating Terraform Definitions: %+v", err)
 		}
 	} else {

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_service_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_service_definition.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func codeForServiceDefinition(namespace, serviceName string, resourceProvider, terraformPackage *string, data models.AzureApiDefinition) string {
+func codeForServiceDefinition(namespace, serviceName string, resourceProvider, terraformPackage *string, apiVersions []models.AzureApiDefinition) string {
 	rp := "null"
 	if resourceProvider != nil {
 		rp = fmt.Sprintf("%q", *resourceProvider)
@@ -20,13 +20,15 @@ func codeForServiceDefinition(namespace, serviceName string, resourceProvider, t
 	}
 
 	terraformResources := make([]string, 0)
-	for _, resource := range data.Resources {
-		if resource.Terraform == nil {
-			continue
-		}
+	for _, apiVersion := range apiVersions {
+		for _, resource := range apiVersion.Resources {
+			if resource.Terraform == nil {
+				continue
+			}
 
-		for _, v := range resource.Terraform.Resources {
-			terraformResources = append(terraformResources, fmt.Sprintf("new Terraform.%sResource(),", v.ResourceName))
+			for _, v := range resource.Terraform.Resources {
+				terraformResources = append(terraformResources, fmt.Sprintf("new Terraform.%sResource(),", v.ResourceName))
+			}
 		}
 	}
 	sort.Strings(terraformResources)

--- a/tools/importer-rest-api-specs/pipeline/run_importer.go
+++ b/tools/importer-rest-api-specs/pipeline/run_importer.go
@@ -3,78 +3,122 @@ package pipeline
 import (
 	"fmt"
 	"log"
-	"os"
-	"sync"
+	"sort"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/discovery"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 func runImporter(input RunInput, generationData []discovery.ServiceInput, swaggerGitSha string) error {
-	var wg sync.WaitGroup
+	// group the API Versions by Service
+	dataByServices := make(map[string][]discovery.ServiceInput)
 	for _, v := range generationData {
-		wg.Add(1)
-		go func(v discovery.ServiceInput) {
-			logger := input.Logger.Named(fmt.Sprintf("Importer Service %q / API Version %q", v.ServiceName, v.ApiVersion))
-
-			task := pipelineTask{}
-			logger.Trace("Task: Parsing Data..")
-			data, err := task.parseDataForApiVersion(v, logger)
-			if err != nil {
-				logger.Error("parsing data for Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err)
-				wg.Done()
-				os.Exit(1)
-				return
-			}
-			if data == nil {
-				// e.g. service is ignored
-				logger.Trace("no data returned - ignored etc - skipping")
-				wg.Done()
-				return
-			}
-
-			// generate the schema
-			logger.Trace(fmt.Sprintf("generating Terraform Details for Service %q / Version %q", v.ServiceName, v.ApiVersion))
-			terraformDetails, err := task.generateTerraformDetails(v, data, logger.Named("TerraformDetails"))
-			if err != nil {
-				logger.Error(fmt.Sprintf("generating Terraform Details for Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err))
-				wg.Done()
-				os.Exit(1)
-				return
-			}
-			// TODO: stuff n things @stephybun
-			log.Printf("Got Stuff: %+v", terraformDetails)
-
-			// build the tests
-			logger.Trace(fmt.Sprintf("generating Terraform Tests for Service %q / Version %q", v.ServiceName, v.ApiVersion))
-			terraformDetails, err = task.generateTerraformTests(v, *terraformDetails, logger.Named("TerraformTests"))
-			if err != nil {
-				logger.Error(fmt.Sprintf("generating Terraform Tests for Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err))
-				wg.Done()
-				os.Exit(1)
-				return
-			}
-
-			logger.Trace("Task: Applying Overrides from Existing Data..")
-			data, err = task.applyOverridesFromExistingData(*data, input.DataApiEndpoint, logger)
-			if err != nil {
-				logger.Error("applying overrides for existing data for Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err)
-				wg.Done()
-				os.Exit(1)
-				return
-			}
-
-			logger.Trace("Task: Generating Data API Definitions..")
-			if err := task.generateApiDefinitions(v, *data, swaggerGitSha, logger); err != nil {
-				log.Printf("generating API Definitions for Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err)
-				wg.Done()
-				os.Exit(1)
-				return
-			}
-
-			wg.Done()
-		}(v)
+		existing, ok := dataByServices[v.ServiceName]
+		if !ok {
+			existing = append(existing, v)
+			dataByServices[v.ServiceName] = existing
+			continue
+		}
+		dataByServices[v.ServiceName] = []discovery.ServiceInput{
+			v,
+		}
 	}
 
-	wg.Wait()
+	// sort these so it's easier for parsing/tracing
+	serviceNames := make([]string, 0)
+	for serviceName := range dataByServices {
+		serviceNames = append(serviceNames, serviceName)
+	}
+	sort.Strings(serviceNames)
+
+	// then parse/process the data for each of the API Versions for each service
+	for _, serviceName := range serviceNames {
+		serviceDetails := dataByServices[serviceName]
+		logger := input.Logger.Named(fmt.Sprintf("Importer for Service %q", serviceName))
+		if err := runImportForService(input, serviceName, serviceDetails, logger, swaggerGitSha); err != nil {
+			return fmt.Errorf("parsing data for Service %q: %+v", serviceName, err)
+		}
+	}
+
+	return nil
+}
+
+func runImportForService(input RunInput, serviceName string, apiVersionsForService []discovery.ServiceInput, logger hclog.Logger, swaggerGitSha string) error {
+	task := pipelineTask{}
+	apiVersions := make([]models.AzureApiDefinition, 0)
+	rootNamespace := ""
+	var resourceProvider *string
+	var terraformPackageName *string
+
+	for _, apiVersion := range apiVersionsForService {
+		versionLogger := logger.Named(fmt.Sprintf("Importer for API Version %q", apiVersion.ApiVersion))
+
+		// populate the service information based on this api version
+		if rootNamespace == "" {
+			rootNamespace = apiVersion.RootNamespace
+		}
+		if rootNamespace != "" && rootNamespace != apiVersion.RootNamespace {
+			// TODO: this is possible, just requires refactoring this.
+			return fmt.Errorf("different root namespaces were found for different api versions for the same service - previously found %q but got %q", rootNamespace, apiVersion.RootNamespace)
+		}
+		if resourceProvider == nil && apiVersion.ResourceProvider != nil {
+			rpName := *apiVersion.ResourceProvider
+			resourceProvider = &rpName
+		}
+		if terraformPackageName == nil && apiVersion.TerraformServiceDefinition != nil {
+			packageName := apiVersion.TerraformServiceDefinition.TerraformPackageName
+			terraformPackageName = &packageName
+		}
+
+		versionLogger.Trace("Task: Parsing Data..")
+		dataForApiVersion, err := task.parseDataForApiVersion(apiVersion, versionLogger)
+		if err != nil {
+			return fmt.Errorf("parsing data for Service %q / Version %q: %+v", apiVersion.ServiceName, apiVersion.ApiVersion, err)
+		}
+		if dataForApiVersion == nil {
+			// e.g. service is ignored
+			versionLogger.Trace("no data returned - ignored etc - skipping")
+			return nil
+		}
+
+		// generate the schema
+		versionLogger.Trace(fmt.Sprintf("generating Terraform Details for Service %q / Version %q", apiVersion.ServiceName, apiVersion.ApiVersion))
+		terraformDetails, err := task.generateTerraformDetails(apiVersion, dataForApiVersion, versionLogger.Named("TerraformDetails"))
+		if err != nil {
+			return fmt.Errorf(fmt.Sprintf("generating Terraform Details for Service %q / Version %q: %+v", apiVersion.ServiceName, apiVersion.ApiVersion, err))
+		}
+		// TODO: stuff n things @stephybun
+		log.Printf("Got Stuff: %+v", terraformDetails)
+
+		// build the tests
+		versionLogger.Trace(fmt.Sprintf("generating Terraform Tests for Service %q / Version %q", apiVersion.ServiceName, apiVersion.ApiVersion))
+		terraformDetails, err = task.generateTerraformTests(apiVersion, *terraformDetails, versionLogger.Named("TerraformTests"))
+		if err != nil {
+			return fmt.Errorf(fmt.Sprintf("generating Terraform Tests for Service %q / Version %q: %+v", apiVersion.ServiceName, apiVersion.ApiVersion, err))
+		}
+
+		versionLogger.Trace("Task: Applying Overrides from Existing Data..")
+		dataForApiVersion, err = task.applyOverridesFromExistingData(*dataForApiVersion, input.DataApiEndpoint, versionLogger)
+		if err != nil {
+			return fmt.Errorf("applying overrides for existing data for Service %q / Version %q: %+v", apiVersion.ServiceName, apiVersion.ApiVersion, err)
+		}
+
+		versionLogger.Trace("Task: Generating Data API Definitions..")
+		if err := task.generateApiDefinitions(apiVersion, *dataForApiVersion, swaggerGitSha, versionLogger); err != nil {
+			return fmt.Errorf("generating API Definitions for Service %q / Version %q: %+v", apiVersion.ServiceName, apiVersion.ApiVersion, err)
+		}
+
+		// finally once we have all of the information for this API version, add it to the list so that we can
+		// generate the canonical "Terraform Data Sources/Resources" for this Service
+		apiVersions = append(apiVersions, *dataForApiVersion)
+		return nil
+	}
+
+	logger.Trace("Task: Generating Service Definitions..")
+	if err := task.generateServiceDefinitions(serviceName, input.OutputDirectory, rootNamespace, swaggerGitSha, resourceProvider, terraformPackageName, apiVersions, logger.Named("Service Definitions")); err != nil {
+		return fmt.Errorf("generating Service Definitions for %q: %+v", serviceName, err)
+	}
+
 	return nil
 }

--- a/tools/importer-rest-api-specs/pipeline/task_generate_api_definitions.go
+++ b/tools/importer-rest-api-specs/pipeline/task_generate_api_definitions.go
@@ -15,8 +15,8 @@ func (pipelineTask) generateApiDefinitions(input discovery.ServiceInput, data mo
 	if input.TerraformServiceDefinition != nil {
 		terraformPackageName = &input.TerraformServiceDefinition.TerraformPackageName
 	}
-	dataApiGenerator := dataapigenerator.NewService(data, input.OutputDirectory, input.RootNamespace, swaggerGitSha, input.ResourceProvider, terraformPackageName, logger.Named("Data API Generator"))
-	if err := dataApiGenerator.Generate(); err != nil {
+	dataApiGenerator := dataapigenerator.NewForApiVersion(data.ServiceName, data.ApiVersion, input.OutputDirectory, input.RootNamespace, swaggerGitSha, input.ResourceProvider, terraformPackageName, logger.Named("Data API Generator"))
+	if err := dataApiGenerator.GenerateForApiVersion(data); err != nil {
 		err = fmt.Errorf("generating Data API Definitions for Service %q / API Version %q: %+v", data.ServiceName, data.ApiVersion, err)
 		logger.Info(fmt.Sprintf("❌ Service %q - Api Version %q", data.ServiceName, data.ApiVersion))
 		logger.Error(fmt.Sprintf("     💥 Error: %+v", err))

--- a/tools/importer-rest-api-specs/pipeline/task_generate_service_definitions.go
+++ b/tools/importer-rest-api-specs/pipeline/task_generate_service_definitions.go
@@ -1,0 +1,19 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigenerator"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+func (pipelineTask) generateServiceDefinitions(serviceName, outputDirectory, rootNamespace, swaggerGitSha string, resourceProvider, terraformPackageName *string, apiVersions []models.AzureApiDefinition, logger hclog.Logger) error {
+	s := dataapigenerator.NewForService(serviceName, outputDirectory, rootNamespace, swaggerGitSha, resourceProvider, terraformPackageName, logger)
+
+	if err := s.GenerateForService(apiVersions); err != nil {
+		return fmt.Errorf("generating service %q: %+v", serviceName, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit fixes #1376 by passing all ApiVersions to the Service Definitions generation such that we have all of the Terraform Data Sources & Resources present within a given API Version.

This ensures that the list of Terraform Data Sources & Resources is consistent, meaning this will no longer change repeatedly between regenerations.