### PR TITLE
Data API: filtering to the current assembly when using reflection

### DIFF
--- a/data/Pandora.Data/Transformers/Model.cs
+++ b/data/Pandora.Data/Transformers/Model.cs
@@ -279,8 +279,8 @@ public static class Model
         }
 
         // 2: find all of the implementations for this type
-        var allTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes());
-        var implementations = allTypes.Where(t => t.IsAssignableTo(input) && !t.IsAbstract && !t.IsInterface).ToList();
+        var allTypes = AppDomain.CurrentDomain.GetAssemblies().Where(x => x.FullName == input.Assembly.FullName).SelectMany(x => x.GetTypes());
+        var implementations = allTypes.Where(t => t.Namespace == input.Namespace && t.IsAssignableTo(input) && !t.IsAbstract && !t.IsInterface).ToList();
         return implementations;
     }
 
@@ -369,8 +369,8 @@ public static class Model
                 }
 
                 // 2: find all of the implementations for this type
-                var allTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes());
-                var implementations = allTypes.Where(t => t.IsAssignableTo(input) && !t.IsAbstract && !t.IsInterface).ToList();
+                var allTypes = AppDomain.CurrentDomain.GetAssemblies().Where(x => x.FullName == input.Assembly.FullName).SelectMany(x => x.GetTypes());
+                var implementations = allTypes.Where(t => t.Namespace == input.Namespace && t.IsAssignableTo(input) && !t.IsAbstract && !t.IsInterface).ToList();
                 foreach (var implementation in implementations)
                 {
                     var modelName = implementation.Name.RemoveSuffixFromTypeName();

--- a/data/Pandora.Definitions/Discovery/Services.cs
+++ b/data/Pandora.Definitions/Discovery/Services.cs
@@ -10,8 +10,8 @@ public static class Services
     public static List<ServiceDefinition> WithinServicesDefinition(ServicesDefinition input)
     {
         var containingNamespace = Helpers.ContainingNamespaceForType(input.GetType());
-        var types = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.DefinedTypes);
-        var servicesTypes = types.Where(t => t.IsAssignableTo(typeof(ServiceDefinition)) && t.FullName.StartsWith(containingNamespace)).ToList();
+        var types = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName == input.GetType().Assembly.FullName).SelectMany(a => a.DefinedTypes);
+        var servicesTypes = types.Where(t => t.FullName.StartsWith(containingNamespace) && t.IsAssignableTo(typeof(ServiceDefinition))).ToList();
         var services = servicesTypes.Select(Activator.CreateInstance).Select(t => t as ServiceDefinition).ToList();
         return services;
     }

--- a/data/Pandora.Definitions/Discovery/Versions.cs
+++ b/data/Pandora.Definitions/Discovery/Versions.cs
@@ -10,7 +10,7 @@ public static class Versions
     public static List<ApiVersionDefinition> WithinServiceDefinition(ServiceDefinition input)
     {
         var containingNamespace = Helpers.ContainingNamespaceForType(input.GetType());
-        var types = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.DefinedTypes);
+        var types = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName == input.GetType().Assembly.FullName).SelectMany(a => a.DefinedTypes);
         // The FullName for a Type is `Namespace.TypeName` - so whilst searching for a prefix of `Namespace` works in most cases
         // some services use the same prefix as other services - for example RecoveryServices, RecoveryServicesBackup & RecoveryServicesSiteRecovery
         // as such we check for a prefix of `Namespace.` which'll exact match this namespace, rather than all 3 in this instance
@@ -22,7 +22,7 @@ public static class Versions
             namespaceToSearchFor = containingNamespace;
         }
 
-        var versionDefinitionTypes = types.Where(t => t.IsAssignableTo(typeof(ApiVersionDefinition)) && t.FullName.StartsWith(namespaceToSearchFor)).ToList();
+        var versionDefinitionTypes = types.Where(t => t.FullName.StartsWith(namespaceToSearchFor) && t.IsAssignableTo(typeof(ApiVersionDefinition))).ToList();
         var versionDefinitions = versionDefinitionTypes.Select(Activator.CreateInstance).Select(t => t as ApiVersionDefinition).ToList();
         return versionDefinitions;
     }


### PR DESCRIPTION
This improves the performance when loading models/discriminated types:

from:
> 2673.2997ms
> 2648.0048ms
> 2651.0066ms

to:

> 1029.4117ms
> 1041.4719ms
> 1031.9356ms
> 1025.5475ms
> 1036.7969ms
> 1039.169ms
> 1045.0298ms

Still work to do, but that's a worthwhile improvement