### PR TITLE
config: add compute @ 2022-03-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -61,7 +61,7 @@ service "communication" {
 }
 service "compute" {
   name      = "Compute"
-  available = ["2021-07-01", "2021-11-01", "2022-03-02"]
+  available = ["2021-07-01", "2021-11-01", "2022-03-01", "2022-03-02"]
 }
 service "confidentialledger" {
   name      = "ConfidentialLedger"


### PR DESCRIPTION
cont. of #1553 which was reverted

This was once removed due to eventual consistency issue in #1578. Now that the change https://github.com/hashicorp/pandora/commit/4f5ec640fce1c9dd4052db6fc2a48bf9c5142a88 mentioned in the regenerating pr has been merged, assuming #1579 is resolved so that this api version could be added back.