### PR TITLE
config: add `deviceupdate` @ `2022-10-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -115,6 +115,10 @@ service "deviceprovisioningservices" {
   name      = "DeviceProvisioningServices"
   available = ["2022-02-05"]
 }
+service "deviceupdate" {
+  name      = "DeviceUpdate"
+  available = ["2022-10-01"]
+}
 service "digitaltwins" {
   name      = "DigitalTwins"
   available = ["2020-12-01"]


### PR DESCRIPTION
This is a new resource requested by service team. The GA date is 9/30.
[Swagger](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/deviceupdate/resource-manager/Microsoft.DeviceUpdate/stable/2022-10-01)
[Document](https://learn.microsoft.com/en-us/azure/iot-hub-device-update/create-device-update-account)
