### PR TITLE
tools/importer-rest-api-specs: outputting the Complete test method using a `.` rather than a `,`

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_tests.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_tests.go
@@ -43,7 +43,7 @@ func addCompleteTestConfig(input *string) string {
 	if input != nil {
 		return fmt.Sprintf(`@"
 %s
-	",AsTerraformTestConfig()`, *input)
+	".AsTerraformTestConfig()`, *input)
 	}
 
 	return "null"


### PR DESCRIPTION
Fixes a typo