### PR TITLE
refactor: moving Example Usage Generation into `tools/importer-rest-api-specs`

### DIFF
--- a/data/Pandora.Api/V1/ResourceManager/Terraform.cs
+++ b/data/Pandora.Api/V1/ResourceManager/Terraform.cs
@@ -52,11 +52,7 @@ public partial class TerraformController : ControllerBase
             {
                 Category = input.ResourceCategory,
                 Description = input.ResourceDescription,
-                ExampleUsageHcl = @"
-resource 'example_resource' 'example' {
-    example_field = '...'
-}
-".Replace("'", "\""),
+                ExampleUsageHcl = input.ResourceExampleUsage,
                 // TODO: does the top level object need a List<Categories> for the ServiceDefinition?
             },
             Resource = input.Resource,

--- a/data/Pandora.Data/Models/TerraformResourceDefinition.cs
+++ b/data/Pandora.Data/Models/TerraformResourceDefinition.cs
@@ -17,8 +17,9 @@ public class TerraformResourceDefinition
     public string ResourceIdName { get; set; }
     public string ResourceLabel { get; set; }
     public string ResourceName { get; set; }
-    public string ResourceDescription { get; set; }
     public string ResourceCategory { get; set; }
+    public string ResourceDescription { get; set; }
+    public string ResourceExampleUsage { get; set; }
     public string? SchemaModelName { get; set; }
     public Dictionary<string, TerraformSchemaModelDefinition>? SchemaModels { get; set; }
     public TerraformResourceTestDefinition? Tests { get; set; }

--- a/data/Pandora.Data/Transformers/ServiceTests.cs
+++ b/data/Pandora.Data/Transformers/ServiceTests.cs
@@ -168,11 +168,11 @@ public static class ServiceTests
                 Method = typeof(FakeTerraformOperation),
                 TimeoutInMinutes = 30,
             };
-
             public Definitions.Interfaces.ResourceID ResourceId => new FakeTerraformOperationResourceId();
             public string ResourceLabel => "fake_resource";
             public string ResourceCategory => "fake resource category";
             public string ResourceDescription => "fake resource description";
+            public string ResourceExampleUsage => "fake example usage";
             public Type? SchemaModel => typeof(FakeTerraformSchemaModel);
             public Definitions.Interfaces.TerraformMappingDefinition SchemaMappings => new FakeTerraformResourceMappings();
             public Definitions.Interfaces.TerraformResourceTestDefinition Tests => new FakeTestDefinition();

--- a/data/Pandora.Data/Transformers/TerraformResourceDefinition.cs
+++ b/data/Pandora.Data/Transformers/TerraformResourceDefinition.cs
@@ -61,8 +61,9 @@ public static class TerraformResourceDefinition
             Resource = resourceIdDetails.APIResource,
             ResourceLabel = input.ResourceLabel,
             ResourceName = resourceName,
-            ResourceDescription = input.ResourceDescription,
             ResourceCategory = input.ResourceCategory,
+            ResourceDescription = input.ResourceDescription,
+            ResourceExampleUsage = input.ResourceExampleUsage,
             ResourceIdName = resourceIdDetails.Name,
             UpdateMethod = updateMethod,
         };

--- a/data/Pandora.Data/Transformers/TerraformResourceDefinitionTests.cs
+++ b/data/Pandora.Data/Transformers/TerraformResourceDefinitionTests.cs
@@ -36,6 +36,9 @@ public class TerraformResourceDefinitionTests
         Assert.AreEqual("SomeRead", actual.ReadMethod.MethodName);
         Assert.AreEqual(11, actual.ReadMethod.TimeoutInMinutes);
         Assert.AreEqual("fake_planet", actual.ResourceLabel);
+        Assert.AreEqual("fake category", actual.ResourceCategory);
+        Assert.AreEqual("fake description", actual.ResourceDescription);
+        Assert.AreEqual("fake example usage", actual.ResourceExampleUsage);
         Assert.AreEqual("FakeResourceId", actual.ResourceIdName);
         Assert.AreEqual("Basic", actual.ResourceName);
         Assert.AreEqual("Example", actual.Resource);
@@ -105,6 +108,7 @@ public class TerraformResourceDefinitionTests
         public string ResourceLabel => "fake_planet";
         public string ResourceCategory => "fake resource category";
         public string ResourceDescription => "fake resource description";
+        public string ResourceExampleUsage => "fake example usage";
         public Type? SchemaModel => typeof(BasicResourceSchema);
 
         public Definitions.Interfaces.TerraformMappingDefinition SchemaMappings => new BasicResourceMappings();
@@ -176,6 +180,7 @@ public class TerraformResourceDefinitionTests
         public string ResourceLabel => "fake_planet";
         public string ResourceCategory => "fake resource category";
         public string ResourceDescription => "fake resource description";
+        public string ResourceExampleUsage => "fake example usage";
         public Type? SchemaModel => null;
         public Definitions.Interfaces.TerraformMappingDefinition SchemaMappings => null;
         public Definitions.Interfaces.TerraformResourceTestDefinition Tests => null;

--- a/data/Pandora.Data/Transformers/TerraformResourceDefinitionTests.cs
+++ b/data/Pandora.Data/Transformers/TerraformResourceDefinitionTests.cs
@@ -36,7 +36,7 @@ public class TerraformResourceDefinitionTests
         Assert.AreEqual("SomeRead", actual.ReadMethod.MethodName);
         Assert.AreEqual(11, actual.ReadMethod.TimeoutInMinutes);
         Assert.AreEqual("fake_planet", actual.ResourceLabel);
-        Assert.AreEqual("fake category", actual.ResourceCategory);
+        Assert.AreEqual("fake resource category", actual.ResourceCategory);
         Assert.AreEqual("fake description", actual.ResourceDescription);
         Assert.AreEqual("fake example usage", actual.ResourceExampleUsage);
         Assert.AreEqual("FakeResourceId", actual.ResourceIdName);

--- a/data/Pandora.Definitions.ResourceManager/LoadTestService/Terraform/LoadTest-Resource.cs
+++ b/data/Pandora.Definitions.ResourceManager/LoadTestService/Terraform/LoadTest-Resource.cs
@@ -8,8 +8,13 @@ public class LoadTestResource : TerraformResourceDefinition
     public string DisplayName => "Load Test";
     public ResourceID ResourceId => new v2021_12_01_preview.LoadTests.LoadTestId();
     public string ResourceLabel => "load_test";
-    public string ResourceDescription => "Manages a Load Test Service";
     public string ResourceCategory => "Load Test";
+    public string ResourceDescription => "Manages a Load Test Service";
+    public string ResourceExampleUsage => @"resource 'azurerm_load_example' 'example' {
+  location            = azurerm_resource_group.example.location
+  name                = 'example'
+  resource_group_name = azurerm_resource_group.example.name
+}".AsTerraformTestConfig();
     public Type? SchemaModel => typeof(LoadTestResourceSchema);
     public TerraformMappingDefinition SchemaMappings => new LoadTestResourceMappings();
     public TerraformResourceTestDefinition Tests => new LoadTestResourceTests();

--- a/data/Pandora.Definitions.ResourceManager/LoadTestService/Terraform/LoadTest-Resource.cs
+++ b/data/Pandora.Definitions.ResourceManager/LoadTestService/Terraform/LoadTest-Resource.cs
@@ -1,4 +1,5 @@
 using System;
+using Pandora.Definitions.Helpers;
 using Pandora.Definitions.Interfaces;
 
 namespace Pandora.Definitions.ResourceManager.LoadTestService.Terraform;

--- a/data/Pandora.Definitions.ResourceManager/ManagedIdentity/Terraform/UserAssignedIdentity-Resource.cs
+++ b/data/Pandora.Definitions.ResourceManager/ManagedIdentity/Terraform/UserAssignedIdentity-Resource.cs
@@ -8,8 +8,13 @@ public class UserAssignedIdentityResource : TerraformResourceDefinition
     public string DisplayName => "User Assigned Identity";
     public ResourceID ResourceId => new v2018_11_30.ManagedIdentities.UserAssignedIdentityId();
     public string ResourceLabel => "user_assigned_identity";
-    public string ResourceDescription => "Manages a User Assigned Identity";
     public string ResourceCategory => "Authorization";
+    public string ResourceDescription => "Manages a User Assigned Identity";
+    public string ResourceExampleUsage => @"resource 'azurerm_user_assigned_identity' 'example' {
+  location            = azurerm_resource_group.example.location
+  name                = 'example'
+  resource_group_name = azurerm_resource_group.example.name
+}".AsTerraformTestConfig();
     public Type? SchemaModel => typeof(UserAssignedIdentityResourceSchema);
     public TerraformMappingDefinition SchemaMappings => new UserAssignedIdentityResourceMappings();
     public TerraformResourceTestDefinition Tests => new UserAssignedIdentityResourceTests();

--- a/data/Pandora.Definitions.ResourceManager/ManagedIdentity/Terraform/UserAssignedIdentity-Resource.cs
+++ b/data/Pandora.Definitions.ResourceManager/ManagedIdentity/Terraform/UserAssignedIdentity-Resource.cs
@@ -1,4 +1,5 @@
 using System;
+using Pandora.Definitions.Helpers;
 using Pandora.Definitions.Interfaces;
 
 namespace Pandora.Definitions.ResourceManager.ManagedIdentity.Terraform;

--- a/data/Pandora.Definitions/Interfaces/TerraformResourceDefinition.cs
+++ b/data/Pandora.Definitions/Interfaces/TerraformResourceDefinition.cs
@@ -44,6 +44,21 @@ public interface TerraformResourceDefinition
     public MethodDefinition ReadMethod { get; }
 
     /// <summary>
+    /// ResourceCategory is the Category under which this Resource should appear in the documentation.
+    /// </summary>
+    public string ResourceCategory { get; }
+
+    /// <summary>
+    /// ResourceDescription is the description which should be used for this Resource.
+    /// </summary>
+    public string ResourceDescription { get; }
+
+    /// <summary>
+    /// ResourceExampleUsage is the Example Usage snippet for this Resource which can be used in the documentation.
+    /// </summary>
+    public string ResourceExampleUsage { get; }
+
+    /// <summary>
     /// ResourceId specifies the Resource ID associated with this Terraform Resource.
     /// </summary>
     public ResourceID ResourceId { get; }
@@ -53,16 +68,6 @@ public interface TerraformResourceDefinition
     /// **without** the Provider Prefix (e.g. `resource_group` rather than `azurerm_resource_group`).
     /// </summary>
     public string ResourceLabel { get; }
-
-    /// <summary>
-    /// ResourceDescription is the description which should be used for this Resource.
-    /// </summary>
-    public string ResourceDescription { get; }
-
-    /// <summary>
-    /// ResourceCategory is the Category under which  this Resource should appear on the website.
-    /// </summary>
-    public string ResourceCategory { get; }
 
     /// <summary>
     /// SchemaModel is a reference to a Type defining the Terraform Schema for this Resource. 

--- a/tools/generator-terraform/generator/resource/docs/component_example_usage.go
+++ b/tools/generator-terraform/generator/resource/docs/component_example_usage.go
@@ -2,44 +2,19 @@ package docs
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
-	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func codeForExampleUsage(input models.ResourceInput) (*string, error) {
-	example := convertBasicTestToUsableExample(input.Details.Tests)
 	code := strings.TrimSpace(fmt.Sprintf(`
 ## Example Usage
 
 '''hcl
 %[1]s
 '''
-`, example))
+`, input.Details.Documentation.ExampleUsageHcl))
 	output := strings.ReplaceAll(code, "'", "`")
 	return &output, nil
-}
-
-func convertBasicTestToUsableExample(tests resourcemanager.TerraformResourceTestsDefinition) string {
-	// TODO add the template config once it's filled with the prerequisite resources
-	example := strings.Replace(tests.BasicConfiguration, "test", "example", -1)
-	example = strings.Replace(example, "acc", "", -1)
-	re := regexp.MustCompile("[-][$][{](.*)[}]")
-	example = re.ReplaceAllLiteralString(example, "")
-
-	testVariables := map[string]string{
-		// TODO: add more
-		"random_integer":   "21",
-		"primary_location": "West Europe",
-	}
-	for variable, replacement := range testVariables {
-		example = strings.ReplaceAll(example, fmt.Sprintf("${local.%s}", variable), replacement)
-		example = strings.ReplaceAll(example, fmt.Sprintf("local.%s", variable), replacement)
-	}
-
-	example = strings.TrimSpace(string(hclwrite.Format([]byte(example))))
-	return example
 }

--- a/tools/generator-terraform/generator/resource/docs/component_example_usage_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_example_usage_test.go
@@ -12,9 +12,9 @@ import (
 func TestExampleUsage(t *testing.T) {
 	input := models.ResourceInput{
 		Details: resourcemanager.TerraformResourceDetails{
-			Tests: resourcemanager.TerraformResourceTestsDefinition{
-				BasicConfiguration: `
-resource "azurerm_resource_group" "test" {
+			Documentation: resourcemanager.ResourceDocumentationDefinition{
+				ExampleUsageHcl: `
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
@@ -37,62 +37,4 @@ resource "azurerm_resource_group" "example" {
 '''
 `, "'", "`")
 	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
-}
-
-func TestConvertBasicTestToUsableExample(t *testing.T) {
-	testData := []struct {
-		input    string
-		expected string
-	}{
-		{
-			input: `
-resource "azurerm_resource_group" "test" {
-  name     = "example-resources"
-  location = "West Europe"
-}
-`,
-			expected: `
-resource "azurerm_resource_group" "example" {
-  name     = "example-resources"
-  location = "West Europe"
-}
-`,
-		},
-		{
-			input: `
-resource "azurerm_resource_group" "test" {
-  name     = "acctest-${local.random_integer}"
-  location = "${local.primary_location}"
-}
-`,
-			expected: `
-resource "azurerm_resource_group" "example" {
-  name     = "example"
-  location = "West Europe"
-}
-`,
-		},
-		{
-			input: `
-resource "azurerm_resource_group" "test" {
-  name     = "example${local.random_integer}"
-  location = "${local.primary_location}"
-}
-`,
-			expected: `
-resource "azurerm_resource_group" "example" {
-  name     = "example21"
-  location = "West Europe"
-}
-`,
-		},
-	}
-	for _, v := range testData {
-		t.Logf("Testing Input %q", v.input)
-		input := resourcemanager.TerraformResourceTestsDefinition{
-			BasicConfiguration: v.input,
-		}
-		actual := convertBasicTestToUsableExample(input)
-		testhelpers.AssertTemplatedCodeMatches(t, v.expected, actual)
-	}
 }

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_definition.go
@@ -23,6 +23,7 @@ func codeForTerraformResourceDefinition(terraformNamespace, apiVersion, apiResou
 	exampleUsage := prepareTerraformTestConfigForOutput(details.Documentation.ExampleUsageHcl)
 
 	return fmt.Sprintf(`using System;
+using Pandora.Definitions.Helpers;
 using Pandora.Definitions.Interfaces;
 
 namespace %[1]s;

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_definition.go
@@ -20,6 +20,8 @@ func codeForTerraformResourceDefinition(terraformNamespace, apiVersion, apiResou
 	}
 	components = append(components, updateCode)
 
+	exampleUsage := prepareTerraformTestConfigForOutput(details.Documentation.ExampleUsageHcl)
+
 	return fmt.Sprintf(`using System;
 using Pandora.Definitions.Interfaces;
 
@@ -30,8 +32,9 @@ public class %[2]sResource : TerraformResourceDefinition
     public string DisplayName => "%[3]s";
     public ResourceID ResourceId => new %[4]s.%[5]s.%[6]s();
     public string ResourceLabel => "%[7]s";
-    public string ResourceDescription => "%[9]s";
     public string ResourceCategory => "%[10]s";
+    public string ResourceDescription => "%[9]s";
+    public string ResourceExampleUsage => @"%[11]s".AsTerraformTestConfig();
     public Type? SchemaModel => typeof(%[2]sResourceSchema);
     public TerraformMappingDefinition SchemaMappings => new %[2]sResourceMappings();
     public TerraformResourceTestDefinition Tests => new %[2]sResourceTests();
@@ -42,7 +45,7 @@ public class %[2]sResource : TerraformResourceDefinition
 
     %[8]s
 }
-`, terraformNamespace, details.ResourceName, details.DisplayName, apiVersion, apiResource, details.ResourceIdName, resourceLabel, strings.Join(components, "\n"), details.Documentation.Description, details.Documentation.Category)
+`, terraformNamespace, details.ResourceName, details.DisplayName, apiVersion, apiResource, details.ResourceIdName, resourceLabel, strings.Join(components, "\n"), details.Documentation.Description, details.Documentation.Category, exampleUsage)
 }
 
 func templateForTerraformMethodDefinition(methodName string, method resourcemanager.MethodDefinition, nullable bool, apiVersion, apiResource string) string {

--- a/tools/importer-rest-api-specs/pipeline/run_importer.go
+++ b/tools/importer-rest-api-specs/pipeline/run_importer.go
@@ -96,17 +96,23 @@ func runImportForService(input RunInput, serviceName string, apiVersionsForServi
 			}
 		}
 
-		versionLogger.Trace(fmt.Sprintf("generating Terraform Details for Service %q / Version %q", serviceName, apiVersion))
+		versionLogger.Trace("generating Terraform Details")
 		var err error
 		dataForApiVersion, err = task.generateTerraformDetails(dataForApiVersion, versionLogger.Named("TerraformDetails"))
 		if err != nil {
 			return fmt.Errorf(fmt.Sprintf("generating Terraform Details for Service %q / Version %q: %+v", serviceName, apiVersion, err))
 		}
 
-		versionLogger.Trace(fmt.Sprintf("generating Terraform Tests for Service %q / Version %q", serviceName, apiVersion))
+		versionLogger.Trace("generating Terraform Tests")
 		dataForApiVersion, err = task.generateTerraformTests(dataForApiVersion, input.ProviderPrefix, versionLogger.Named("TerraformTests"))
 		if err != nil {
 			return fmt.Errorf(fmt.Sprintf("generating Terraform Tests for Service %q / Version %q: %+v", serviceName, apiVersion, err))
+		}
+
+		versionLogger.Trace("Generating Example Usage from the Terraform Tests")
+		dataForApiVersion, err = task.generateTerraformExampleUsage(dataForApiVersion, input.ProviderPrefix, versionLogger.Named("TerraformExampleUsage"))
+		if err != nil {
+			return fmt.Errorf(fmt.Sprintf("generating Terraform Example Usage for Service %q / Version %q: %+v", serviceName, apiVersion, err))
 		}
 
 		versionLogger.Trace("Task: Applying Overrides from Existing Data..")

--- a/tools/importer-rest-api-specs/pipeline/task_generate_terraform_example_usage.go
+++ b/tools/importer-rest-api-specs/pipeline/task_generate_terraform_example_usage.go
@@ -1,0 +1,53 @@
+package pipeline
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+func (t pipelineTask) generateTerraformExampleUsage(data *models.AzureApiDefinition, providerPrefix string, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+	apiResources := make(map[string]models.AzureApiResource)
+	for k, v := range data.Resources {
+		if v.Terraform != nil {
+			// TODO: support Data Sources
+
+			tfResources := make(map[string]resourcemanager.TerraformResourceDetails)
+			for resourceKey, resourceValue := range v.Terraform.Resources {
+				example := convertBasicTestToUsableExample(resourceValue.Tests)
+				resourceValue.Documentation.ExampleUsageHcl = example
+				tfResources[resourceKey] = resourceValue
+			}
+			v.Terraform.Resources = tfResources
+		}
+		apiResources[k] = v
+	}
+	data.Resources = apiResources
+	return data, nil
+}
+
+func convertBasicTestToUsableExample(tests resourcemanager.TerraformResourceTestsDefinition) string {
+	// TODO add the template config once it's filled with the prerequisite resources
+	example := strings.Replace(tests.BasicConfiguration, "test", "example", -1)
+	example = strings.Replace(example, "acc", "", -1)
+	re := regexp.MustCompile("[-][$][{](.*)[}]")
+	example = re.ReplaceAllLiteralString(example, "")
+
+	testVariables := map[string]string{
+		// TODO: add more
+		"random_integer":   "21",
+		"primary_location": "West Europe",
+	}
+	for variable, replacement := range testVariables {
+		example = strings.ReplaceAll(example, fmt.Sprintf("${local.%s}", variable), replacement)
+		example = strings.ReplaceAll(example, fmt.Sprintf("local.%s", variable), replacement)
+	}
+
+	example = strings.TrimSpace(string(hclwrite.Format([]byte(example))))
+	return example
+}

--- a/tools/importer-rest-api-specs/pipeline/task_generate_terraform_example_usage_test.go
+++ b/tools/importer-rest-api-specs/pipeline/task_generate_terraform_example_usage_test.go
@@ -1,0 +1,68 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
+)
+
+// TODO: this should likely be refactored into a Component, but refactoring this usage for now
+
+func TestConvertBasicTestToUsableExample(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input: `
+resource "azurerm_resource_group" "test" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+`,
+			expected: `
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+`,
+		},
+		{
+			input: `
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-${local.random_integer}"
+  location = "${local.primary_location}"
+}
+`,
+			expected: `
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "West Europe"
+}
+`,
+		},
+		{
+			input: `
+resource "azurerm_resource_group" "test" {
+  name     = "example${local.random_integer}"
+  location = "${local.primary_location}"
+}
+`,
+			expected: `
+resource "azurerm_resource_group" "example" {
+  name     = "example21"
+  location = "West Europe"
+}
+`,
+		},
+	}
+	for _, v := range testData {
+		t.Logf("Testing Input %q", v.input)
+		input := resourcemanager.TerraformResourceTestsDefinition{
+			BasicConfiguration: v.input,
+		}
+		actual := convertBasicTestToUsableExample(input)
+		testhelpers.AssertTemplatedCodeMatches(t, v.expected, actual)
+	}
+}


### PR DESCRIPTION
This PR refactors the Example Usage Generation to be done in `tools/importer-rest-api-specs` so that we can include this in the Data API and proof this - meaning that we'll catch #1720.

Once this PR is merged we can look to fix #1720, but I figured this is worth refactoring first so that we can fix why we missed this bug in the first place.