### PR TITLE
terraform: updating the segments for User Assigned Identity ID

### DIFF
--- a/config/resources/managedidentity.hcl
+++ b/config/resources/managedidentity.hcl
@@ -4,7 +4,7 @@ service "ManagedIdentity" {
   api "2022-01-31-preview" {
     package "ManagedIdentities" {
       definition "user_assigned_identity" {
-        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}"
+        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}"
         display_name = "User Assigned Identity"
         website_subcategory = "Authorization"
         description = "Manages a User Assigned Identity"

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity.go
@@ -22,7 +22,7 @@ func (commonIdUserAssignedIdentity) id() models.ParsedResourceId {
 			models.StaticResourceIDSegment("providers", "providers"),
 			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
 			models.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.UserSpecifiedResourceIDSegment("resourceName"),
+			models.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity_test.go
@@ -18,7 +18,7 @@ func TestCommonResourceID_UserAssignedIdentity(t *testing.T) {
 			models.StaticResourceIDSegment("providers", "providers"),
 			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
 			models.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.UserSpecifiedResourceIDSegment("resourceName"),
+			models.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
 		},
 	}
 	invalid := models.ParsedResourceId{
@@ -31,7 +31,7 @@ func TestCommonResourceID_UserAssignedIdentity(t *testing.T) {
 			models.StaticResourceIDSegment("providers", "providers"),
 			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
 			models.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.UserSpecifiedResourceIDSegment("userIdentityName"),
+			models.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
 			models.StaticResourceIDSegment("someResource", "someResource"),
 			models.UserSpecifiedResourceIDSegment("resourceName"),
 		},


### PR DESCRIPTION
Matching the behaviour introduced in hashicorp/pandora#2011 which unblocks fixing https://github.com/hashicorp/pandora/actions/runs/4073772510

Dependent on https://github.com/hashicorp/go-azure-helpers/pull/147 / being fixed in `terraform-provider-azurerm`