### PR TITLE
data: Zone and Zones are custom types

### DIFF
--- a/data/Pandora.Data/Helpers/Type.cs
+++ b/data/Pandora.Data/Helpers/Type.cs
@@ -110,6 +110,8 @@ public static class TypeExtensions
             typeof(Definitions.CustomTypes.UserAssignedIdentityList),
             typeof(Definitions.CustomTypes.UserAssignedIdentityMap),
             typeof(Definitions.CustomTypes.SystemData),
+            typeof(Definitions.CustomTypes.Zone),
+            typeof(Definitions.CustomTypes.Zones),
         };
         return customTypes.Contains(input);
     }


### PR DESCRIPTION
Reset this change but meant to commit/push it, this change means that we don't erroneously output Zones as a Model (https://github.com/hashicorp/go-azure-sdk/pull/198/files#diff-0fcb75d1dbaf606e6b83b826a2d2fa4c70fd98e70644a2742123e0da79b21225R6-R7) but rather as a Custom Type