### PR TITLE
tools/generator-go-sdk: support for specifying the services to generate

### DIFF
--- a/tools/generator-terraform/cmd/generate.go
+++ b/tools/generator-terraform/cmd/generate.go
@@ -42,6 +42,8 @@ Flags:
   Specifies the path to the Data API.
 * '--output-dir=../generated-tf-dev'
   Specifies the path where the generated files should be output
+* '--services=Example1,Example2'
+  Specifies a comma-separated list of services to import, rather than the full set.
 `, "'", "`")
 }
 


### PR DESCRIPTION
This matches the TF Generator, which we can use in the documentation later