### PR TITLE
tools/importer-rest-api-specs: normalizing `Vm`, `Vmss` and `Cpu`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
+++ b/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
@@ -563,6 +563,11 @@ func NormalizeCanonicalisation(input string) string {
 
 	// intentionally case-sensitive
 	output = strings.ReplaceAll(output, "Ip", "IP")
+	output = strings.ReplaceAll(output, "Vmss", "VMSS")
+	output = strings.ReplaceAll(output, "vmss", "VMSS")
+	output = strings.ReplaceAll(output, "Vm", "VM")
+	output = strings.ReplaceAll(output, "vm", "VM")
+	output = strings.ReplaceAll(output, "Cpu", "CPU")
 
 	output = strings.ReplaceAll(output, "Https", "HTTPS")
 	output = strings.ReplaceAll(output, "Http", "HTTP")


### PR DESCRIPTION
This unblocks #1873