### PR TITLE
`kubernetes_fleet_manager` - outputting that this is in Preview

### DIFF
--- a/config/resources/containerservice.hcl
+++ b/config/resources/containerservice.hcl
@@ -7,7 +7,11 @@ service "ContainerService" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}"
         display_name = "Kubernetes Fleet Manager"
         website_subcategory = "Containers"
-        description = "Manages a Kubernetes Fleet Manager"
+        description = <<HERE
+Manages a Kubernetes Fleet Manager
+
+~> **Note:** This Resource is in **Preview** to use this you must be opted into the Preview. You can do this by running `az feature register --namespace Microsoft.ContainerService --name FleetResourcePreview` and then `az provider register -n Microsoft.ContainerService`
+HERE
       }
     }
   }

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_terraform_resource_definition.go
@@ -34,7 +34,7 @@ public class %[2]sResource : TerraformResourceDefinition
     public ResourceID ResourceId => new %[4]s.%[5]s.%[6]s();
     public string ResourceLabel => "%[7]s";
     public string ResourceCategory => "%[10]s";
-    public string ResourceDescription => "%[9]s";
+    public string ResourceDescription => @"%[9]s";
     public string ResourceExampleUsage => @"%[11]s".AsTerraformTestConfig();
     public Type? SchemaModel => typeof(%[2]sResourceSchema);
     public TerraformMappingDefinition SchemaMappings => new %[2]sResourceMappings();


### PR DESCRIPTION
This PR adds a disclaimer that the Kubernetes Fleet Manager resource is in Preview - and adds support for multi-line descriptions.

Whilst longer-term I have a feeling we'll want to expose Preview information in a different manner, this should be fine in the interim.