### PR TITLE
feat: create authorization service version 2020-10-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -32,6 +32,10 @@ service "attestation" {
   name      = "Attestation"
   available = ["2020-10-01"]
 }
+service "authorization" {
+  name      = "Authorization"
+  available = ["2020-10-01"]
+}
 service "automation" {
   name      = "Automation"
   available = ["2019-06-01", "2021-06-22", "2022-08-08"]


### PR DESCRIPTION
Hi,

This PR is to create a newer version of the authorization api so that I can make a resource for Role Eligibility Schedule Requests for PIM on Azure Resources.

Would you recommend to use the latest version, i.e. `2022-04-01-preview` or `2020-10-01` as it's stable?

Cheers