### PR TITLE
tools/importer-rest-api-specs / Data API: initial support for Dictionaries in the Schema

### DIFF
--- a/data/Pandora.Api/V1/ResourceManager/Terraform-Models.cs
+++ b/data/Pandora.Api/V1/ResourceManager/Terraform-Models.cs
@@ -218,6 +218,7 @@ public partial class TerraformController
         // Core items
         Boolean,
         DateTime,
+        Dictionary,
         Integer,
         Float,
         List,

--- a/data/Pandora.Api/V1/ResourceManager/Terraform.cs
+++ b/data/Pandora.Api/V1/ResourceManager/Terraform.cs
@@ -247,6 +247,8 @@ public partial class TerraformController : ControllerBase
                 return TerraformSchemaFieldType.Boolean.ToString();
             case Data.Models.TerraformSchemaFieldType.DateTime:
                 return TerraformSchemaFieldType.DateTime.ToString();
+            case Data.Models.TerraformSchemaFieldType.Dictionary:
+                return TerraformSchemaFieldType.Dictionary.ToString();
             case Data.Models.TerraformSchemaFieldType.Float:
                 return TerraformSchemaFieldType.Float.ToString();
             case Data.Models.TerraformSchemaFieldType.Integer:

--- a/data/Pandora.Data/Models/TerraformSchemaObjectDefinition.cs
+++ b/data/Pandora.Data/Models/TerraformSchemaObjectDefinition.cs
@@ -13,6 +13,7 @@ public enum TerraformSchemaFieldType
 {
     Boolean,
     DateTime,
+    Dictionary,
     Float,
     Integer,
     List,

--- a/data/Pandora.Data/Transformers/TerraformSchemaObjectDefinition.cs
+++ b/data/Pandora.Data/Transformers/TerraformSchemaObjectDefinition.cs
@@ -14,6 +14,17 @@ public static class TerraformSchemaObjectDefinition
         // TODO: add tests specifically for this method
         // TODO: support for Sets
 
+        if (input.IsAGenericDictionary())
+        {
+            var listElement = input.GenericDictionaryValueElement();
+            var nestedItem = Map(listElement);
+            return new Models.TerraformSchemaObjectDefinition
+            {
+                Type = TerraformSchemaFieldType.Dictionary,
+                NestedObject = nestedItem,
+            };
+        }
+
         if (input.IsAGenericList())
         {
             var listElement = input.GenericListElement();

--- a/data/Pandora.Data/Transformers/TerraformSchemaObjectDefinitionTests.cs
+++ b/data/Pandora.Data/Transformers/TerraformSchemaObjectDefinitionTests.cs
@@ -110,6 +110,43 @@ public static class TerraformSchemaObjectDefinitionTests
     }
 
     [TestCase]
+    public static void MappingADictionaryOfBasicTypes()
+    {
+        var basicTypes = new Dictionary<Type, TerraformSchemaFieldType>
+        {
+            {typeof(Dictionary<string, bool>), TerraformSchemaFieldType.Boolean},
+            {typeof(Dictionary<string, float>), TerraformSchemaFieldType.Float},
+            {typeof(Dictionary<string, int>), TerraformSchemaFieldType.Integer},
+            {typeof(Dictionary<string, string>), TerraformSchemaFieldType.String},
+        };
+        foreach (var basicType in basicTypes)
+        {
+            var result = TerraformSchemaObjectDefinition.Map(basicType.Key);
+            Assert.NotNull(result);
+            Assert.AreEqual(TerraformSchemaFieldType.Dictionary, result.Type);
+            Assert.NotNull(result.NestedObject);
+            Assert.Null(result.ReferenceName);
+            Assert.AreEqual(basicType.Value, result.NestedObject.Type);
+            Assert.Null(result.NestedObject.NestedObject);
+            Assert.Null(result.NestedObject.ReferenceName);
+        }
+    }
+
+    [TestCase]
+    public static void MappingADictionaryOfComplexType()
+    {
+        var result = TerraformSchemaObjectDefinition.Map(typeof(Dictionary<string, SomeModel>));
+        Assert.NotNull(result);
+        Assert.AreEqual(TerraformSchemaFieldType.Dictionary, result.Type);
+        Assert.NotNull(result.NestedObject);
+        Assert.Null(result.ReferenceName);
+        Assert.AreEqual(TerraformSchemaFieldType.Reference, result.NestedObject.Type);
+        Assert.Null(result.NestedObject.NestedObject);
+        Assert.NotNull(result.NestedObject.ReferenceName);
+        Assert.AreEqual("SomeModel", result.NestedObject.ReferenceName);
+    }
+
+    [TestCase]
     public static void MappingAReference()
     {
         var result = TerraformSchemaObjectDefinition.Map(typeof(SomeModel));

--- a/tools/generator-terraform/generator/helpers/object_definition.go
+++ b/tools/generator-terraform/generator/helpers/object_definition.go
@@ -42,6 +42,20 @@ func GolangFieldTypeFromObjectFieldDefinition(input resourcemanager.TerraformSch
 		return &goTypeName, nil
 	}
 
+	if input.Type == resourcemanager.TerraformSchemaFieldTypeDictionary {
+		if input.NestedObject == nil {
+			return nil, fmt.Errorf("dictionary type had no nested object")
+		}
+
+		nestedObjectType, err := GolangFieldTypeFromObjectFieldDefinition(*input.NestedObject)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving golang field type for dictionary nested item: %+v", err)
+		}
+
+		output := fmt.Sprintf("map[string]%s", *nestedObjectType)
+		return &output, nil
+	}
+
 	if input.Type == resourcemanager.TerraformSchemaFieldTypeReference {
 		if input.ReferenceName == nil {
 			return nil, fmt.Errorf("reference type had no reference")

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_schema.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_schema.go
@@ -98,6 +98,19 @@ func topLevelFieldObjectDefinition(input resourcemanager.TerraformSchemaFieldObj
 }
 
 func dotNetTypeNameForTerraformFieldObjectDefinition(input resourcemanager.TerraformSchemaFieldObjectDefinition, constants map[string]resourcemanager.ConstantDetails, models map[string]resourcemanager.TerraformSchemaModelDefinition) (*string, error) {
+	if input.Type == resourcemanager.TerraformSchemaFieldTypeDictionary {
+		if input.NestedObject == nil {
+			return nil, fmt.Errorf("a dictionary must have a nested object")
+		}
+		
+		nestedObject, err := dotNetTypeNameForTerraformFieldObjectDefinition(*input.NestedObject, constants, models)
+		if err != nil {
+			return nil, fmt.Errorf("determining dotnet type name for nested object definition: %+v", err)
+		}
+		out := fmt.Sprintf("Dictionary<string, %s>", *nestedObject)
+		return &out, nil
+	}
+
 	if input.Type == resourcemanager.TerraformSchemaFieldTypeList {
 		if input.NestedObject == nil {
 			return nil, fmt.Errorf("a list must have a nested object")

--- a/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
+++ b/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
@@ -531,6 +531,10 @@ func NormalizeCanonicalisation(input string) string {
 		output = strings.Replace(output, "http", "HTTP", 1)
 	}
 
+	if strings.Contains(output, "github") {
+		output = strings.Replace(output, "github", "gitHub", 1)
+	}
+
 	if strings.EqualFold(output, "Publicipaddress") {
 		// This is an explicit force for broken data in `Network`
 		output = "PublicIPAddress"

--- a/tools/importer-rest-api-specs/components/schema/object_definition.go
+++ b/tools/importer-rest-api-specs/components/schema/object_definition.go
@@ -9,13 +9,13 @@ import (
 var apiObjectDefinitionTypesToFieldObjectDefinitionTypes = map[resourcemanager.ApiObjectDefinitionType]resourcemanager.TerraformSchemaFieldType{
 	resourcemanager.BooleanApiObjectDefinitionType: resourcemanager.TerraformSchemaFieldTypeBoolean,
 	//resourcemanager.CsvApiObjectDefinitionType:  resourcemanager.TerraformSchemaFieldTypeCsv, // TODO: implement
-	resourcemanager.DateTimeApiObjectDefinitionType: resourcemanager.TerraformSchemaFieldTypeDateTime,
-	//resourcemanager.DictionaryApiObjectDefinitionType:  resourcemanager.TerraformSchemaFieldTypeDictionary, // TODO: implement
-	resourcemanager.IntegerApiObjectDefinitionType:   resourcemanager.TerraformSchemaFieldTypeInteger,
-	resourcemanager.FloatApiObjectDefinitionType:     resourcemanager.TerraformSchemaFieldTypeFloat,
-	resourcemanager.ListApiObjectDefinitionType:      resourcemanager.TerraformSchemaFieldTypeList,
-	resourcemanager.ReferenceApiObjectDefinitionType: resourcemanager.TerraformSchemaFieldTypeReference,
-	resourcemanager.StringApiObjectDefinitionType:    resourcemanager.TerraformSchemaFieldTypeString,
+	resourcemanager.DateTimeApiObjectDefinitionType:   resourcemanager.TerraformSchemaFieldTypeDateTime,
+	resourcemanager.DictionaryApiObjectDefinitionType: resourcemanager.TerraformSchemaFieldTypeDictionary,
+	resourcemanager.IntegerApiObjectDefinitionType:    resourcemanager.TerraformSchemaFieldTypeInteger,
+	resourcemanager.FloatApiObjectDefinitionType:      resourcemanager.TerraformSchemaFieldTypeFloat,
+	resourcemanager.ListApiObjectDefinitionType:       resourcemanager.TerraformSchemaFieldTypeList,
+	resourcemanager.ReferenceApiObjectDefinitionType:  resourcemanager.TerraformSchemaFieldTypeReference,
+	resourcemanager.StringApiObjectDefinitionType:     resourcemanager.TerraformSchemaFieldTypeString,
 
 	// Custom Types
 	resourcemanager.EdgeZoneApiObjectDefinitionType:                                resourcemanager.TerraformSchemaFieldTypeEdgeZone,

--- a/tools/sdk/resourcemanager/terraform.go
+++ b/tools/sdk/resourcemanager/terraform.go
@@ -382,14 +382,15 @@ type ResourceDocumentationDefinition struct {
 type TerraformSchemaFieldType string
 
 const (
-	TerraformSchemaFieldTypeBoolean   TerraformSchemaFieldType = "Boolean"
-	TerraformSchemaFieldTypeDateTime  TerraformSchemaFieldType = "DateTime"
-	TerraformSchemaFieldTypeFloat     TerraformSchemaFieldType = "Float"
-	TerraformSchemaFieldTypeInteger   TerraformSchemaFieldType = "Integer"
-	TerraformSchemaFieldTypeList      TerraformSchemaFieldType = "List"
-	TerraformSchemaFieldTypeReference TerraformSchemaFieldType = "Reference"
-	TerraformSchemaFieldTypeSet       TerraformSchemaFieldType = "Set"
-	TerraformSchemaFieldTypeString    TerraformSchemaFieldType = "String"
+	TerraformSchemaFieldTypeBoolean    TerraformSchemaFieldType = "Boolean"
+	TerraformSchemaFieldTypeDateTime   TerraformSchemaFieldType = "DateTime"
+	TerraformSchemaFieldTypeDictionary TerraformSchemaFieldType = "Dictionary"
+	TerraformSchemaFieldTypeFloat      TerraformSchemaFieldType = "Float"
+	TerraformSchemaFieldTypeInteger    TerraformSchemaFieldType = "Integer"
+	TerraformSchemaFieldTypeList       TerraformSchemaFieldType = "List"
+	TerraformSchemaFieldTypeReference  TerraformSchemaFieldType = "Reference"
+	TerraformSchemaFieldTypeSet        TerraformSchemaFieldType = "Set"
+	TerraformSchemaFieldTypeString     TerraformSchemaFieldType = "String"
 	// NOTE: we intentionally only have Terraform Schema fields (and specific CustomSchema types) here - meaning
 	// that we don't have RawObject/RawFile since we have no means of expressing them today.
 


### PR DESCRIPTION
This PR adds support for Dictionaries to the Terraform Schema in both the `importer-rest-api-specs` tool and the `Data API` such we can look to output these.

At this point in time no Resources make use of this, so whilst this is incomplete (and the remaining mappings work is tracked in #1777) - this isn't currently threaded through end-to-end and thus isn't usable at this time.

An example Resource which uses this is DeveloperHub:

```hcl
service "DevHub" {
  terraform_package = "developerhub"

  api "2022-04-01-preview" {
    package "Workflow" {
      definition "developerhub_workflow" {
        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevHub/workflows/{workflowName}"
        display_name = "Developer Hub Workflow"
        website_subcategory = "Developer Hub"
        description = "Manages a Developer Hub Workflow"
      }
    }
  }
}
```