### PR TITLE
tools/importer-rest-api-specs: support for filtering operations outside of the specified Resource Provider

### DIFF
--- a/docs/resource-manager-service-import.md
+++ b/docs/resource-manager-service-import.md
@@ -14,6 +14,7 @@ service "analysisservices" {
   available = ["2017-08-01"]
   # Optional
   # ignore = []
+  # resource_provider = "Some.ResourceProvider"
 }
 ```
 
@@ -23,6 +24,7 @@ Those properties are:
 * `name` - (Required) - A Normalized Version of the Service Name (generally, TitleCased with no spaces) used to uniquely identify this service.
 * `available` - (Required) - A list of API Versions which should be Imported into Pandora's Data Format.
 * `ignore` - (Optional) - A list of API Versions which should be Ignored by the `version-bumper` tool (see the main Readme for info) when automatically adding new API Versions for this Service.
+* `resource_provider` - (Optional) - The Resource Provider which operations should be filtered to. This allows filtering operations from other Resource Providers - and shouldn't be generally used - please open an issue before using.
 
 As such to import the Service `MSI` with API Version `2018-11-30` ([from this Swagger Definition](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/msi/resource-manager/Microsoft.ManagedIdentity/stable/2018-11-30)) you'd need to add:
 

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -13,7 +13,8 @@ func ParseSwaggerFileForTesting(t *testing.T, file string) (*models.AzureApiDefi
 		t.Fatalf("loading: %+v", err)
 	}
 
-	resourceIds, err := parsed.ParseResourceIds()
+	var resourceProvider *string = nil // we're not filtering to just this RP, so it's fine
+	resourceIds, err := parsed.ParseResourceIds(resourceProvider)
 	if err != nil {
 		t.Fatalf("parsing Resource Ids: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/load_and_parse.go
+++ b/tools/importer-rest-api-specs/components/parser/load_and_parse.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVersion string, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVersion string, resourceProvider *string, logger hclog.Logger) (*models.AzureApiDefinition, error) {
 	// Some Services have been deprecated or should otherwise be ignored - check before proceeding
 	if serviceShouldBeIgnored(serviceName) {
 		logger.Debug(fmt.Sprintf("Service %q should be ignored - skipping", serviceName))
@@ -29,7 +29,7 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 			return nil, fmt.Errorf("parsing file %q: %+v", file, err)
 		}
 
-		parsedResourceIds, err := swaggerFile.ParseResourceIds()
+		parsedResourceIds, err := swaggerFile.ParseResourceIds(resourceProvider)
 		if err != nil {
 			return nil, fmt.Errorf("parsing Resource Ids from %q (Service %q / Api Version %q): %+v", file, serviceName, apiVersion, err)
 		}

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
@@ -63,12 +65,55 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceIds re
 	}, nil
 }
 
-func (d *SwaggerDefinition) ParseResourceIds() (*resourceids.ParseResult, error) {
+func (d *SwaggerDefinition) ParseResourceIds(resourceProvider *string) (*resourceids.ParseResult, error) {
 	parser := resourceids.NewParser(d.logger.Named("ResourceID Parser"), d.swaggerSpecExpanded)
 
 	resourceIds, err := parser.Parse()
 	if err != nil {
-		return nil, fmt.Errorf("finding resource ids: %+v", err)
+		return nil, fmt.Errorf("finding Resource IDs: %+v", err)
 	}
+
+	if resourceProvider != nil {
+		d.logger.Trace(fmt.Sprintf("Filtering Resource IDs to the Resource Provider %q..", *resourceProvider))
+		resourceIds, err = d.filterResourceIdsToResourceProvider(*resourceIds, *resourceProvider)
+		if err != nil {
+			return nil, fmt.Errorf("filtering Resource IDs to Resource Provider %q: %+v", *resourceProvider, err)
+		}
+	} else {
+		d.logger.Trace("Skipping the filtering of Resource IDs to a given Resource Provider since none was specified")
+	}
+
 	return resourceIds, nil
+}
+
+func (d *SwaggerDefinition) filterResourceIdsToResourceProvider(input resourceids.ParseResult, resourceProvider string) (*resourceids.ParseResult, error) {
+	output := resourceids.ParseResult{
+		OriginalUrisToResourceIDs: input.OriginalUrisToResourceIDs,
+		NamesToResourceIDs:        map[string]models.ParsedResourceId{},
+		Constants:                 input.Constants,
+	}
+
+	for name := range input.NamesToResourceIDs {
+		value := input.NamesToResourceIDs[name]
+		add := true
+
+		d.logger.Trace(fmt.Sprintf("Processing ID %q (%q)", name, value.ID()))
+		for i, segment := range value.Segments {
+			if segment.Type != resourcemanager.ResourceProviderSegment {
+				continue
+			}
+
+			if segment.FixedValue == nil {
+				return nil, fmt.Errorf("the Resource ID Named %q Segment %d was a ResourceProviderSegment with no FixedValue", name, i)
+			}
+			if !strings.EqualFold(*segment.FixedValue, resourceProvider) {
+				add = false
+			}
+		}
+		if add {
+			output.NamesToResourceIDs[name] = value
+		}
+	}
+
+	return &output, nil
 }

--- a/tools/importer-rest-api-specs/components/parser/parser_test.go
+++ b/tools/importer-rest-api-specs/components/parser/parser_test.go
@@ -180,7 +180,7 @@ func validateDirectory(serviceName, apiVersion, versionDirectory string) error {
 		fileNames = append(fileNames, fileName)
 	}
 
-	if _, err := LoadAndParseFiles(versionDirectory, *swaggerFiles, serviceName, apiVersion, hclog.New(hclog.DefaultOptions)); err != nil {
+	if _, err := LoadAndParseFiles(versionDirectory, *swaggerFiles, serviceName, apiVersion, nil, hclog.New(hclog.DefaultOptions)); err != nil {
 		return err
 	}
 

--- a/tools/importer-rest-api-specs/pipeline/task_parse_data.go
+++ b/tools/importer-rest-api-specs/pipeline/task_parse_data.go
@@ -40,7 +40,7 @@ func (pipelineTask) parseDataForApiVersion(input discovery.ServiceInput, logger 
 }
 
 func parseSwaggerFiles(input discovery.ServiceInput, logger hclog.Logger) (*models.AzureApiDefinition, error) {
-	parseResult, err := parser.LoadAndParseFiles(input.SwaggerDirectory, input.SwaggerFiles, input.ServiceName, input.ApiVersion, logger)
+	parseResult, err := parser.LoadAndParseFiles(input.SwaggerDirectory, input.SwaggerFiles, input.ServiceName, input.ApiVersion, input.ResourceProvider, logger)
 	if err != nil {
 		return nil, fmt.Errorf("parsing files in %q: %+v", input.SwaggerDirectory, err)
 	}

--- a/tools/sdk/config/services/model.go
+++ b/tools/sdk/config/services/model.go
@@ -18,4 +18,13 @@ type Service struct {
 	// Ignore is a list of Versions which should be Ignored for this Service
 	// A version is automatically ignored if it's not defined in
 	Ignore *[]string `hcl:"ignore"`
+
+	// ResourceProvider is the name of the Resource Provider for this Service.
+	// When specified, this is used to filter the Operations in the Service to only operations
+	// targeting this Resource Provider.
+	//
+	// As a general rule - this should be left blank, at the time of writing this is only applicable
+	// to the Network service, which includes operations from both the Compute and Networking Resource
+	// Providers, which causes issues with ID parsing, hence this filter option to filter Compute operations.
+	ResourceProvider *string `hcl:"resource_provider"`
 }


### PR DESCRIPTION
Some Azure Services define operations outside of their Resource Provider, for example the `network` service includes operations from both `Microsoft.Compute` and `Microsoft.Network` - which causes issues when parsing since duplicate Resource ID names are parsed out (#1223).

This PR adds support for optionally filtering the Resource IDs imported to just those which match the Resource Provider listed in `./config/resource-manager.hcl` - which avoids the issue by filtering these Resource ID's out. Whilst this isn't something we want to do for every Service, doing so allows us to skip these 4 operations which aren't relevant to us - which allows us to import `network`.

Fixes #1223