### PR TITLE
`generator-go-sdk`: compatiable with literal string response

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -587,10 +587,16 @@ func (c methodsAutoRestTemplater) responderTemplate(responseStructName string, d
 
 	steps := make([]string, 0)
 	steps = append(steps, fmt.Sprintf("azure.WithErrorUnlessStatusCode(%s)", strings.Join(expectedStatusCodes, ", ")))
+	// delcare []byte for string body
+	var bsDeclare, bsAssign string
 	if c.operation.ResponseObject != nil {
 		if discriminatedType == "" { // If this is a discriminated type with a parent interface, do not use the autorest decorator to unmarshal it
 			if c.operation.FieldContainingPaginationDetails != nil {
 				steps = append(steps, "autorest.ByUnmarshallingJSON(&respObj)")
+			} else if typ := c.operation.ContentType; typ != nil && *typ == "text/powershell" {
+				bsDeclare = "var content []byte\n\t"
+				bsAssign = "str := string(content)\n\tresult.Model = &str\n\t"
+				steps = append(steps, "autorest.ByUnmarshallingBytes(&content)")
 			} else {
 				steps = append(steps, "autorest.ByUnmarshallingJSON(&result.Model)")
 			}
@@ -678,14 +684,15 @@ func (c %[1]s) responderFor%[2]s(resp *http.Response) (result %[5]s, err error) 
 // responderFor%[2]s handles the response to the %[2]s request. The method always
 // closes the http.Response Body.
 func (c %[1]s) responderFor%[2]s(resp *http.Response) (result %[5]s, err error) {
-	err = autorest.Respond(
+	%[6]serr = autorest.Respond(
 		resp,
 		%[3]s)
-	result.HttpResponse = resp
+	%[7]sresult.HttpResponse = resp
 
 	return
 }
-`, data.serviceClientName, c.operationName, strings.Join(steps, ",\n\t\t"), discriminatedType, responseStructName)
+`, data.serviceClientName, c.operationName, strings.Join(steps, ",\n\t\t"), discriminatedType, responseStructName,
+		bsDeclare, bsAssign)
 
 	return &output, nil
 }

--- a/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
@@ -190,11 +190,14 @@ func (c pandaClient) List(ctx context.Context, id PandaPop) (resp ListOperationR
 // responderForList handles the response to the List request. The method always
 // closes the http.Response Body.
 func (c pandaClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	var content []byte
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(),
-		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByUnmarshallingBytes(&content),
 		autorest.ByClosing())
+	str := string(content)
+	result.Model = &str
 	result.HttpResponse = resp
 	return
 }

--- a/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
@@ -138,6 +138,7 @@ func TestTemplateMethodsAutoRestBaseTypePredicates(t *testing.T) {
 				Type: resourcemanager.StringApiObjectDefinitionType,
 			},
 			ResourceIdName: stringPointer("PandaPop"),
+			ContentType:    stringPointer("text/powershell"),
 		},
 		operationName: "List",
 	}.listOperationTemplate(input)
@@ -180,6 +181,7 @@ func (c pandaClient) List(ctx context.Context, id PandaPop) (resp ListOperationR
 			"api-version": defaultApiVersion,
 		}
 		preparer := autorest.CreatePreparer(
+		autorest.AsContentType("text/powershell"),
 		autorest.AsGet(),
 		autorest.WithBaseURL(c.baseUri),
 		autorest.WithPath(id.ID()),


### PR DESCRIPTION
If the Response Body is a literal string, not a structure JSON, the currently generated code will also unmarshal by JSON which causes an error. This PR tries to unmarshalBytes for this kind of response. So we don't need to wait service team to fix the swagger issue https://github.com/Azure/azure-sdk-for-go/issues/17591 and we can solve all failed Automation AccTest cases.

Makes these PRs possible or improved
- https://github.com/hashicorp/terraform-provider-azurerm/pull/17875
-  https://github.com/hashicorp/terraform-provider-azurerm/pull/18213
- https://github.com/hashicorp/terraform-provider-azurerm/pull/17801
- https://github.com/hashicorp/terraform-provider-azurerm/pull/17804

## TODO
remove test code in `preparerForList` for content type (`autorest.AsContentType("text/powershell"),`  once https://github.com/hashicorp/pandora/pull/1908 merged.

## Diff of generated code

I have generated all RPs locally, and here is the diff between the code by the new template and the main branch of [hashicorp/go-azure-sdk](https://github.com/hashicorp/go-azure-sdk)

```diff
diff --git a/resource-manager/automation/2019-06-01/dscconfiguration/method_getcontent_autorest.go b/resource-manager/automation/2019-06-01/dscconfiguration/method_getcontent_autorest.go
index 1af9f4fa..c136f91e 100644
--- a/resource-manager/automation/2019-06-01/dscconfiguration/method_getcontent_autorest.go
+++ b/resource-manager/automation/2019-06-01/dscconfiguration/method_getcontent_autorest.go
@@ -58,11 +58,14 @@ func (c DscConfigurationClient) preparerForGetContent(ctx context.Context, id Co
 // responderForGetContent handles the response to the GetContent request. The method always
 // closes the http.Response Body.
 func (c DscConfigurationClient) responderForGetContent(resp *http.Response) (result GetContentOperationResponse, err error) {
+	var content []byte
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByUnmarshallingBytes(&content),
 		autorest.ByClosing())
+	str := string(content)
+	result.Model = &str
 	result.HttpResponse = resp
 
 	return
diff --git a/resource-manager/automation/2019-06-01/job/method_getoutput_autorest.go b/resource-manager/automation/2019-06-01/job/method_getoutput_autorest.go
index e4c1838b..48c601a8 100644
--- a/resource-manager/automation/2019-06-01/job/method_getoutput_autorest.go
+++ b/resource-manager/automation/2019-06-01/job/method_getoutput_autorest.go
@@ -87,11 +87,14 @@ func (c JobClient) preparerForGetOutput(ctx context.Context, id JobId, options G
 // responderForGetOutput handles the response to the GetOutput request. The method always
 // closes the http.Response Body.
 func (c JobClient) responderForGetOutput(resp *http.Response) (result GetOutputOperationResponse, err error) {
+	var content []byte
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByUnmarshallingBytes(&content),
 		autorest.ByClosing())
+	str := string(content)
+	result.Model = &str
 	result.HttpResponse = resp
 
 	return
diff --git a/resource-manager/automation/2019-06-01/job/method_getrunbookcontent_autorest.go b/resource-manager/automation/2019-06-01/job/method_getrunbookcontent_autorest.go
index d906300d..5960a471 100644
--- a/resource-manager/automation/2019-06-01/job/method_getrunbookcontent_autorest.go
+++ b/resource-manager/automation/2019-06-01/job/method_getrunbookcontent_autorest.go
@@ -87,11 +87,14 @@ func (c JobClient) preparerForGetRunbookContent(ctx context.Context, id JobId, o
 // responderForGetRunbookContent handles the response to the GetRunbookContent request. The method always
 // closes the http.Response Body.
 func (c JobClient) responderForGetRunbookContent(resp *http.Response) (result GetRunbookContentOperationResponse, err error) {
+	var content []byte
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByUnmarshallingBytes(&content),
 		autorest.ByClosing())
+	str := string(content)
+	result.Model = &str
 	result.HttpResponse = resp
 
 	return
diff --git a/resource-manager/automation/2019-06-01/runbook/method_getcontent_autorest.go b/resource-manager/automation/2019-06-01/runbook/method_getcontent_autorest.go
index 22370327..2bb7cbca 100644
--- a/resource-manager/automation/2019-06-01/runbook/method_getcontent_autorest.go
+++ b/resource-manager/automation/2019-06-01/runbook/method_getcontent_autorest.go
@@ -58,11 +58,14 @@ func (c RunbookClient) preparerForGetContent(ctx context.Context, id RunbookId)
 // responderForGetContent handles the response to the GetContent request. The method always
 // closes the http.Response Body.
 func (c RunbookClient) responderForGetContent(resp *http.Response) (result GetContentOperationResponse, err error) {
+	var content []byte
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByUnmarshallingBytes(&content),
 		autorest.ByClosing())
+	str := string(content)
+	result.Model = &str
 	result.HttpResponse = resp
 
 	return
diff --git a/resource-manager/automation/2019-06-01/runbookdraft/method_getcontent_autorest.go b/resource-manager/automation/2019-06-01/runbookdraft/method_getcontent_autorest.go
index 15814ca0..c75b0910 100644
--- a/resource-manager/automation/2019-06-01/runbookdraft/method_getcontent_autorest.go
+++ b/resource-manager/automation/2019-06-01/runbookdraft/method_getcontent_autorest.go
@@ -58,11 +58,14 @@ func (c RunbookDraftClient) preparerForGetContent(ctx context.Context, id Runboo
 // responderForGetContent handles the response to the GetContent request. The method always
 // closes the http.Response Body.
 func (c RunbookDraftClient) responderForGetContent(resp *http.Response) (result GetContentOperationResponse, err error) {
+	var content []byte
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByUnmarshallingBytes(&content),
 		autorest.ByClosing())
+	str := string(content)
+	result.Model = &str
 	result.HttpResponse = resp
 
 	return
diff --git a/resource-manager/postgresql/2021-06-01/getprivatednszonesuffix/method_execute_autorest.go b/resource-manager/postgresql/2021-06-01/getprivatednszonesuffix/method_execute_autorest.go
index 57464513..2100294a 100644
--- a/resource-manager/postgresql/2021-06-01/getprivatednszonesuffix/method_execute_autorest.go
+++ b/resource-manager/postgresql/2021-06-01/getprivatednszonesuffix/method_execute_autorest.go
@@ -57,11 +57,14 @@ func (c GetPrivateDnsZoneSuffixClient) preparerForExecute(ctx context.Context) (
 // responderForExecute handles the response to the Execute request. The method always
 // closes the http.Response Body.
 func (c GetPrivateDnsZoneSuffixClient) responderForExecute(resp *http.Response) (result ExecuteOperationResponse, err error) {
+	var content []byte
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
-		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByUnmarshallingBytes(&content),
 		autorest.ByClosing())
+	str := string(content)
+	result.Model = &str
 	result.HttpResponse = resp
 
 	return

```


## May affect RPs:

![image](https://user-images.githubusercontent.com/2633022/197940022-24dc2933-3a96-4160-981d-be816a0cfab4.png)

