### PR TITLE
tools/importer-rest-api-specs: rewriting the Resource ID segments to be consistent

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
@@ -1,0 +1,55 @@
+package dataworkarounds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ workaround = workaroundInconsistentlyDefinedSegments{}
+
+type workaroundInconsistentlyDefinedSegments struct{}
+
+func (workaroundInconsistentlyDefinedSegments) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	return true
+}
+
+func (workaroundInconsistentlyDefinedSegments) Name() string {
+	return "Workaround Inconsistently Defined Resource ID Segments"
+}
+
+func (workaroundInconsistentlyDefinedSegments) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resources := make(map[string]models.AzureApiResource, 0)
+	for resourceName := range apiDefinition.Resources {
+		resource := apiDefinition.Resources[resourceName]
+
+		ids := make(map[string]models.ParsedResourceId, 0)
+		for key := range resource.ResourceIds {
+			id := resource.ResourceIds[key]
+			segments := make([]resourcemanager.ResourceIdSegment, 0)
+			for i, val := range id.Segments {
+				if i > 0 && val.Type == resourcemanager.UserSpecifiedSegment {
+					// switch out the name of the User Specified Segment presuming it's not an `{val}Id` or `{val}Key`, since these names make more sense
+					// this works around issues in the Swagger where the same URI may be defined differently depending on the endpoint
+					if !strings.HasSuffix(val.Name, "Alias") && !strings.HasSuffix(val.Name, "Id") && !strings.HasSuffix(val.Name, "Key") && !strings.HasSuffix(val.Name, "Identifier") {
+						previous := segments[i-1]
+						if previous.Type == resourcemanager.StaticSegment && previous.FixedValue != nil {
+							singularNameOfPrevious := cleanup.GetSingular(*previous.FixedValue)
+							val.Name = fmt.Sprintf("%sName", singularNameOfPrevious)
+						}
+					}
+				}
+				segments = append(segments, val)
+			}
+			id.Segments = segments
+			ids[key] = id
+		}
+		resource.ResourceIds = ids
+		resources[resourceName] = resource
+	}
+	apiDefinition.Resources = resources
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -11,6 +11,10 @@ var workarounds = []workaround{
 	workaroundContainerService21394{},
 	workaroundLoadTest20961{},
 	workaroundMedia21581{},
+
+	// @tombuildsstuff: this is an odd place for this however this allows working around inconsistencies in the Swagger
+	// we should look at moving this into the `resourceids` package when time allows.
+	workaroundInconsistentlyDefinedSegments{},
 }
 
 func ApplyWorkarounds(input []models.AzureApiDefinition, logger hclog.Logger) (*[]models.AzureApiDefinition, error) {


### PR DESCRIPTION
This PR dynamically renames the `UserSpecifiedSegment` keys to match the preceding Static Segment value where possible - for example a Resource ID in the form `/static/{value}` will be updated to `/static/{staticName}`.

Whilst this may seem pedantic, this fixes the repeated inconsistencies seen here where the API Definitions define the same Resource ID using different segments:

https://github.com/hashicorp/pandora/pull/2010/files#diff-aad1409e4b94d6c75f639fd03d2f0f44ed8672f62ca8944813b05e50f4f48817L15-R15

---

This is going to introduce a lot of changes to the generated SDK.. however this one-time breaking change should mostly remove the Swagger issues we're facing when the Segment Values don't align - which feels like a valuable tradeoff - however some usages may need fixing as a result.