### PR TITLE
tools/importer-rest-api-specs: parsing operations from the Swagger tags when the Operations use the same tag in different casing

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers.go
@@ -38,7 +38,7 @@ func operationMatchesTag(operation *spec.Operation, tag *string) bool {
 	}
 
 	for _, thisTag := range operation.Tags {
-		if thisTag == *tag {
+		if strings.EqualFold(thisTag, *tag) {
 			return true
 		}
 	}

--- a/tools/importer-rest-api-specs/components/parser/normalization.go
+++ b/tools/importer-rest-api-specs/components/parser/normalization.go
@@ -10,7 +10,11 @@ func normalizeOperationName(operationId string, tag *string) string {
 	operationName := operationId
 	// in some cases the OperationId *is* the Tag, in this instance I guess we take that as ok?
 	if tag != nil && !strings.EqualFold(operationName, *tag) {
-		operationName = strings.TrimPrefix(operationName, *tag)
+		// we're intentionally not using `strings.TrimPrefix` here since we want
+		// to account for the casing of the tag being different
+		if strings.HasPrefix(strings.ToLower(operationName), strings.ToLower(*tag)) {
+			operationName = operationName[len(*tag):]
+		}
 	}
 	operationName = strings.ReplaceAll(operationName, "_", "")
 	operationName = strings.TrimPrefix(operationName, "Operations") // sanity checking

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -25,6 +25,7 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceIds re
 		}
 
 		if resource != nil {
+			d.logger.Trace(fmt.Sprintf("The Tag %q has %d API Operations", tag, len(resource.Operations)))
 			normalizedTag := normalizeTag(tag)
 			normalizedTag = cleanup.NormalizeResourceName(normalizedTag)
 			resources[normalizedTag] = *resource

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags.go
@@ -25,7 +25,7 @@ func (d *SwaggerDefinition) findTags() []string {
 
 	out := make([]string, 0)
 	for key := range tags {
-		out = append(out, key)
+		out = append(out, strings.Title(key))
 	}
 	sort.Strings(out)
 	return out

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
@@ -1,0 +1,35 @@
+package parser
+
+import "testing"
+
+func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "operations_single_tag_different_casing.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	resource, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatal("the Resource 'Hello' was not found")
+	}
+
+	// sanity checking
+	if len(resource.Constants) != 0 {
+		t.Fatalf("expected 0 constants but got %d", len(resource.Constants))
+	}
+	if len(resource.Models) != 1 {
+		t.Fatalf("expected 1 model but got %d", len(resource.Models))
+	}
+	if len(resource.Operations) != 2 {
+		t.Fatalf("expected 2 Operations but got %d", len(resource.Operations))
+	}
+	if len(resource.ResourceIds) != 0 {
+		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
@@ -26,10 +26,21 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 	if len(resource.Models) != 1 {
 		t.Fatalf("expected 1 model but got %d", len(resource.Models))
 	}
-	if len(resource.Operations) != 2 {
-		t.Fatalf("expected 2 Operations but got %d", len(resource.Operations))
+	if len(resource.Operations) != 4 {
+		t.Fatalf("expected 4 Operations but got %d", len(resource.Operations))
 	}
 	if len(resource.ResourceIds) != 0 {
 		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))
+	}
+	expectedOperations := []string{
+		"First",
+		"PutBar",
+		"PutFoo",
+		"Second",
+	}
+	for _, expected := range expectedOperations {
+		if _, ok := resource.Operations[expected]; !ok {
+			t.Fatalf("expected there to be an operation named %q but didn't get one", expected)
+		}
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_single_tag_different_casing.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_single_tag_different_casing.json
@@ -23,7 +23,7 @@
         "tags": [
           "hello"
         ],
-        "operationId": "hello_PutWorld",
+        "operationId": "hello_PutFoo",
         "description": "A PUT request with no body returned.",
         "parameters": [
           {
@@ -48,7 +48,7 @@
         "tags": [
           "Hello"
         ],
-        "operationId": "Hello_PutWorld",
+        "operationId": "Hello_PutBar",
         "description": "A PUT request with no body returned.",
         "parameters": [
           {

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_single_tag_different_casing.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_single_tag_different_casing.json
@@ -1,0 +1,84 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/foo": {
+      "put": {
+        "tags": [
+          "hello"
+        ],
+        "operationId": "hello_PutWorld",
+        "description": "A PUT request with no body returned.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Example request object."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    },
+    "/bar": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_PutWorld",
+        "description": "A PUT request with no body returned.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Example request object."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    }
+  },
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_single_tag_different_casing.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_single_tag_different_casing.json
@@ -67,6 +67,54 @@
           }
         }
       }
+    },
+    "/some-other-uri": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_First",
+        "description": "A PUT request with no body returned.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Example request object."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "hello_Second",
+        "description": "A PATCH request with no body returned.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Example request object."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
This fixes an issue when importing `Kusto` where the Scripts Operations are defined both within the Swagger Tag `scripts` and `Scripts` - by normalising the Swagger tag to `Scripts`.

Fixes #1727