### PR TITLE
tooling: running the `importer-rest-api-specs` tool connected to the Data API

### DIFF
--- a/.github/workflows/automation-rest-api-specs-importer.yaml
+++ b/.github/workflows/automation-rest-api-specs-importer.yaml
@@ -34,13 +34,33 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      - name: build and run importer-rest-api-specs
-        id: import-data
+      - name: build the Data API
+        id: build-data-api
+        run: |
+          cd ./data
+          make tools
+          make build
+
+      - name: build the importer-rest-api-specs
+        id: build-importer-rest-api-specs
         run: |
           cd ./tools/importer-rest-api-specs
           make tools
+          make install
+
+      - name: build and run the automation wrapper for importer-rest-api-specs
+        id: import-data
+        run: |
+          cd ./tools/wrapper-automation
+          make tools
           make build
-          make import
+          ./wrapper-automation rest-api-specs-importer --data-api-assembly-path=../../data/Pandora.Api/bin/Debug/net6.0/Pandora.Api.dll
+
+      - name: then format the generated code
+        id: format-imported-data
+        run: |
+          cd ./data
+          make fmt
 
       - name: then commit the diff
         id: commit-imported-data

--- a/tools/importer-rest-api-specs/components/transformer/api_to_models.go
+++ b/tools/importer-rest-api-specs/components/transformer/api_to_models.go
@@ -126,6 +126,8 @@ func mapApiObjectDefinitionType(input resourcemanager.ApiObjectDefinitionType) (
 		resourcemanager.UserAssignedIdentityListApiObjectDefinitionType:                models.CustomFieldTypeUserAssignedIdentityList,
 		resourcemanager.UserAssignedIdentityMapApiObjectDefinitionType:                 models.CustomFieldTypeUserAssignedIdentityMap,
 		resourcemanager.TagsApiObjectDefinitionType:                                    models.CustomFieldTypeTags,
+		resourcemanager.SystemData:                                                     models.CustomFieldTypeSystemData,
+		resourcemanager.ZonesApiObjectDefinitionType:                                   models.CustomFieldTypeZones,
 	}
 	if v, ok := customTypes[input]; ok {
 		return nil, &v, nil

--- a/tools/wrapper-automation/run.go
+++ b/tools/wrapper-automation/run.go
@@ -45,7 +45,7 @@ func run(args Arguments) error {
 	if args.RunRestApiSpecsImporter {
 		log.Printf("Running the Rest Api Specs Importer..")
 		if err := runRestApiSpecsImporter(dataApiUri, args.OutputDirectory); err != nil {
-			return fmt.Errorf("running the Go SDK Generator: %+v", err)
+			return fmt.Errorf("running the Rest API Specs Importer: %+v", err)
 		}
 		log.Printf("Rest Api Specs Importer has been run.")
 	}
@@ -63,7 +63,7 @@ func run(args Arguments) error {
 	if args.RunTerraformGenerator {
 		log.Printf("Running the Terraform Generator..")
 		if err := runTerraformGenerator(dataApiUri, args.OutputDirectory); err != nil {
-			return fmt.Errorf("running the Go SDK Generator: %+v", err)
+			return fmt.Errorf("running the Terraform Generator: %+v", err)
 		}
 		log.Printf("Terraform Generator has been run.")
 	}


### PR DESCRIPTION
This enables loading existing data from the Data API and diffing it against the imported data.

Initially this is only focused on the Terraform Tests, but will be expanded to other items in the future

Fixes https://github.com/hashicorp/pandora/issues/403