### PR TITLE
Data API: outputting the mapping value for optional fields

### DIFF
--- a/data/Pandora.Definitions/Mappings/Expression.cs
+++ b/data/Pandora.Definitions/Mappings/Expression.cs
@@ -10,6 +10,12 @@ static class ExpressionHelpers
         // val will be `s.Foo.Bar` - so trim whatever label we've given it
         var dot = val.IndexOf(".");
         // then we should have `Foo.Bar`
-        return val.Substring(dot + 1);
+        var output = val.Substring(dot + 1);
+        if (output.Contains(","))
+        {
+            var position = output.IndexOf(",");
+            output = output.Substring(0, position);
+        }
+        return output;
     }
 }


### PR DESCRIPTION
This fixes a bug when mapping an optional boolean where the expression gets output as "StartOnCreation, Object)" rather than "StartOnCreation"