### PR TITLE
tools/generator-go-sdk: reverting the `optional object` logic for now

### DIFF
--- a/tools/generator-go-sdk/generator/templater_models.go
+++ b/tools/generator-go-sdk/generator/templater_models.go
@@ -188,7 +188,6 @@ func (c modelsTemplater) structLineForField(fieldName, fieldType string, fieldDe
 	jsonDetails := fieldDetails.JsonName
 
 	isOptional := false
-	isReference := false
 	if fieldDetails.Optional {
 		isOptional = true
 
@@ -196,10 +195,7 @@ func (c modelsTemplater) structLineForField(fieldName, fieldType string, fieldDe
 		// by default since Parent types are output as an interface (which is implied nullable)
 		if fieldDetails.ObjectDefinition.Type == resourcemanager.ReferenceApiObjectDefinitionType {
 			model, ok := data.models[*fieldDetails.ObjectDefinition.ReferenceName]
-			if ok {
-				isReference = true
-			}
-			if model.TypeHintIn != nil && model.ParentTypeName == nil {
+			if ok && model.TypeHintIn != nil && model.ParentTypeName == nil {
 				isOptional = false
 			}
 		}
@@ -207,9 +203,7 @@ func (c modelsTemplater) structLineForField(fieldName, fieldType string, fieldDe
 
 	if isOptional {
 		fieldType = fmt.Sprintf("*%s", fieldType)
-		if !isReference {
-			jsonDetails += ",omitempty"
-		}
+		jsonDetails += ",omitempty"
 	}
 
 	line := fmt.Sprintf("\t%s %s `json:\"%s\"`", fieldName, fieldType, jsonDetails)

--- a/tools/generator-go-sdk/generator/templater_models_test.go
+++ b/tools/generator-go-sdk/generator/templater_models_test.go
@@ -262,7 +262,7 @@ import (
 // acctests licence placeholder
 
 type Basic struct {
-	BobcatOptional *Bobcat ''json:"bobcatOptional"''
+	BobcatOptional *Bobcat ''json:"bobcatOptional,omitempty"''
 	BobcatRequired Bobcat ''json:"bobcatRequired"''
 	Name string ''json:"name"''
 }


### PR DESCRIPTION
Unfortunately there's a number of APIs this causes issues with (DataBricks, Media, Mixed Reality and Notification Hubs) as such we'll want to revert this for now, raise API issues, then look to re-introduce this