### PR TITLE
`importer-rest-api-specs` and `generator-terraform`: various fixes

### DIFF
--- a/tools/generator-terraform/generator/resource/component_update_func.go
+++ b/tools/generator-terraform/generator/resource/component_update_func.go
@@ -150,7 +150,11 @@ func (h updateFuncHelpers) payloadDefinition() (*string, error) {
 				return fmt.Errorf("retrieving existing %%s: properties was nil", *id)
 			}
 			payload := *existing.Model
-`, methodName, methodArguments)
+
+			if err := r.map%[3]sTo%[4]s(config, &payload); err != nil {
+				return fmt.Errorf("mapping schema model to sdk model: %%+v", err)
+			}
+`, methodName, methodArguments, h.schemaModelName, *h.updateMethod.RequestObject.ReferenceName)
 		return &output, nil
 	}
 

--- a/tools/generator-terraform/generator/resource/component_update_func_test.go
+++ b/tools/generator-terraform/generator/resource/component_update_func_test.go
@@ -801,6 +801,9 @@ func TestComponentUpdate_PayloadDefinition_ModelSharedBetweenCreateReadUpdate(t 
 		return fmt.Errorf("retrieving existing %s: properties was nil", *id)
 	}
 	payload := *existing.Model
+	if err := r.mapToSharedPayload(config, &payload); err != nil {
+		return fmt.Errorf("mapping schema model to sdk model: %+v", err)
+	}
 `
 	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
 }

--- a/tools/importer-rest-api-specs/components/parser/swagger_data_workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_data_workarounds.go
@@ -38,29 +38,6 @@ func patchSwaggerData(input []models.AzureApiDefinition, logger hclog.Logger) (*
 			item.Resources["LoadTests"] = resource
 		}
 
-		// Works around the `DnsPrefix` field being required but being marked as Optional
-		// Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/21394
-		if item.ServiceName == "ContainerService" && item.ApiVersion == "2022-09-02-preview" {
-			logger.Trace(fmt.Sprintf("Processing Overrides for Service %q / API Version %q..", item.ServiceName, item.ApiVersion))
-			resource, ok := item.Resources["Fleets"]
-			if !ok {
-				return nil, fmt.Errorf("couldn't find API Resource Fleets")
-			}
-			model, ok := resource.Models["FleetHubProfile"]
-			if !ok {
-				return nil, fmt.Errorf("couldn't find Model FleetHubProfile")
-			}
-			field, ok := model.Fields["DnsPrefix"]
-			if !ok {
-				return nil, fmt.Errorf("couldn't find field DnsPrefix within model FleetHubProfile")
-			}
-			field.Required = true
-
-			model.Fields["DnsPrefix"] = field
-			resource.Models["FleetHubProfile"] = model
-			item.Resources["Fleets"] = resource
-		}
-
 		output = append(output, item)
 	}
 

--- a/tools/importer-rest-api-specs/components/schema/fields_nested.go
+++ b/tools/importer-rest-api-specs/components/schema/fields_nested.go
@@ -132,16 +132,17 @@ func (b Builder) identifyFieldsWithinPropertiesBlock(schemaModelName string, inp
 		definition.ObjectDefinition = *objectDefinition
 
 		if objectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeReference {
+			nestedModelName := *objectDefinition.ReferenceName
 			if fieldExists(input.createPropertiesPayload, k) {
-				mappings.Fields = append(mappings.Fields, modelToModelMappingBetween(fmt.Sprintf("%s%s", schemaModelName, fieldNameForTypedModel), input.createPropertiesModelName, k))
+				mappings.Fields = append(mappings.Fields, modelToModelMappingBetween(nestedModelName, input.createPropertiesModelName, k))
 			}
 
 			if fieldExists(input.readPropertiesPayload, k) && input.createPropertiesModelName != input.readPropertiesModelName {
-				mappings.Fields = append(mappings.Fields, modelToModelMappingBetween(fmt.Sprintf("%s%s", schemaModelName, fieldNameForTypedModel), input.readPropertiesModelName, k))
+				mappings.Fields = append(mappings.Fields, modelToModelMappingBetween(nestedModelName, input.readPropertiesModelName, k))
 			}
 			if input.updatePayload != nil && input.updatePropertiesPayload != nil && fieldExists(*input.updatePropertiesPayload, k) {
 				if input.createPropertiesModelName != *input.updatePropertiesModelName && input.readPropertiesModelName != *input.updatePropertiesModelName {
-					mappings.Fields = append(mappings.Fields, modelToModelMappingBetween(fmt.Sprintf("%s%s", schemaModelName, fieldNameForTypedModel), *input.updatePropertiesModelName, k))
+					mappings.Fields = append(mappings.Fields, modelToModelMappingBetween(nestedModelName, *input.updatePropertiesModelName, k))
 				}
 			}
 		}

--- a/tools/importer-rest-api-specs/components/testattributes/test_attributes.go
+++ b/tools/importer-rest-api-specs/components/testattributes/test_attributes.go
@@ -385,7 +385,7 @@ func (h TestAttributesHelpers) referencedModelContainsRequiredFields(details res
 				continue
 			}
 
-			hasNested, err := h.referencedModelContainsRequiredFields(details)
+			hasNested, err := h.referencedModelContainsRequiredFields(fieldDetails)
 			if err != nil {
 				return nil, fmt.Errorf("checking if the nested field %q contains required fields: %+v", fieldName, err)
 			}

--- a/tools/importer-rest-api-specs/components/testattributes/test_attributes.go
+++ b/tools/importer-rest-api-specs/components/testattributes/test_attributes.go
@@ -46,7 +46,18 @@ func (h TestAttributesHelpers) GetAttributesForTests(resourceLabel string, input
 			requiredFields = append(requiredFields, fieldName)
 			continue
 		}
-		if !requiredOnly {
+
+		if requiredOnly {
+			// check if the field itself contains nested fields
+			containsRequiredFields, err := h.referencedModelContainsRequiredFields(details)
+			if err != nil {
+				return fmt.Errorf("checking if the field %q contains required fields: %+v", fieldName, err)
+			}
+			if *containsRequiredFields {
+				requiredFields = append(requiredFields, fieldName)
+				continue
+			}
+		} else {
 			if details.Optional {
 				optionalFields = append(optionalFields, fieldName)
 				continue
@@ -69,6 +80,14 @@ func (h TestAttributesHelpers) GetAttributesForTests(resourceLabel string, input
 		}
 	}
 	return nil
+}
+
+func topLevelObjectDefinition(input resourcemanager.TerraformSchemaFieldObjectDefinition) resourcemanager.TerraformSchemaFieldObjectDefinition {
+	if input.NestedObject != nil {
+		return topLevelObjectDefinition(*input.NestedObject)
+	}
+
+	return input
 }
 
 func (h TestAttributesHelpers) codeForTestAttribute(resourceLabel string, input resourcemanager.TerraformSchemaFieldDefinition, requiredOnly bool, hclBody *hclwrite.Body) error {
@@ -344,6 +363,37 @@ func (h TestAttributesHelpers) codeForTestAttributeWithPossibleValues(input reso
 	}
 
 	return fmt.Errorf("missing PossibleValues implementation for Schema Field %q (%s)", input.HclName, input.ObjectDefinition.String())
+}
+
+func (h TestAttributesHelpers) referencedModelContainsRequiredFields(details resourcemanager.TerraformSchemaFieldDefinition) (*bool, error) {
+	containsRequiredFields := false
+
+	topLevelObject := topLevelObjectDefinition(details.ObjectDefinition)
+	if topLevelObject.Type == resourcemanager.TerraformSchemaFieldTypeReference {
+		other, ok := h.SchemaModels[*topLevelObject.ReferenceName]
+		if !ok {
+			return nil, fmt.Errorf("the schema model %q was not found", *topLevelObject.ReferenceName)
+		}
+		for fieldName, fieldDetails := range other.Fields {
+			if fieldDetails.Required {
+				containsRequiredFields = true
+				break
+			}
+
+			topLevel := topLevelObjectDefinition(fieldDetails.ObjectDefinition)
+			if topLevel.Type != resourcemanager.TerraformSchemaFieldTypeReference || *topLevel.ReferenceName == *topLevelObject.ReferenceName {
+				continue
+			}
+
+			hasNested, err := h.referencedModelContainsRequiredFields(details)
+			if err != nil {
+				return nil, fmt.Errorf("checking if the nested field %q contains required fields: %+v", fieldName, err)
+			}
+			containsRequiredFields = *hasNested
+			break
+		}
+	}
+	return &containsRequiredFields, nil
 }
 
 func addCommentToTestConfig(hclBody hclwrite.Body, comment string) {

--- a/tools/importer-rest-api-specs/components/testattributes/test_attributes.go
+++ b/tools/importer-rest-api-specs/components/testattributes/test_attributes.go
@@ -86,6 +86,10 @@ func (h TestAttributesHelpers) codeForTestAttribute(resourceLabel string, input 
 		hclBody.SetAttributeValue(input.HclName, cty.NumberIntVal(15))
 	case resourcemanager.TerraformSchemaFieldTypeString:
 		switch input.HclName {
+		case "dns_prefix":
+			{
+				hclBody.SetAttributeValue(input.HclName, cty.StringVal("acctest"))
+			}
 		case "name":
 			// todo pipe in packagename to make "acctest-vm-${local.random_integer}"
 			tokens := hclwrite.Tokens{


### PR DESCRIPTION
This PR includes a number of fixes to both `importer-rest-api-specs` and `generator-terraform`:

1. Ensures that we output the Mappings in the Terraform Generator for an Update function where the SDK Model is shared between a Create and Update
2. `tools/importer-rest-api-specs`: outputting the referenced model name for `ModelToModel` mappings rather than computing it (which maybe wrong if this has been renamed)
3. `tools/importer-rest-api-specs`: outputs the value `acctest` in the Test HCL for fields named `dns_prefix` (there's several of these, and they're prefixes, so this is fine)
4. `tools/importer-rest-api-specs`: handling an optional field containing a required field (such that the block is ultimately required)