### PR TITLE
New Resource: generating Kubernetes Fleet Manager

### DIFF
--- a/config/resources/containerservice.hcl
+++ b/config/resources/containerservice.hcl
@@ -1,0 +1,14 @@
+service "ContainerService" {
+  terraform_package = "containers"
+
+  api "2022-09-02-preview" {
+    package "Fleets" {
+      definition "kubernetes_fleet_manager" {
+        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}"
+        display_name = "Kubernetes Fleet Manager"
+        website_subcategory = "Kubernetes Fleet Manager"
+        description = "Manages a Fleet of Kubernetes Clusters"
+      }
+    }
+  }
+}

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_schema.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_schema.go
@@ -102,7 +102,7 @@ func dotNetTypeNameForTerraformFieldObjectDefinition(input resourcemanager.Terra
 		if input.NestedObject == nil {
 			return nil, fmt.Errorf("a dictionary must have a nested object")
 		}
-		
+
 		nestedObject, err := dotNetTypeNameForTerraformFieldObjectDefinition(*input.NestedObject, constants, models)
 		if err != nil {
 			return nil, fmt.Errorf("determining dotnet type name for nested object definition: %+v", err)


### PR DESCRIPTION
This PR introduces support for Kubernetes Fleet Manager, which is in Preview.

There's an upstream issue in the Swagger, which is fixed in this PR: https://github.com/Azure/azure-rest-api-specs/pull/21394

To workaround that in the interim this PR includes an override to allow us to generate this resource.