### PR TITLE
tools/importer-rest-api-specs: updating `openshiftclusters` -> `openShiftClusters`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -350,7 +350,7 @@ service "recoveryservicessiterecovery" {
   available = ["2022-05-01", "2022-09-10", "2022-10-01"]
 }
 service "redhatopenshift" {
-  name      = "RedhatOpenShift"
+  name      = "RedHatOpenShift"
   available = ["2022-04-01", "2022-09-04"]
 }
 service "redisenterprise" {

--- a/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
+++ b/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
@@ -138,6 +138,7 @@ func NormalizeSegment(input string, camelCase bool) string {
 		"migratemysql":                            "migrateMySql",
 		"nodecounts":                              "nodeCounts",
 		"notificationchannels":                    "notificationChannels",
+		"openshiftclusters":                       "openShiftClusters",
 		"operationresults":                        "operationResults",
 		"pipelineruns":                            "pipelineRuns",
 		"policysets":                              "policySets",


### PR DESCRIPTION
This fixes data inconsistencies, see #2060 for details