### PR TITLE
documentation: minor fixes

### DIFF
--- a/tools/importer-rest-api-specs/components/schema/fields_top_level.go
+++ b/tools/importer-rest-api-specs/components/schema/fields_top_level.go
@@ -53,7 +53,7 @@ func (b Builder) schemaFromTopLevelFields(schemaModelName string, input operatio
 				ForceNew:         !hasUpdate,
 				HclName:          "identity",
 				Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
-					Markdown: field.Description,
+					Markdown: fmt.Sprintf("Specifies the Managed Identity which should be assigned to this %s.", resourceDisplayName),
 				},
 			}
 

--- a/tools/importer-rest-api-specs/components/schema/helpers.go
+++ b/tools/importer-rest-api-specs/components/schema/helpers.go
@@ -154,6 +154,13 @@ func extractDescription(markdown string) string {
 	description, _, _ = strings.Cut(description, "Minimum api-version:")
 	description, _, _ = strings.Cut(description, "; example")
 
+	// recase words as required
+	description = strings.ReplaceAll(description, "identity", "Identity")
+	description = strings.ReplaceAll(description, "id", "ID")
+	description = strings.ReplaceAll(description, "principal", "Principal")
+	description = strings.ReplaceAll(description, "service", "Service")
+	description = strings.ReplaceAll(description, "tenant", "Tenant")
+
 	if description != "" {
 		description = capitalizeFirstLetter(description)
 
@@ -163,6 +170,7 @@ func extractDescription(markdown string) string {
 			description = punctuateEndOfSentence(description)
 		}
 	}
+	description = strings.TrimSpace(description)
 
 	return description
 }

--- a/tools/importer-rest-api-specs/components/schema/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/schema/helpers_test.go
@@ -27,3 +27,20 @@ func checkDirectAssignmentMappingExistsBetween(t *testing.T, mappings []resource
 		t.Fatalf("expected there to be a DirectAssignment Mapping from Schema Model %q Path %q to SDK Model %q Path %q but there wasn't", schemaModelName, schemaFieldPath, sdkModelName, sdkFieldPath)
 	}
 }
+
+func TestExtractDescription(t *testing.T) {
+	testData := map[string]string{
+		// input : expected
+		"": "",
+		"The id of the app associated with the identity. ":                             "The ID of the app associated with the Identity.",
+		"The id of the service principal object associated with the created identity.": "The ID of the Service Principal object associated with the created Identity.",
+		"The id of the tenant which the identity belongs to.":                          "The ID of the Tenant which the Identity belongs to.",
+	}
+	for input, expected := range testData {
+		t.Logf("Testing input %q", input)
+		actual := extractDescription(input)
+		if expected != actual {
+			t.Fatalf("expected %q but got %q", expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes a couple of issues spotted whilst reviewing the documentation:

```
* `identity` - (Optional) 
```

and

```
* `client_id` - The id of the app associated with the identity. 

 * `principal_id` - The id of the service principal object associated with the created identity.

 * `tenant_id` - The id of the tenant which the identity belongs to.
```

these are now output as:

> Specifies the Managed Identity which should be assigned to this Load Test.
> The ID of the app associated with the Identity.
> The ID of the Service Principal object associated with the created Identity.
> The ID of the Tenant which the Identity belongs to.