### PR TITLE
Schema: pull ResourceGroupName into topLevelModels for resources without parent resource

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_schema.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_schema.go
@@ -202,7 +202,7 @@ var commonSchemaFieldTypesToDotNetTypes = map[resourcemanager.TerraformSchemaFie
 	resourcemanager.TerraformSchemaFieldTypeIdentitySystemOrUserAssigned:  "CommonSchema.SystemOrUserAssignedIdentity",
 	resourcemanager.TerraformSchemaFieldTypeIdentityUserAssigned:          "CommonSchema.UserAssignedIdentity",
 	resourcemanager.TerraformSchemaFieldTypeLocation:                      "CommonSchema.Location",
-	resourcemanager.TerraformSchemaFieldTypeResourceGroup:                 "CommonSchema.ResourceGroup",
+	resourcemanager.TerraformSchemaFieldTypeResourceGroup:                 "CommonSchema.ResourceGroupName",
 	resourcemanager.TerraformSchemaFieldTypeTags:                          "CommonSchema.Tags",
 	resourcemanager.TerraformSchemaFieldTypeZone:                          "CommonSchema.ZoneSingle",
 	resourcemanager.TerraformSchemaFieldTypeZones:                         "CommonSchema.ZonesMultiple",

--- a/tools/importer-rest-api-specs/components/schema/resource_id.go
+++ b/tools/importer-rest-api-specs/components/schema/resource_id.go
@@ -42,8 +42,19 @@ func (b Builder) identityTopLevelFieldsWithinResourceID(input resourcemanager.Re
 					HclName:  parentResourceSchemaField,
 				}
 			}
-
 			// TODO: perhaps add the components here instead, aside from Subscription/Tenant ID etc?
+		} else {
+			// NOTE: Happy path case where we have a "standard" ID `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/...`
+			if input.Segments[2].FixedValue != nil && *input.Segments[2].FixedValue == "resourceGroups" {
+				out["ResourceGroupName"] = resourcemanager.TerraformSchemaFieldDefinition{
+					ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeResourceGroup,
+					},
+					Required: true,
+					ForceNew: true,
+					HclName:  "resource_group_name",
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
VirtualMachine example:
```go
type VirtualMachineResourceSchema struct {
        AdditionalCapabilities  []VirtualMachineResourceAdditionalCapabilitiesSchema     `tfschema:"additional_capabilities"`
        ApplicationProfile      []VirtualMachineResourceApplicationProfileSchema         `tfschema:"application_profile"`
        AvailabilitySet         []VirtualMachineResourceSubResourceSchema                `tfschema:"availability_set"`
        BillingProfile          []VirtualMachineResourceBillingProfileSchema             `tfschema:"billing_profile"`
        CapacityReservation     []VirtualMachineResourceCapacityReservationProfileSchema `tfschema:"capacity_reservation"`
        DiagnosticsProfile      []VirtualMachineResourceDiagnosticsProfileSchema         `tfschema:"diagnostics_profile"`
        EvictionPolicy          string                                                   `tfschema:"eviction_policy"`
        ExtensionsTimeBudget    string                                                   `tfschema:"extensions_time_budget"`
        HardwareProfile         []VirtualMachineResourceHardwareProfileSchema            `tfschema:"hardware_profile"`
        Host                    []VirtualMachineResourceSubResourceSchema                `tfschema:"host"`
        HostGroup               []VirtualMachineResourceSubResourceSchema                `tfschema:"host_group"`
        Identity                identity.ModelSystemAssignedUserAssigned                 `tfschema:"identity"`
        InstanceView            []VirtualMachineResourceVirtualMachineInstanceViewSchema `tfschema:"instance_view"`
        Location                string                                                   `tfschema:"location"`
        Name                    string                                                   `tfschema:"name"`
        NetworkProfile          []VirtualMachineResourceNetworkProfileSchema             `tfschema:"network_profile"`
        OsProfile               []VirtualMachineResourceOSProfileSchema                  `tfschema:"os_profile"`
        PlatformFaultDomain     int64                                                    `tfschema:"platform_fault_domain"`
        Priority                string                                                   `tfschema:"priority"`
        ProximityPlacementGroup []VirtualMachineResourceSubResourceSchema                `tfschema:"proximity_placement_group"`
        ResourceGroupName       string                                                   `tfschema:"resource_group_name"`
        ScaleSet                []VirtualMachineResourceSubResourceSchema                `tfschema:"scale_set"`
        ScheduledEventsProfile  []VirtualMachineResourceScheduledEventsProfileSchema     `tfschema:"scheduled_events_profile"`
        SecurityProfile         []VirtualMachineResourceSecurityProfileSchema            `tfschema:"security_profile"`
        StorageProfile          []VirtualMachineResourceStorageProfileSchema             `tfschema:"storage_profile"`
        Tags                    map[string]interface{}                                   `tfschema:"tags"`
        TimeCreated             string                                                   `tfschema:"time_created"`
        UserData                string                                                   `tfschema:"user_data"`
        VmId                    string                                                   `tfschema:"vm_id"`
}
...

func (r VirtualMachineResource) Arguments() map[string]*pluginsdk.Schema {
        return map[string]*pluginsdk.Schema{
                "location": commonschema.Location(),
                "name": {
                        ForceNew: true,
                        Required: true,
                        Type:     pluginsdk.TypeString,
                },
                "resource_group_name": commonschema.ResourceGroupName(),
                "additional_capabilities": {
```

