### PR TITLE
tools/importer-rest-api-specs: handling the responses having multiple response objects

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/operations_test.go
+++ b/tools/importer-rest-api-specs/components/parser/operations_test.go
@@ -3200,3 +3200,51 @@ func TestParseOperationsContainingContentTypes(t *testing.T) {
 	validateOperationHasContentType("XmlRequest", "application/xml")
 	validateOperationHasContentType("XmlResponse", "application/xml")
 }
+
+func TestParseOperationContainingMultipleReturnObjects(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_return_objects.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	operation, ok := hello.Operations["HeadWorld"]
+	if !ok {
+		t.Fatalf("expected an operation named `HeadWorld` but didn't get one")
+	}
+	if operation.RequestObject != nil {
+		t.Fatalf("expected there to be no Request object but got: %+v", *operation.RequestObject)
+	}
+	if operation.ResponseObject == nil {
+		t.Fatalf("expected there to be a Response object but didn't get one")
+	}
+	if operation.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the Response Object to be a Reference but got %q", string(operation.ResponseObject.Type))
+	}
+	if operation.ResponseObject.ReferenceName == nil || *operation.ResponseObject.ReferenceName != "FirstModel" {
+		t.Fatalf("expected the Response Object to be a Reference to FirstModel but got %q", *operation.ResponseObject.ReferenceName)
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_single_multiple_return_objects.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_single_multiple_return_objects.json
@@ -1,0 +1,63 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_HeadWorld",
+        "description": "An operation returning two different types.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FirstModel"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/OtherModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "FirstModel": {
+      "properties": {
+        "hello": {
+          "type": "string"
+        }
+      }
+    },
+    "OtherModel": {
+      "properties": {
+        "there": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
When the operation has multiple response objects, we pick the lowest status code where possible.

As a general rule this should be a 200/201, but this works around operations having different response objects for different operations, since we only parse the HTTP Response when we're expecting a 200.

When a single response object is returned we parse the status code regardless, so this change is limited to operations with multiple status codes.

Fixes the issues seen in #1984