### PR TITLE
tools/importer-rest-api-specs: ignoring `OperationStatus`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/internal/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/helpers.go
@@ -19,6 +19,9 @@ func OperationShouldBeIgnored(operationUri string) bool {
 	if strings.Contains(strings.ToLower(operationUri), "/operationresults/") {
 		return true
 	}
+	if strings.Contains(strings.ToLower(operationUri), "/operationstatus/") {
+		return true
+	}
 	if strings.Contains(strings.ToLower(operationUri), "/operationstatuses/") {
 		return true
 	}


### PR DESCRIPTION
These shouldn't be output because they're LRO operations we instead call directly, so there's no point outputting these specifically

Removes this operation:

> /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/operationStatus/{operationId}

from https://github.com/hashicorp/pandora/pull/1537