### PR TITLE
tools/generator-terraform: outputting the resource Display Name as the description

### DIFF
--- a/tools/generator-terraform/generator/resource/docs/component_frontmatter.go
+++ b/tools/generator-terraform/generator/resource/docs/component_frontmatter.go
@@ -8,14 +8,18 @@ import (
 )
 
 func codeForYAMLFrontMatter(input models.ResourceInput) (*string, error) {
+	// NOTE: we're intentionally not reusing the Description here since it can be multi-line and invalid
+	// for the YAML description. Whilst this definitely isn't perfect grammatically (`a` vs `an`), since
+	// this is only used for the website description it should be fine.
+	frontMatterDescription := fmt.Sprintf("Manages a %s.", input.Details.DisplayName)
 	output := strings.TrimSpace(fmt.Sprintf(`
 ---
 subcategory: "%[1]s"
 layout: "%[2]s"
 page_title: "Azure Resource Manager: %[2]s_%[3]s"
 description: |-
-  %[4]s.
----
-`, input.Details.Documentation.Category, input.ProviderPrefix, input.ResourceLabel, input.Details.Documentation.Description))
+  %[4]s
+--- 
+`, input.Details.Documentation.Category, input.ProviderPrefix, input.ResourceLabel, frontMatterDescription))
 	return &output, nil
 }


### PR DESCRIPTION
Whilst we could output the regular description here this isn't necessarily valid as YAML FrontMatter - which causes this linting error:

`* website/docs/r/kubernetes_fleet_manager.html.markdown: error checking file frontmatter: error parsing YAML frontmatter: yaml: line 9: could not find expected ':'`

As such this commit changes to using a pre-formatted string for the frontmatter description which whilst isn't perfect (grammatically) works well enough for now

Fixes https://github.com/hashicorp/terraform-provider-azurerm/actions/runs/3395699863/jobs/5645911212