### PR TITLE
Schema: fixes for RG special Case and missing `Computed` attributes

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_schema.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_schema.go
@@ -51,7 +51,8 @@ func dotNetFieldDefinitionForTerraformSchemaField(name string, input resourceman
 		return nil, fmt.Errorf("determining dotnet type name for field object definition: %+v", err)
 	}
 	attributes := make([]string, 0)
-	if input.Computed {
+	// TODO - The Or case here shouldn't be needed, however, some deeply nested models are not currently being processed, so this will catch those for now and just enforces the rule in any case
+	if input.Computed || (!input.Optional && !input.Required) {
 		attributes = append(attributes, "[Computed]")
 	}
 	attributes = append(attributes, fmt.Sprintf("[HclName(%q)]", input.HclName))

--- a/tools/importer-rest-api-specs/components/schema/resource_id.go
+++ b/tools/importer-rest-api-specs/components/schema/resource_id.go
@@ -45,7 +45,7 @@ func (b Builder) identityTopLevelFieldsWithinResourceID(input resourcemanager.Re
 			// TODO: perhaps add the components here instead, aside from Subscription/Tenant ID etc?
 		} else {
 			// NOTE: Happy path case where we have a "standard" ID `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/...`
-			if input.Segments[2].FixedValue != nil && *input.Segments[2].FixedValue == "resourceGroups" {
+			if len(input.Segments) != 4 && input.Segments[2].FixedValue != nil && *input.Segments[2].FixedValue == "resourceGroups" {
 				out["ResourceGroupName"] = resourcemanager.TerraformSchemaFieldDefinition{
 					ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
 						Type: resourcemanager.TerraformSchemaFieldTypeResourceGroup,


### PR DESCRIPTION
skip rename when it's a resource group id explicitly
add catchall for Computed in TF Schema classes