### PR TITLE
tools/importer-rest-api-specs: handling ModelToModel mappings when renaming fields

### DIFF
--- a/tools/importer-rest-api-specs/components/schema/processors/helpers.go
+++ b/tools/importer-rest-api-specs/components/schema/processors/helpers.go
@@ -25,6 +25,11 @@ func applyFieldRenameToFieldMapping(v resourcemanager.FieldMappingDefinition, mo
 				v.DirectAssignment.SchemaFieldPath = updatedFieldName
 			}
 		}
+	case resourcemanager.ModelToModelMappingDefinitionType:
+		{
+			// nothing to do
+			break
+		}
 	default:
 		panic(fmt.Sprintf("unimplemented: field rename for mapping type %q", string(v.Type)))
 	}


### PR DESCRIPTION
Without this the importer crashes since the `importer-rest-api-specs` tool isn't completing