### PR TITLE
tools/importer-rest-api-specs: filtering operations in addition to Resource IDs

### DIFF
--- a/tools/importer-rest-api-specs/components/discovery/data.go
+++ b/tools/importer-rest-api-specs/components/discovery/data.go
@@ -55,12 +55,13 @@ func FindServices(input FindServiceInput, terraformConfig definitions.Config) (*
 				}
 
 				resourceManagerService := ResourceManagerServiceInput{
-					ServiceName:      service.Name,
-					ApiVersion:       version,
-					ResourceProvider: serviceDetails.ResourceProvider,
-					OutputDirectory:  input.OutputDirectory,
-					SwaggerDirectory: versionDirectory,
-					SwaggerFiles:     filesForVersion,
+					ServiceName:                service.Name,
+					ApiVersion:                 version,
+					ResourceProvider:           &serviceDetails.ResourceProvider,
+					ResourceProviderToFilterTo: service.ResourceProvider,
+					OutputDirectory:            input.OutputDirectory,
+					SwaggerDirectory:           versionDirectory,
+					SwaggerFiles:               filesForVersion,
 				}
 
 				definition, ok := terraformConfig.Services[service.Name]
@@ -122,12 +123,13 @@ func FindServicesByName(input FindServiceInput, terraformConfig definitions.Conf
 				}
 
 				resourceManagerService := ResourceManagerServiceInput{
-					ServiceName:      service.Name,
-					ApiVersion:       version,
-					ResourceProvider: serviceDetails.ResourceProvider,
-					OutputDirectory:  input.OutputDirectory,
-					SwaggerDirectory: versionDirectory,
-					SwaggerFiles:     filesForVersion,
+					ServiceName:                service.Name,
+					ApiVersion:                 version,
+					ResourceProvider:           &serviceDetails.ResourceProvider,
+					ResourceProviderToFilterTo: service.ResourceProvider,
+					OutputDirectory:            input.OutputDirectory,
+					SwaggerDirectory:           versionDirectory,
+					SwaggerFiles:               filesForVersion,
 				}
 
 				definition, ok := terraformConfig.Services[service.Name]

--- a/tools/importer-rest-api-specs/components/discovery/interface.go
+++ b/tools/importer-rest-api-specs/components/discovery/interface.go
@@ -3,21 +3,47 @@ package discovery
 import "github.com/hashicorp/pandora/tools/sdk/config/definitions"
 
 type ServiceInput struct {
-	RootNamespace              string
-	ServiceName                string
-	ApiVersion                 string
-	OutputDirectory            string
-	ResourceProvider           *string
-	SwaggerDirectory           string
-	SwaggerFiles               []string
+	// RootNamespace is the root namespace which should be used as a prefix for each Service/API Version etc.
+	// (e.g. `Pandora.Definitions.ResourceManager`).
+	RootNamespace string
+
+	// ServiceName is the name of the Service (e.g. `Compute`).
+	ServiceName string
+
+	// ApiVersion is the version of the API (e.g. `2020-10-01`).
+	ApiVersion string
+
+	// OutputDirectory is the directory where the generated files should be output.
+	OutputDirectory string
+
+	// ResourceProvider is the ResourceProvider associated with this Service (for example `Microsoft.Compute`)
+	// parsed from the Resource ID.
+	ResourceProvider *string
+
+	// ResourceProviderToFilterTo allows filtering the operations for the given Service/API Version to only
+	// operations contained within this Resource Provider. Whilst the majority of the time this can be left
+	// unset, some Services such as Network include operations from different Resource Providers which can
+	// cause issues - as such this field can be conditionally set to remove unrelated operations.
+	ResourceProviderToFilterTo *string
+
+	// SwaggerDirectory is the path to the directory containing the Swagger/OpenAPI files for this Service/API Version.
+	SwaggerDirectory string
+
+	// SwaggerFiles is a list of the Swagger/OpenAPI files for this Service/API Version.
+	SwaggerFiles []string
+
+	// TerraformServiceDefinition defines the Terraform related details for this Service, used for Terraform
+	// related processing/generation.
 	TerraformServiceDefinition *definitions.ServiceDefinition
 }
 
+// ResourceManagerServiceInput provides a Resource Manager specific wrapper around a ServiceInput
 type ResourceManagerServiceInput struct {
 	ServiceName                string
 	ApiVersion                 string
 	OutputDirectory            string
-	ResourceProvider           string
+	ResourceProvider           *string
+	ResourceProviderToFilterTo *string
 	SwaggerDirectory           string
 	SwaggerFiles               []string
 	TerraformServiceDefinition *definitions.ServiceDefinition
@@ -28,7 +54,8 @@ func (rmi ResourceManagerServiceInput) ToRunInput() ServiceInput {
 		RootNamespace:              "Pandora.Definitions.ResourceManager",
 		ServiceName:                rmi.ServiceName,
 		ApiVersion:                 rmi.ApiVersion,
-		ResourceProvider:           &rmi.ResourceProvider,
+		ResourceProvider:           rmi.ResourceProvider,
+		ResourceProviderToFilterTo: rmi.ResourceProviderToFilterTo,
 		OutputDirectory:            rmi.OutputDirectory,
 		SwaggerDirectory:           rmi.SwaggerDirectory,
 		SwaggerFiles:               rmi.SwaggerFiles,

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -19,7 +19,7 @@ func ParseSwaggerFileForTesting(t *testing.T, file string) (*models.AzureApiDefi
 		t.Fatalf("parsing Resource Ids: %+v", err)
 	}
 
-	out, err := parsed.parse("Example", "2020-01-01", *resourceIds)
+	out, err := parsed.parse("Example", "2020-01-01", resourceProvider, *resourceIds)
 	if err != nil {
 		t.Fatalf("parsing file %q: %+v", file, err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/load_and_parse.go
+++ b/tools/importer-rest-api-specs/components/parser/load_and_parse.go
@@ -45,7 +45,7 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 			return nil, fmt.Errorf("parsing file %q: %+v", file, err)
 		}
 
-		definition, err := swaggerFile.parse(serviceName, apiVersion, *resourceIdResult)
+		definition, err := swaggerFile.parse(serviceName, apiVersion, resourceProvider, *resourceIdResult)
 		if err != nil {
 			return nil, fmt.Errorf("parsing definition: %+v", err)
 		}

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
-
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceIds resourceids.ParseResult) (*models.AzureApiDefinition, error) {

--- a/tools/importer-rest-api-specs/components/parser/swagger_resources.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_resources.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (d *SwaggerDefinition) parseResourcesWithinSwaggerTag(tag *string, resourceIds resourceids.ParseResult) (*models.AzureApiResource, error) {
+func (d *SwaggerDefinition) parseResourcesWithinSwaggerTag(tag *string, resourceProvider *string, resourceIds resourceids.ParseResult) (*models.AzureApiResource, error) {
 	result := internal.ParseResult{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Models:    map[string]models.ModelDetails{},
@@ -24,7 +24,7 @@ func (d *SwaggerDefinition) parseResourcesWithinSwaggerTag(tag *string, resource
 	}
 
 	// pull out the operations and any inlined/top-level constants/models
-	operations, nestedResult, err := d.parseOperationsWithinTag(tag, resourceIds.OriginalUrisToResourceIDs, result, d.logger.Named("Operations Parser"))
+	operations, nestedResult, err := d.parseOperationsWithinTag(tag, resourceIds.OriginalUrisToResourceIDs, resourceProvider, result)
 	if err != nil {
 		return nil, fmt.Errorf("finding operations: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/pipeline/task_parse_data.go
+++ b/tools/importer-rest-api-specs/pipeline/task_parse_data.go
@@ -40,7 +40,7 @@ func (pipelineTask) parseDataForApiVersion(input discovery.ServiceInput, logger 
 }
 
 func parseSwaggerFiles(input discovery.ServiceInput, logger hclog.Logger) (*models.AzureApiDefinition, error) {
-	parseResult, err := parser.LoadAndParseFiles(input.SwaggerDirectory, input.SwaggerFiles, input.ServiceName, input.ApiVersion, input.ResourceProvider, logger)
+	parseResult, err := parser.LoadAndParseFiles(input.SwaggerDirectory, input.SwaggerFiles, input.ServiceName, input.ApiVersion, input.ResourceProviderToFilterTo, logger)
 	if err != nil {
 		return nil, fmt.Errorf("parsing files in %q: %+v", input.SwaggerDirectory, err)
 	}


### PR DESCRIPTION
This PR fixes the regression introduced in #2030 which surfaced in #2032, where Resource IDs are removed at a far broader scale than intended.

Since the `ResourceProvider` value is used against the Service MetaData - this PR introduces a new internal-only field for filtering on the Resource Provider - `ResourceProviderToFilterTo` - which ultimately allows for `Network` to be imported/generated.