### PR TITLE
config: fixing the website category for Kubernetes Fleet Manager

### DIFF
--- a/config/resources/containerservice.hcl
+++ b/config/resources/containerservice.hcl
@@ -6,8 +6,8 @@ service "ContainerService" {
       definition "kubernetes_fleet_manager" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}"
         display_name = "Kubernetes Fleet Manager"
-        website_subcategory = "Kubernetes Fleet Manager"
-        description = "Manages a Fleet of Kubernetes Clusters"
+        website_subcategory = "Containers"
+        description = "Manages a Kubernetes Fleet Manager"
       }
     }
   }


### PR DESCRIPTION
This should be `containers`