### PR TITLE
config: add `azurestackhci` @ `2022-09-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -37,7 +37,7 @@ service "azure-kusto" {
 }
 service "azurestackhci" {
   name      = "AzureStackHCI"
-  available = ["2020-10-01"]
+  available = ["2020-10-01", "2022-09-01"]
 }
 service "chaos" {
   name      = "ChaosStudio"


### PR DESCRIPTION
swagger: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/stable/2022-09-01
doc: https://learn.microsoft.com/en-us/azure-stack/hci/