### PR TITLE
Do not set request content-type for GET and HEAD request

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -473,7 +473,8 @@ func (c methodsAutoRestTemplater) preparerTemplate(data ServiceGeneratorData) (*
 
 	steps := make([]string, 0)
 	listSteps := make([]string, 0)
-	if c.operation.ContentType != nil && (c.operation.Method != "GET" && c.operation.Method != "HEAD") {
+	if c.operation.ContentType != nil && (!strings.EqualFold(c.operation.Method, "GET") &&
+		!strings.EqualFold(c.operation.Method, "HEAD")) {
 		steps = append(steps, fmt.Sprintf("autorest.AsContentType(%q)", *c.operation.ContentType))
 		listSteps = append(listSteps, fmt.Sprintf("autorest.AsContentType(%q)", *c.operation.ContentType))
 	}

--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -473,7 +473,7 @@ func (c methodsAutoRestTemplater) preparerTemplate(data ServiceGeneratorData) (*
 
 	steps := make([]string, 0)
 	listSteps := make([]string, 0)
-	if c.operation.ContentType != nil {
+	if c.operation.ContentType != nil && (c.operation.Method != "GET" && c.operation.Method != "HEAD") {
 		steps = append(steps, fmt.Sprintf("autorest.AsContentType(%q)", *c.operation.ContentType))
 		listSteps = append(listSteps, fmt.Sprintf("autorest.AsContentType(%q)", *c.operation.ContentType))
 	}


### PR DESCRIPTION
from importer tool logic, the content-type for GET/HEAD request is used for response content, should not use it in the request.


https://github.com/hashicorp/pandora/blob/1332cc74c2c5e088bf37e8b6a83af4bd520db902/tools/importer-rest-api-specs/components/parser/operations.go#L221-L226