### PR TITLE
tools/generator-terraform: support for Manual Mappings

### DIFF
--- a/tools/generator-terraform/generator/mappings/assignment_direct.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct.go
@@ -23,6 +23,8 @@ var _ assignmentType = directAssignmentLine{}
 
 type directAssignmentLine struct{}
 
+// TODO: support for when Mapping is Computed
+
 func (d directAssignmentLine) assignmentForCreateUpdateMapping(mapping resourcemanager.FieldMappingDefinition, schemaModel resourcemanager.TerraformSchemaModelDefinition, sdkModel resourcemanager.ModelDetails, sdkConstant *assignmentConstantDetails) (*string, error) {
 	schemaFieldName, err := singleFieldNameFromFieldPath(mapping.From.SchemaFieldPath)
 	if err != nil {

--- a/tools/generator-terraform/generator/mappings/assignment_manual.go
+++ b/tools/generator-terraform/generator/mappings/assignment_manual.go
@@ -1,0 +1,139 @@
+package mappings
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ assignmentType = manualAssignmentLine{}
+
+type manualAssignmentLine struct{}
+
+// TODO: support for when Mapping is Computed
+
+func (m manualAssignmentLine) assignmentForCreateUpdateMapping(mapping resourcemanager.FieldMappingDefinition, schemaModel resourcemanager.TerraformSchemaModelDefinition, sdkModel resourcemanager.ModelDetails, sdkConstant *assignmentConstantDetails) (*string, error) {
+	if mapping.Manual == nil {
+		return nil, fmt.Errorf("manual mapping had no manual definition")
+	}
+
+	schemaFieldName, err := singleFieldNameFromFieldPath(mapping.From.SchemaFieldPath)
+	if err != nil {
+		return nil, fmt.Errorf("obtaining Schema Field Name from Field Path %q: %+v", mapping.From.SchemaFieldPath, err)
+	}
+	schemaField, ok := schemaModel.Fields[*schemaFieldName]
+	if !ok {
+		return nil, fmt.Errorf("the Field %q for Schema Model %q was not found", *schemaFieldName, mapping.From.SchemaModelName)
+	}
+
+	sdkFieldName, err := singleFieldNameFromFieldPath(mapping.To.SdkFieldPath)
+	if err != nil {
+		return nil, fmt.Errorf("obtaining SDK Field Name from Field Path %q: %+v", mapping.To.SdkFieldPath, err)
+	}
+	sdkField, ok := sdkModel.Fields[*sdkFieldName]
+	if !ok {
+		return nil, fmt.Errorf("the Field %q for SDK Model %q was not found", *sdkFieldName, mapping.To.SdkModelName)
+	}
+
+	if schemaField.Required {
+		line := fmt.Sprintf(`
+%[1]s, err := %[4]s(input.%[2]s)
+if err != nil {
+		return fmt.Errorf("flattening %[2]q: %%+v", err)
+}
+out.%[3]s = %[1]s
+`, sdkField.JsonName, mapping.From.SchemaFieldPath, mapping.To.SdkFieldPath, mapping.Manual.MethodName)
+		if sdkField.Optional {
+			line = fmt.Sprintf(`
+%[1]s, err := %[4]s(input.%[2]s)
+if err != nil {
+	return fmt.Errorf("flattening %[2]q: %%+v", err)
+}
+out.%[3]s = &%[1]s
+`, sdkField.JsonName, mapping.From.SchemaFieldPath, mapping.To.SdkFieldPath, mapping.Manual.MethodName)
+		}
+		return &line, nil
+	}
+
+	if sdkField.Required {
+		// if the SDK Field is Required but the Schema Field is Optional this is a Data Issue
+		// TODO: handle where it's defaulted?
+		return nil, fmt.Errorf("the Sdk Model %q Field %q was Required but Schema Model %q Field %q was Optional but must be Required", mapping.To.SdkModelName, mapping.To.SdkFieldPath, mapping.From.SchemaModelName, mapping.From.SchemaFieldPath)
+	}
+
+	// Optional -> Optional
+	line := fmt.Sprintf(`
+if input.%[2]s != nil {
+	%[1]s, err := %[4]s(*input.%[2]s)
+	if err != nil {
+		return fmt.Errorf("flattening %[2]q: %%+v", err)
+	}
+	out.%[3]s = &%[1]s
+}
+`, sdkField.JsonName, mapping.From.SchemaFieldPath, mapping.To.SdkFieldPath, mapping.Manual.MethodName)
+	return &line, nil
+}
+
+func (m manualAssignmentLine) assignmentForReadMapping(mapping resourcemanager.FieldMappingDefinition, schemaModel resourcemanager.TerraformSchemaModelDefinition, sdkModel resourcemanager.ModelDetails, sdkConstant *assignmentConstantDetails) (*string, error) {
+	if mapping.Manual == nil {
+		return nil, fmt.Errorf("manual mapping had no manual definition")
+	}
+
+	schemaFieldName, err := singleFieldNameFromFieldPath(mapping.From.SchemaFieldPath)
+	if err != nil {
+		return nil, fmt.Errorf("obtaining Schema Field Name from Field Path %q: %+v", mapping.From.SchemaFieldPath, err)
+	}
+	schemaField, ok := schemaModel.Fields[*schemaFieldName]
+	if !ok {
+		return nil, fmt.Errorf("the Field %q for Schema Model %q was not found", *schemaFieldName, mapping.From.SchemaModelName)
+	}
+
+	sdkFieldName, err := singleFieldNameFromFieldPath(mapping.To.SdkFieldPath)
+	if err != nil {
+		return nil, fmt.Errorf("obtaining SDK Field Name from Field Path %q: %+v", mapping.To.SdkFieldPath, err)
+	}
+	sdkField, ok := sdkModel.Fields[*sdkFieldName]
+	if !ok {
+		return nil, fmt.Errorf("the Field %q for SDK Model %q was not found", *sdkFieldName, mapping.To.SdkModelName)
+	}
+
+	if schemaField.Required {
+		line := fmt.Sprintf(`
+%[1]s, err := %[4]s(input.%[3]s)
+if err != nil {
+		return fmt.Errorf("flattening %[3]q: %%+v", err)
+}
+out.%[2]s = %[1]s
+`, sdkField.JsonName, mapping.From.SchemaFieldPath, mapping.To.SdkFieldPath, mapping.Manual.MethodName)
+		if sdkField.Optional {
+			line = fmt.Sprintf(`
+if input.%[3]s != nil {
+	%[1]s, err := %[4]s(*input.%[3]s)
+	if err != nil {
+		return fmt.Errorf("flattening %[3]q: %%+v", err)
+	}
+	out.%[2]s = %[1]s
+}
+`, sdkField.JsonName, mapping.From.SchemaFieldPath, mapping.To.SdkFieldPath, mapping.Manual.MethodName)
+		}
+		return &line, nil
+	}
+
+	if sdkField.Required {
+		// if the SDK Field is Required but the Schema Field is Optional this is a Data Issue
+		// TODO: handle where it's defaulted?
+		return nil, fmt.Errorf("the Sdk Model %q Field %q was Required but Schema Model %q Field %q was Optional but must be Required", mapping.To.SdkModelName, mapping.To.SdkFieldPath, mapping.From.SchemaModelName, mapping.From.SchemaFieldPath)
+	}
+
+	// Optional -> Optional
+	line := fmt.Sprintf(`
+if input.%[3]s != nil {
+	%[1]s, err := %[4]s(*input.%[3]s)
+	if err != nil {
+		return fmt.Errorf("flattening %[3]q: %%+v", err)
+	}
+	out.%[2]s = &%[1]s
+}
+`, sdkField.JsonName, mapping.From.SchemaFieldPath, mapping.To.SdkFieldPath, mapping.Manual.MethodName)
+	return &line, nil
+}

--- a/tools/generator-terraform/generator/mappings/assignment_manual_createorupdate_test.go
+++ b/tools/generator-terraform/generator/mappings/assignment_manual_createorupdate_test.go
@@ -1,0 +1,461 @@
+package mappings
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
+)
+
+func TestManualMapping_CreateOrUpdate_RequiredToRequired_TopLevel(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeString,
+				},
+				HclName:  "from_path",
+				Required: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.StringApiObjectDefinitionType,
+				},
+				Required: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+toPath, err := myCustomMappingFunction(input.FromPath)
+if err != nil {
+	return fmt.Errorf("flattening 'FromPath': %+v", err)
+}
+out.ToPath = toPath
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForCreateUpdateMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building create/update assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_CreateOrUpdate_RequiredToOptional_TopLevel(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeString,
+				},
+				HclName:  "from_path",
+				Required: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.StringApiObjectDefinitionType,
+				},
+				Optional: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+toPath, err := myCustomMappingFunction(input.FromPath)
+if err != nil {
+	return fmt.Errorf("flattening 'FromPath': %+v", err)
+}
+out.ToPath = &toPath
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForCreateUpdateMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building create/update assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_CreateOrUpdate_OptionalToRequired_TopLevel(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeString,
+				},
+				HclName:  "from_path",
+				Optional: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.StringApiObjectDefinitionType,
+				},
+				Required: true,
+			},
+		},
+	}
+
+	actual, err := manualAssignmentLine{}.assignmentForCreateUpdateMapping(mapping, schemaModel, sdkModel, nil)
+	if err == nil {
+		t.Fatalf("expected an error but didn't get one")
+	}
+	if actual != nil {
+		t.Fatalf("expected an error and no result but got a result (%q) and no error", *actual)
+	}
+}
+
+func TestManualMapping_CreateOrUpdate_OptionalToOptional_TopLevel(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeString,
+				},
+				HclName:  "from_path",
+				Optional: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.StringApiObjectDefinitionType,
+				},
+				Optional: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+if input.FromPath != nil {
+	toPath, err := myCustomMappingFunction(*input.FromPath)
+	if err != nil {
+		return fmt.Errorf("flattening 'FromPath': %+v", err)
+	}
+	out.ToPath = &toPath
+}
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForCreateUpdateMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building create/update assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_CreateOrUpdate_RequiredToRequired_List(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeList,
+					NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeString,
+					},
+				},
+				HclName:  "from_path",
+				Required: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.ListApiObjectDefinitionType,
+					NestedItem: &resourcemanager.ApiObjectDefinition{
+						Type: resourcemanager.StringApiObjectDefinitionType,
+					},
+				},
+				Required: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+toPath, err := myCustomMappingFunction(input.FromPath)
+if err != nil {
+	return fmt.Errorf("flattening 'FromPath': %+v", err)
+}
+out.ToPath = toPath
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForCreateUpdateMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building create/update assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_CreateOrUpdate_RequiredToOptional_List(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeList,
+					NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeString,
+					},
+				},
+				HclName:  "from_path",
+				Required: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.ListApiObjectDefinitionType,
+					NestedItem: &resourcemanager.ApiObjectDefinition{
+						Type: resourcemanager.StringApiObjectDefinitionType,
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+toPath, err := myCustomMappingFunction(input.FromPath)
+if err != nil {
+	return fmt.Errorf("flattening 'FromPath': %+v", err)
+}
+out.ToPath = &toPath
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForCreateUpdateMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building create/update assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_CreateOrUpdate_OptionalToRequired_List(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeList,
+					NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeString,
+					},
+				},
+				HclName:  "from_path",
+				Optional: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.ListApiObjectDefinitionType,
+					NestedItem: &resourcemanager.ApiObjectDefinition{
+						Type: resourcemanager.StringApiObjectDefinitionType,
+					},
+				},
+				Required: true,
+			},
+		},
+	}
+
+	actual, err := manualAssignmentLine{}.assignmentForCreateUpdateMapping(mapping, schemaModel, sdkModel, nil)
+	if err == nil {
+		t.Fatalf("expected an error but didn't get one")
+	}
+	if actual != nil {
+		t.Fatalf("expected an error and no result but got a result (%q) and no error", *actual)
+	}
+}
+
+func TestManualMapping_CreateOrUpdate_OptionalToOptional_List(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeList,
+					NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeString,
+					},
+				},
+				HclName:  "from_path",
+				Optional: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.ListApiObjectDefinitionType,
+					NestedItem: &resourcemanager.ApiObjectDefinition{
+						Type: resourcemanager.StringApiObjectDefinitionType,
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+if input.FromPath != nil {
+	toPath, err := myCustomMappingFunction(*input.FromPath)
+	if err != nil {
+		return fmt.Errorf("flattening 'FromPath': %+v", err)
+	}
+	out.ToPath = &toPath
+}
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForCreateUpdateMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building create/update assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}

--- a/tools/generator-terraform/generator/mappings/assignment_manual_read_test.go
+++ b/tools/generator-terraform/generator/mappings/assignment_manual_read_test.go
@@ -1,0 +1,465 @@
+package mappings
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
+)
+
+func TestManualMapping_Read_RequiredToRequired_TopLevel(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeString,
+				},
+				HclName:  "from_path",
+				Required: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.StringApiObjectDefinitionType,
+				},
+				Required: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+toPath, err := myCustomMappingFunction(input.ToPath)
+if err != nil {
+	return fmt.Errorf("flattening 'ToPath': %+v", err)
+}
+out.FromPath = toPath
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building read assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_Read_RequiredToOptional_TopLevel(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeString,
+				},
+				HclName:  "from_path",
+				Required: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.StringApiObjectDefinitionType,
+				},
+				Optional: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+if input.ToPath != nil {
+	toPath, err := myCustomMappingFunction(*input.ToPath)
+	if err != nil {
+		return fmt.Errorf("flattening 'ToPath': %+v", err)
+	}
+	out.FromPath = toPath
+}
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building read assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_Read_OptionalToRequired_TopLevel(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeString,
+				},
+				HclName:  "from_path",
+				Optional: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.StringApiObjectDefinitionType,
+				},
+				Required: true,
+			},
+		},
+	}
+
+	actual, err := manualAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil)
+	if err == nil {
+		t.Fatalf("expected an error but didn't get one")
+	}
+	if actual != nil {
+		t.Fatalf("expected an error and no result but got a result (%q) and no error", *actual)
+	}
+}
+
+func TestManualMapping_Read_OptionalToOptional_TopLevel(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeString,
+				},
+				HclName:  "from_path",
+				Optional: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.StringApiObjectDefinitionType,
+				},
+				Optional: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+if input.ToPath != nil {
+	toPath, err := myCustomMappingFunction(*input.ToPath)
+	if err != nil {
+		return fmt.Errorf("flattening 'ToPath': %+v", err)
+	}
+	out.FromPath = &toPath
+}
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building read assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_Read_RequiredToRequired_List(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeList,
+					NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeString,
+					},
+				},
+				HclName:  "from_path",
+				Required: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.ListApiObjectDefinitionType,
+					NestedItem: &resourcemanager.ApiObjectDefinition{
+						Type: resourcemanager.StringApiObjectDefinitionType,
+					},
+				},
+				Required: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+toPath, err := myCustomMappingFunction(input.ToPath)
+if err != nil {
+	return fmt.Errorf("flattening 'ToPath': %+v", err)
+}
+out.FromPath = toPath
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building read assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_Read_RequiredToOptional_List(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeList,
+					NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeString,
+					},
+				},
+				HclName:  "from_path",
+				Required: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.ListApiObjectDefinitionType,
+					NestedItem: &resourcemanager.ApiObjectDefinition{
+						Type: resourcemanager.StringApiObjectDefinitionType,
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+if input.ToPath != nil {
+	toPath, err := myCustomMappingFunction(*input.ToPath)
+	if err != nil {
+		return fmt.Errorf("flattening 'ToPath': %+v", err)
+	}
+	out.FromPath = toPath
+}
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building read assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestManualMapping_Read_OptionalToRequired_List(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeList,
+					NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeString,
+					},
+				},
+				HclName:  "from_path",
+				Optional: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.ListApiObjectDefinitionType,
+					NestedItem: &resourcemanager.ApiObjectDefinition{
+						Type: resourcemanager.StringApiObjectDefinitionType,
+					},
+				},
+				Required: true,
+			},
+		},
+	}
+
+	actual, err := manualAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil)
+	if err == nil {
+		t.Fatalf("expected an error but didn't get one")
+	}
+	if actual != nil {
+		t.Fatalf("expected an error and no result but got a result (%q) and no error", *actual)
+	}
+}
+
+func TestManualMapping_Read_OptionalToOptional_List(t *testing.T) {
+	mapping := resourcemanager.FieldMappingDefinition{
+		Type: resourcemanager.ManualMappingDefinitionType,
+		From: resourcemanager.FieldMappingFromDefinition{
+			SchemaModelName: "FromModel",
+			SchemaFieldPath: "FromPath",
+		},
+		To: resourcemanager.FieldMappingToDefinition{
+			SdkFieldPath: "ToPath",
+			SdkModelName: "ToModel",
+		},
+		Manual: &resourcemanager.FieldManualMappingDefinition{
+			MethodName: "myCustomMappingFunction",
+		},
+	}
+	schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+		Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+			"FromPath": {
+				ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+					Type: resourcemanager.TerraformSchemaFieldTypeList,
+					NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: resourcemanager.TerraformSchemaFieldTypeString,
+					},
+				},
+				HclName:  "from_path",
+				Optional: true,
+			},
+		},
+	}
+	sdkModel := resourcemanager.ModelDetails{
+		Fields: map[string]resourcemanager.FieldDetails{
+			"ToPath": {
+				JsonName: "toPath",
+				ObjectDefinition: resourcemanager.ApiObjectDefinition{
+					Type: resourcemanager.ListApiObjectDefinitionType,
+					NestedItem: &resourcemanager.ApiObjectDefinition{
+						Type: resourcemanager.StringApiObjectDefinitionType,
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+	expected := strings.ReplaceAll(`
+if input.ToPath != nil {
+	toPath, err := myCustomMappingFunction(*input.ToPath)
+	if err != nil {
+		return fmt.Errorf("flattening 'ToPath': %+v", err)
+	}
+	out.FromPath = &toPath
+}
+`, "'", "\"")
+
+	actual, err := manualAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil)
+	if err != nil {
+		t.Fatalf("error building read assignment: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil but shouldn't be")
+	}
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}

--- a/tools/generator-terraform/generator/mappings/assignments.go
+++ b/tools/generator-terraform/generator/mappings/assignments.go
@@ -9,6 +9,7 @@ import (
 
 var assignmentTypes = map[resourcemanager.MappingDefinitionType]assignmentType{
 	resourcemanager.DirectAssignmentMappingDefinitionType: directAssignmentLine{},
+	resourcemanager.ManualMappingDefinitionType:           manualAssignmentLine{},
 }
 
 type assignmentConstantDetails struct {


### PR DESCRIPTION
Dependent on #1555 

This PR adds support for Manual Mappings - that is where we want to have a manual/escape hatch to convert from the Schema Field Type -> SDK Field Type (and visa-versa).

Whilst in this example below the same method used, in real data the Create/Update/Read methods can be the same/different:

```
 $ go build . && ./generator-terraform mappings                                                                                                                                                                        2022/09/21 19:55:24 nada
2022/09/21 19:55:25 [DEBUG] Service "Resources"
2022/09/21 19:55:25 [DEBUG] Resource Name "resource_group"
2022/09/21 19:55:25 Create Mappings:

func mapCreateResourceGroupResourceSchemaToResourceGroup(input ResourceGroupResourceSchema, out *resourcegroups.ResourceGroup) error {
			out.DirectAssignmentReceiver = &input.DirectAssignmentField

name, err := someMethodForName(input.Name)
if err != nil {
	return fmt.Errorf("flattening "Name": %+v", err)
}
out.Name = &name

			return nil
		}
2022/09/21 19:55:25 Update Mappings:

func mapUpdateResourceGroupResourceSchemaToResourceGroup(input ResourceGroupResourceSchema, out *resourcegroups.ResourceGroup) error {
			out.DirectAssignmentReceiver = &input.DirectAssignmentField

name, err := someMethodForName(input.Name)
if err != nil {
	return fmt.Errorf("flattening "Name": %+v", err)
}
out.Name = &name

			return nil
		}
2022/09/21 19:55:25 Read Mappings:

func mapReadResourceGroupToResourceGroupResourceSchema(input resourcegroups.ResourceGroup, out *ResourceGroupResourceSchema) error {

if input.DirectAssignmentReceiver != nil {
	out.DirectAssignmentField = *input.DirectAssignmentReceiver
}


if input.Name != nil {
	name, err := someMethodForName(*input.Name)
	if err != nil {
		return fmt.Errorf("flattening "Name": %+v", err)
	}
	out.Name = name
}

			return nil
		}
```