### PR TITLE
tools/importer-rest-api-specs: surfacing the `Content-Type` as required

### DIFF
--- a/data/Pandora.Definitions/Operations/GetOperation.cs
+++ b/data/Pandora.Definitions/Operations/GetOperation.cs
@@ -6,8 +6,7 @@ using Pandora.Definitions.Interfaces;
 
 namespace Pandora.Definitions.Operations;
 
-public abstract class
-    GetOperation : ApiOperation
+public abstract class GetOperation : ApiOperation
 {
     public virtual string? ContentType()
     {

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_operation.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_operation.go
@@ -12,7 +12,7 @@ func codeForOperation(namespace string, operationName string, operation models.O
 	code := make([]string, 0)
 
 	if !strings.Contains(strings.ToLower(operation.ContentType), "application/json") {
-		code = append(code, fmt.Sprintf(`		public override string? ContentType() => %[1]q;`, operation.ContentType))
+		code = append(code, fmt.Sprintf(`\t\tpublic override string? ContentType() => %[1]q;`, operation.ContentType))
 	}
 
 	if usesNonDefaultStatusCodes(operation) {
@@ -21,19 +21,19 @@ func codeForOperation(namespace string, operationName string, operation models.O
 			statusCodes = append(statusCodes, fmt.Sprintf("\t\t\t\t%s,", dotnetNameForStatusCode(sc)))
 		}
 		sort.Strings(statusCodes)
-		code = append(code, fmt.Sprintf(`		public override IEnumerable<HttpStatusCode> ExpectedStatusCodes() => new List<HttpStatusCode>
+		code = append(code, fmt.Sprintf(`\t\tpublic override IEnumerable<HttpStatusCode> ExpectedStatusCodes() => new List<HttpStatusCode>
 		{
 %s
 		};`, strings.Join(statusCodes, "\n")))
 	}
 
 	if operation.FieldContainingPaginationDetails != nil {
-		code = append(code, fmt.Sprintf(`		public override string? FieldContainingPaginationDetails() => %[1]q;`, *operation.FieldContainingPaginationDetails))
+		code = append(code, fmt.Sprintf(`\t\tpublic override string? FieldContainingPaginationDetails() => %[1]q;`, *operation.FieldContainingPaginationDetails))
 	}
 
 	if operation.LongRunning {
 		// TODO: we can use the `LongRunning` operation base types too
-		code = append(code, `		public override bool LongRunning() => true;`)
+		code = append(code, `\t\tpublic override bool LongRunning() => true;`)
 	}
 
 	if operation.RequestObject != nil {
@@ -45,11 +45,11 @@ func codeForOperation(namespace string, operationName string, operation models.O
 		code = append(code, fmt.Sprintf(`		public override Type? RequestObject() => typeof(%[1]s);`, *requestOperationTypeName))
 	} else if strings.EqualFold(operation.Method, "POST") || strings.EqualFold(operation.Method, "PUT") {
 		// Post and Put operations should have one but it's possible they don't
-		code = append(code, fmt.Sprintf(`		public override Type? RequestObject() => null;`))
+		code = append(code, fmt.Sprintf(`\t\tpublic override Type? RequestObject() => null;`))
 	}
 
 	if operation.ResourceIdName != nil {
-		code = append(code, fmt.Sprintf(`		public override ResourceID? ResourceId() => new %[1]s();`, *operation.ResourceIdName))
+		code = append(code, fmt.Sprintf(`\t\tpublic override ResourceID? ResourceId() => new %[1]s();`, *operation.ResourceIdName))
 	}
 
 	if operation.ResponseObject != nil {
@@ -59,15 +59,15 @@ func codeForOperation(namespace string, operationName string, operation models.O
 		}
 
 		if operation.FieldContainingPaginationDetails == nil {
-			code = append(code, fmt.Sprintf(`		public override Type? ResponseObject() => typeof(%[1]s);`, *responseOperationTypeName))
+			code = append(code, fmt.Sprintf(`\t\tpublic override Type? ResponseObject() => typeof(%[1]s);`, *responseOperationTypeName))
 		} else {
-			code = append(code, fmt.Sprintf(`		public override Type NestedItemType() => typeof(%[1]s);`, *responseOperationTypeName))
+			code = append(code, fmt.Sprintf(`\t\tpublic override Type NestedItemType() => typeof(%[1]s);`, *responseOperationTypeName))
 		}
 	}
 
 	optionsCode := make([]string, 0)
 	if len(operation.Options) > 0 {
-		code = append(code, fmt.Sprintf(`		public override Type? OptionsObject() => typeof(%[1]sOperation.%[1]sOptions);`, operationName))
+		code = append(code, fmt.Sprintf(`\t\tpublic override Type? OptionsObject() => typeof(%[1]sOperation.%[1]sOptions);`, operationName))
 
 		optionsCode = append(optionsCode, fmt.Sprintf("\t\tinternal class %sOptions", operationName))
 		optionsCode = append(optionsCode, "\t\t{")
@@ -112,7 +112,7 @@ func codeForOperation(namespace string, operationName string, operation models.O
 	}
 
 	if operation.UriSuffix != nil {
-		code = append(code, fmt.Sprintf(`		public override string? UriSuffix() => %[1]q;`, *operation.UriSuffix))
+		code = append(code, fmt.Sprintf(`\t\tpublic override string? UriSuffix() => %[1]q;`, *operation.UriSuffix))
 	}
 
 	operationType := strings.Title(strings.ToLower(operation.Method))
@@ -123,7 +123,7 @@ func codeForOperation(namespace string, operationName string, operation models.O
 		// is a POST not a GET for a List operation)
 		if !strings.EqualFold(operation.Method, "GET") {
 			method := dotNetNameForHttpMethod(operation.Method)
-			code = append(code, fmt.Sprintf(`		public override System.Net.Http.HttpMethod Method() => System.Net.Http.%s;`, method))
+			code = append(code, fmt.Sprintf(`\t\tpublic override System.Net.Http.HttpMethod Method() => System.Net.Http.%s;`, method))
 		}
 	}
 	output := fmt.Sprintf(`using Pandora.Definitions.Attributes;

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_operation.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_operation.go
@@ -11,6 +11,10 @@ import (
 func codeForOperation(namespace string, operationName string, operation models.OperationDetails, resource models.AzureApiResource) (*string, error) {
 	code := make([]string, 0)
 
+	if !strings.Contains(strings.ToLower(operation.ContentType), "application/json") {
+		code = append(code, fmt.Sprintf(`		public override string? ContentType() => %[1]q;`, operation.ContentType))
+	}
+
 	if usesNonDefaultStatusCodes(operation) {
 		statusCodes := make([]string, 0)
 		for _, sc := range operation.ExpectedStatusCodes {

--- a/tools/importer-rest-api-specs/components/parser/operations.go
+++ b/tools/importer-rest-api-specs/components/parser/operations.go
@@ -219,12 +219,12 @@ func (p operationsParser) determineContentType(operation parsedOperation) string
 	contentType := "application/json"
 
 	if strings.EqualFold(operation.httpMethod, "HEAD") || strings.EqualFold(operation.httpMethod, "GET") {
-		if len(operation.operation.Consumes) > 0 {
-			contentType = operation.operation.Consumes[0]
-		}
-	} else {
 		if len(operation.operation.Produces) > 0 {
 			contentType = operation.operation.Produces[0]
+		}
+	} else {
+		if len(operation.operation.Consumes) > 0 {
+			contentType = operation.operation.Consumes[0]
 		}
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/operations_test.go
+++ b/tools/importer-rest-api-specs/components/parser/operations_test.go
@@ -3155,3 +3155,48 @@ func TestParseOperationMultipleBasedOnTheSameResourceId(t *testing.T) {
 		t.Fatal("expected a non-long running operation but it was long running")
 	}
 }
+
+func TestParseOperationsContainingContentTypes(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "operation_content_types.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 0 {
+		t.Fatalf("expected no Models but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 3 {
+		t.Fatalf("expected 3 Operations but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	var validateOperationHasContentType = func(operationName, contentType string) {
+		operation, ok := hello.Operations[operationName]
+		if !ok {
+			t.Fatalf("an operation named %q was not found", operationName)
+		}
+
+		if operation.ContentType != contentType {
+			t.Fatalf("expected the operation %q to have the content-type %q but got %q", operationName, contentType, operation.ContentType)
+		}
+	}
+	validateOperationHasContentType("Default", "application/json")
+	validateOperationHasContentType("XmlRequest", "application/xml")
+	validateOperationHasContentType("XmlResponse", "application/xml")
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/operation_content_types.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operation_content_types.json
@@ -1,0 +1,81 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/default": {
+      "head": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_Default",
+        "description": "An operation using the implied default Request and Response Content-Types (JSON).",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    },
+    "/xml-request": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_XmlRequest",
+        "produces": [
+          "application/xml"
+        ],
+        "description": "An operation using XML as a Content-Type. This intentionally only sets Produces and not Consumes since this shouldn't be set for Get.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/xml-response": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_XmlResponse",
+        "consumes": [
+          "application/xml"
+        ],
+        "description": "An operation using XML as a Content-Type. This intentionally only sets Consumes and not Produces since this shouldn't be set for a PUT.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}


### PR DESCRIPTION
Spotted whilst reviewing #1756 that we're not currently outputting the Content-Type into the Data API, as such we're always outputting JSON regardless of what the operation supports.

This PR fixes this, so that we can use this information down the line - and also fixes a bug where the Consumes and Produces in the Swagger were being parsed the wrong way around (such that we want to parse the Consumes from a PUT/POST etc, and the Consumes from a HEAD/GET)