### PR TITLE
tools/version-bumper: auto-onboarding new versions of existing APIs

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -370,6 +370,7 @@ service "vmware" {
 service "web" {
   name      = "Web"
   available = ["2016-06-01"]
+  ignore    = ["2021-03-01", "2022-03-01"]
 }
 service "webpubsub" {
   name      = "WebPubSub"

--- a/tools/version-bumper/main.go
+++ b/tools/version-bumper/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/config/services"
 )
 
-const onlyFormat = true
+const onlyFormat = false
 const onlyUpdateExistingServices = true
 
 func main() {


### PR DESCRIPTION
This PR enables the auto-onboarding of new API Versions for Services which have been imported into Pandora.

This means that should a new API Version become available, and we've not explicitly marked it as that it should be being ignored, that a PR will be sent to add the new API Version to the config when the Swagger is updated.