### PR TITLE
tools/importer-rest-api-specs: ensuring the top level resource model kicks around

### DIFF
--- a/tools/importer-rest-api-specs/components/schema/build_resource_group_test.go
+++ b/tools/importer-rest-api-specs/components/schema/build_resource_group_test.go
@@ -138,7 +138,7 @@ func TestBuildForResourceGroupHappyPathAllModelsTheSame(t *testing.T) {
 		Resource:        "ResourceGroups",
 		ResourceIdName:  "ResourceGroupId",
 		ResourceName:    "ResourceGroup",
-		SchemaModelName: "ResourceGroup",
+		SchemaModelName: "ResourceGroupResource",
 		UpdateMethod: &resourcemanager.MethodDefinition{
 			Generate:         true,
 			MethodName:       "Update",
@@ -364,7 +364,7 @@ func testValidateResourceGroupSchema(t *testing.T, actualModels *map[string]reso
 	if len(*actualModels) != 1 {
 		t.Errorf("expected 1 model but got %d", len(*actualModels))
 	}
-	r.CurrentModel = "ResourceGroup"
+	r.CurrentModel = "ResourceGroupResource"
 	currentModel, ok := (*actualModels)[r.CurrentModel]
 	if !ok {
 		t.Errorf("top level model %q missing", r.CurrentModel)
@@ -392,20 +392,20 @@ func testValidateResourceGroupSchema(t *testing.T, actualModels *map[string]reso
 	checkResourceIdMappingExistsBetween(t, actualMappings.ResourceId, "Name", "resourceGroupName")
 
 	t.Logf("Checking Create Mappings..")
-	checkDirectAssignmentMappingExistsBetween(t, actualMappings.Create, "ResourceGroup", "Location", "ResourceGroup", "Location")
-	checkDirectAssignmentMappingExistsBetween(t, actualMappings.Create, "ResourceGroup", "Tags", "ResourceGroup", "Tags")
+	checkDirectAssignmentMappingExistsBetween(t, actualMappings.Create, "ResourceGroupResource", "Location", "ResourceGroup", "Location")
+	checkDirectAssignmentMappingExistsBetween(t, actualMappings.Create, "ResourceGroupResource", "Tags", "ResourceGroup", "Tags")
 
 	t.Logf("Checking Update Mappings..")
 	if actualMappings.Update == nil {
 		t.Fatalf("expected update mappings but they were nil")
 	}
 	if allModelsAreTheSame {
-		checkDirectAssignmentMappingExistsBetween(t, *actualMappings.Update, "ResourceGroup", "Tags", "ResourceGroup", "Tags")
+		checkDirectAssignmentMappingExistsBetween(t, *actualMappings.Update, "ResourceGroupResource", "Tags", "ResourceGroup", "Tags")
 	} else {
-		checkDirectAssignmentMappingExistsBetween(t, *actualMappings.Update, "ResourceGroup", "Tags", "ResourceGroupPatchable", "Tags")
+		checkDirectAssignmentMappingExistsBetween(t, *actualMappings.Update, "ResourceGroupResource", "Tags", "ResourceGroupPatchable", "Tags")
 	}
 
 	t.Logf("Checking Read Mappings..")
-	checkDirectAssignmentMappingExistsBetween(t, actualMappings.Read, "ResourceGroup", "Location", "ResourceGroup", "Location")
-	checkDirectAssignmentMappingExistsBetween(t, actualMappings.Read, "ResourceGroup", "Tags", "ResourceGroup", "Tags")
+	checkDirectAssignmentMappingExistsBetween(t, actualMappings.Read, "ResourceGroupResource", "Location", "ResourceGroup", "Location")
+	checkDirectAssignmentMappingExistsBetween(t, actualMappings.Read, "ResourceGroupResource", "Tags", "ResourceGroup", "Tags")
 }

--- a/tools/importer-rest-api-specs/components/schema/builder.go
+++ b/tools/importer-rest-api-specs/components/schema/builder.go
@@ -120,12 +120,12 @@ func (b Builder) Build(input resourcemanager.TerraformResourceDetails, logger hc
 	}
 
 	// finally go through and remove any unused models
-	schemaModels, mappings = removeUnusedModels(input, b.operations, schemaModels, mappings)
+	schemaModels, mappings = removeUnusedModels(input, schemaModels, mappings)
 
 	return &schemaModels, &mappings, nil
 }
 
-func removeUnusedModels(input resourcemanager.TerraformResourceDetails, operations map[string]resourcemanager.ApiOperation, models map[string]resourcemanager.TerraformSchemaModelDefinition, mappings resourcemanager.MappingDefinition) (map[string]resourcemanager.TerraformSchemaModelDefinition, resourcemanager.MappingDefinition) {
+func removeUnusedModels(input resourcemanager.TerraformResourceDetails, models map[string]resourcemanager.TerraformSchemaModelDefinition, mappings resourcemanager.MappingDefinition) (map[string]resourcemanager.TerraformSchemaModelDefinition, resourcemanager.MappingDefinition) {
 	unusedModels := make(map[string]struct{}, 0)
 	// first assume everything is unused
 	for modelName := range models {
@@ -142,30 +142,7 @@ func removeUnusedModels(input resourcemanager.TerraformResourceDetails, operatio
 		}
 	}
 
-	// finally remove any models referenced as top level operations
-	operationMethodNames := []string{
-		input.CreateMethod.MethodName,
-		input.ReadMethod.MethodName,
-		input.DeleteMethod.MethodName,
-	}
-	if input.UpdateMethod != nil {
-		operationMethodNames = append(operationMethodNames, input.UpdateMethod.MethodName)
-	}
-	for _, methodName := range operationMethodNames {
-		operation := operations[methodName]
-		if operation.RequestObject != nil {
-			objectDefinition := topLevelObjectDefinition(*operation.RequestObject)
-			if objectDefinition.Type == resourcemanager.ReferenceApiObjectDefinitionType {
-				delete(unusedModels, *operation.RequestObject.ReferenceName)
-			}
-		}
-		if operation.ResponseObject != nil {
-			objectDefinition := topLevelObjectDefinition(*operation.ResponseObject)
-			if objectDefinition.Type == resourcemanager.ReferenceApiObjectDefinitionType {
-				delete(unusedModels, *operation.ResponseObject.ReferenceName)
-			}
-		}
-	}
+	delete(unusedModels, fmt.Sprintf("%sResource", input.ResourceName))
 
 	// remove any unreferenced models
 	for modelName := range unusedModels {


### PR DESCRIPTION
We want to preserve the model itself rather than the model names used by the CRUD operations