### PR TITLE
tools/importer-rest-api-specs: fixing an issue where the Resource Group naming is inconsistent

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
@@ -55,3 +55,33 @@ func TestCommonResourceID_ResourceGroup(t *testing.T) {
 		t.Fatalf("unexpected Resource ID %q", normalizedResourceId(actual.Segments))
 	}
 }
+
+func TestCommonResourceID_ResourceGroupIncorrectSegment(t *testing.T) {
+	input := []models.ParsedResourceId{
+		{
+			Constants: map[string]resourcemanager.ConstantDetails{},
+			Segments: []resourcemanager.ResourceIdSegment{
+				models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+				models.SubscriptionIDResourceIDSegment("subscriptionId"),
+				models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+				models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			},
+		},
+		{
+			Constants: map[string]resourcemanager.ConstantDetails{},
+			Segments: []resourcemanager.ResourceIdSegment{
+				models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+				models.SubscriptionIDResourceIDSegment("subscriptionId"),
+				models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+				models.ResourceGroupResourceIDSegment("sourceResourceGroupName"),
+			},
+		},
+	}
+	output := switchOutCommonResourceIDsAsNeeded(input)
+	for i, actual := range output {
+		t.Logf("testing %d", i)
+		if actual.CommonAlias == nil || *actual.CommonAlias != "ResourceGroup" {
+			t.Fatalf("expected item %d to be detected as a ResourceGroup but it wasn't", i)
+		}
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
@@ -98,7 +98,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 				}
 			}
 
-			if strings.EqualFold(normalizedSegment, "resourceGroup") || strings.EqualFold(normalizedSegment, "resourceGroupName") {
+			if strings.Contains(strings.ToLower(normalizedSegment), "resourcegroup") {
 				previousSegmentWasResourceGroups := false
 				if len(segments) > 0 {
 					lastSegment := segments[len(segments)-1]

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments_test.go
@@ -239,6 +239,34 @@ func TestParseResourceIDFromOperation_ResourceGroupId(t *testing.T) {
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
 
+func TestParseResourceIDFromOperation_ResourceGroupId_IncorrectSegment(t *testing.T) {
+	swagger := spec.NewOperation("Example_Operation")
+	uri := "/subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}"
+
+	parser := NewParser(hclog.NewNullLogger(), nil)
+	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
+	if err != nil {
+		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
+	}
+
+	if resourceId.uriSuffix != nil {
+		t.Fatalf("expected no uriSuffix but got %q", *resourceId.uriSuffix)
+	}
+	if len(resourceId.constants) != 0 {
+		t.Fatalf("expected 0 constants but got %d", len(resourceId.constants))
+	}
+	if resourceId.segments == nil {
+		t.Fatalf("expected 4 segments but got 0")
+	}
+	expectedSegments := []resourcemanager.ResourceIdSegment{
+		models.StaticResourceIDSegment("providers", "providers"),
+		models.SubscriptionIDResourceIDSegment("subscriptionId"),
+		models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+		models.ResourceGroupResourceIDSegment("resourceGroupName"),
+	}
+	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
+}
+
 func TestParseResourceIDFromOperation_Scope(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/{resourceId}"


### PR DESCRIPTION
This allows incorrectly duplicate segments (such as `sourceResourceGroupName` rather than `resourceGroupName`) to be normalised to `resourceGroupName` providing it contains `resourcegroup` and is preceded by `resourceGroups`