### PR TITLE
importer-rest-api-specs: process nested fields from `allOf` models

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -178,12 +178,13 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 			nestedFields[propName] = *nestedField
 		}
 		for _, inlinedModel := range value.AllOf {
-			remotePath := inlinedModel.Ref.String()
-			remotePathParts := strings.Split(remotePath, "/")
-			remoteRef := remotePathParts[len(remotePathParts)-1]
-			remoteSpec, err := d.findTopLevelObject(remoteRef)
+			remoteRef := fragmentNameFromReference(inlinedModel.Ref)
+			if remoteRef == nil {
+				return nil, nil, fmt.Errorf("allOf Ref had no fragment in path for %q", inlinedName)
+			}
+			remoteSpec, err := d.findTopLevelObject(*remoteRef)
 			if err != nil {
-				return nil, nil, fmt.Errorf("could not find allOf referenced model %q", remoteRef)
+				return nil, nil, fmt.Errorf("could not find allOf referenced model %q", *remoteRef)
 			}
 
 			for propName, propVal := range remoteSpec.Properties {

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -178,7 +178,9 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 			nestedFields[propName] = *nestedField
 		}
 		for _, inlinedModel := range value.AllOf {
-			remoteRef := strings.TrimPrefix(inlinedModel.Ref.String(), "#/definitions/")
+			remotePath := inlinedModel.Ref.String()
+			remotePathParts := strings.Split(remotePath, "/")
+			remoteRef := remotePathParts[len(remotePathParts)-1]
 			remoteSpec, err := d.findTopLevelObject(remoteRef)
 			if err != nil {
 				return nil, nil, fmt.Errorf("could not find allOf referenced model %q", remoteRef)

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -1220,6 +1220,53 @@ func TestParseModelSingleContainingAllOfToTypeObjectWithProperties(t *testing.T)
 	}
 }
 
+func TestParseModelSingleContainingAllOfWithinProperties(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "model_containing_allof_within_properties.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 2 {
+		t.Fatalf("expected 2 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	example, ok := hello.Models["Example"]
+	if !ok {
+		t.Fatalf("expected there to be a model named Example")
+	}
+	if len(example.Fields) != 2 {
+		t.Fatalf("expected the model Example to have 2 fields but got %d", len(example.Fields))
+	}
+
+	props, ok := hello.Models["ExampleProperties"]
+	if !ok {
+		t.Fatalf("expected there to be a model named ExampleProperties")
+	}
+	if len(props.Fields) != 3 {
+		t.Fatalf("expected the model ExampleProperties to have 3 fields but got %d", len(props.Fields))
+	}
+}
+
 func TestParseModelWithCircularReferences(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "model_with_circular_reference.json")
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/parser/testdata/model_containing_allof_within_properties.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/model_containing_allof_within_properties.json
@@ -1,0 +1,119 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/someUri": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_World",
+        "description": "Tests parsing of a simple model.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Wrapper class."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ResourceWithLocation": {
+      "description": "Base type for a Resource with a Location.",
+      "properties": {
+        "country": {
+          "type": "string",
+          "description": "the location of this Resource"
+        }
+      },
+      "required": [
+        "country"
+      ],
+      "title": "ResourceWithLocation",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "NestedFieldsForObject": {
+      "description": "Base type for a Resource with a Location.",
+      "properties": {
+        "nested": {
+          "type": "string",
+          "description": "a nested remote property of this Resource"
+        },
+        "moreNested": {
+          "type": "string",
+          "description": "a nested remote property of this Resource"
+        }
+      },
+      "required": [
+        "nested"
+      ],
+      "title": "ResourceWithLocation",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "Example": {
+      "description": "The Resource definition.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceWithLocation"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/NestedFieldsForObject"
+            }
+          ],
+          "description": "Nested",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "the name of this thing"
+            }
+          },
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "x-ms-client-flatten": true
+        }
+      },
+      "title": "Example",
+      "type": "object",
+      "x-ms-azure-resource": true
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
fixes #1714


```csharp
using System;
using System.Collections.Generic;
using System.Text.Json.Serialization;
using Pandora.Definitions.Attributes;
using Pandora.Definitions.Attributes.Validation;
using Pandora.Definitions.CustomTypes;


// Copyright (c) Microsoft Corporation. All rights reserved.
// Licensed under the MIT License. See NOTICE.txt in the project root for license information.


namespace Pandora.Definitions.ResourceManager.SecurityInsights.v2021_09_01_preview.AlertRuleTemplates;


internal class MLBehaviorAnalyticsAlertRuleTemplatePropertiesModel
{
    [JsonPropertyName("alertRulesCreatedByTemplateCount")]
    [Required]
    public int AlertRulesCreatedByTemplateCount { get; set; }

    [DateFormat(DateFormatAttribute.DateFormat.RFC3339)]
    [JsonPropertyName("createdDateUTC")]
    public DateTime? CreatedDateUTC { get; set; }

    [JsonPropertyName("description")]
    [Required]
    public string Description { get; set; }

    [JsonPropertyName("displayName")]
    [Required]
    public string DisplayName { get; set; }

    [DateFormat(DateFormatAttribute.DateFormat.RFC3339)]
    [JsonPropertyName("lastUpdatedDateUTC")]
    public DateTime? LastUpdatedDateUTC { get; set; }

    [JsonPropertyName("requiredDataConnectors")]
    public List<AlertRuleTemplateDataSourceModel>? RequiredDataConnectors { get; set; }

    [JsonPropertyName("severity")]
    [Required]
    public AlertSeverityConstant Severity { get; set; }

    [JsonPropertyName("status")]
    [Required]
    public TemplateStatusConstant Status { get; set; }

    [JsonPropertyName("tactics")]
    public List<AttackTacticConstant>? Tactics { get; set; }
}

```

```go
package alertruletemplates

import (
	"time"

	"github.com/hashicorp/go-azure-helpers/lang/dates"
)

// Copyright (c) Microsoft Corporation. All rights reserved.
// Licensed under the MIT License. See NOTICE.txt in the project root for license information.

type MLBehaviorAnalyticsAlertRuleTemplateProperties struct {
	AlertRulesCreatedByTemplateCount int64                          `json:"alertRulesCreatedByTemplateCount"`
	CreatedDateUTC                   *string                        `json:"createdDateUTC,omitempty"`
	Description                      string                         `json:"description"`
	DisplayName                      string                         `json:"displayName"`
	LastUpdatedDateUTC               *string                        `json:"lastUpdatedDateUTC,omitempty"`
	RequiredDataConnectors           *[]AlertRuleTemplateDataSource `json:"requiredDataConnectors,omitempty"`
	Severity                         AlertSeverity                  `json:"severity"`
	Status                           TemplateStatus                 `json:"status"`
	Tactics                          *[]AttackTactic                `json:"tactics,omitempty"`
}

func (o *MLBehaviorAnalyticsAlertRuleTemplateProperties) GetCreatedDateUTCAsTime() (*time.Time, error) {
	if o.CreatedDateUTC == nil {
		return nil, nil
	}
	return dates.ParseAsFormat(o.CreatedDateUTC, "2006-01-02T15:04:05Z07:00")
}

func (o *MLBehaviorAnalyticsAlertRuleTemplateProperties) SetCreatedDateUTCAsTime(input time.Time) {
	formatted := input.Format("2006-01-02T15:04:05Z07:00")
	o.CreatedDateUTC = &formatted
}

func (o *MLBehaviorAnalyticsAlertRuleTemplateProperties) GetLastUpdatedDateUTCAsTime() (*time.Time, error) {
	if o.LastUpdatedDateUTC == nil {
		return nil, nil
	}
	return dates.ParseAsFormat(o.LastUpdatedDateUTC, "2006-01-02T15:04:05Z07:00")
}

func (o *MLBehaviorAnalyticsAlertRuleTemplateProperties) SetLastUpdatedDateUTCAsTime(input time.Time) {
	formatted := input.Format("2006-01-02T15:04:05Z07:00")
	o.LastUpdatedDateUTC = &formatted
}
```