### PR TITLE
`generator-terraform` - fix bugs for identity in properties and legacy identity

### DIFF
--- a/tools/generator-terraform/generator/mappings/assignment_direct.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct.go
@@ -54,8 +54,15 @@ func (d directAssignmentLine) assignmentForCreateUpdateMapping(mapping resourcem
 	}
 
 	// check if it requires a custom transform
-	if v, ok := transformTypes[schemaField.ObjectDefinition.Type]; ok && v == sdkField.ObjectDefinition.Type {
-		return d.schemaToSdkMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
+	if v, ok := transformTypes[schemaField.ObjectDefinition.Type]; ok {
+		if sdkType := sdkField.ObjectDefinition.Type; v == sdkType {
+			return d.schemaToSdkMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
+		} else {
+			// patch for legacy identity blocks
+			if code, ok := patchIdentityTransform(sdkType, true, mapping, sdkField.JsonName); ok {
+				return &code, nil
+			}
+		}
 	}
 
 	// check the assignment type - if it's a List these are special-cased
@@ -96,8 +103,16 @@ func (d directAssignmentLine) assignmentForReadMapping(mapping resourcemanager.F
 	}
 
 	// check if it requires a custom transform
-	if v, ok := transformTypes[schemaField.ObjectDefinition.Type]; ok && v == sdkField.ObjectDefinition.Type {
-		return d.sdkToSchemaMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
+	if v, ok := transformTypes[schemaField.ObjectDefinition.Type]; ok {
+		if sdkType := sdkField.ObjectDefinition.Type; v == sdkType {
+			return d.sdkToSchemaMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
+		} else {
+			// patch for legacy identity blocks
+			code, ok := patchIdentityTransform(sdkType, false, mapping, sdkField.JsonName)
+			if ok {
+				return &code, nil
+			}
+		}
 	}
 
 	// check the assignment type - if it's a List these are special-cased

--- a/tools/generator-terraform/generator/mappings/assignment_direct.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct.go
@@ -59,7 +59,7 @@ func (d directAssignmentLine) assignmentForCreateUpdateMapping(mapping resourcem
 			return d.schemaToSdkMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
 		} else {
 			// patch for legacy identity blocks
-			if code, ok := patchIdentityTransform(sdkType, true, mapping, sdkField.JsonName); ok {
+			if code, done := patchIdentityTransformExpand(sdkType, mapping, sdkField.JsonName); done {
 				return &code, nil
 			}
 		}
@@ -108,8 +108,7 @@ func (d directAssignmentLine) assignmentForReadMapping(mapping resourcemanager.F
 			return d.sdkToSchemaMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
 		} else {
 			// patch for legacy identity blocks
-			code, ok := patchIdentityTransform(sdkType, false, mapping, sdkField.JsonName)
-			if ok {
+			if code, done := patchIdentityTransformFlatten(sdkType, mapping, sdkField.JsonName); done {
 				return &code, nil
 			}
 		}

--- a/tools/generator-terraform/generator/mappings/assignment_direct_identity.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct_identity.go
@@ -1,0 +1,62 @@
+package mappings
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+// handle all kind of identity block transform: expand and flatten
+
+type transformer struct {
+	expandFn    string
+	flattenFn   string
+	packageName string
+}
+
+func newIdentityTransformer(expandFn string, flattenFn string) transformer {
+	return transformer{
+		expandFn:    expandFn,
+		flattenFn:   flattenFn,
+		packageName: "identity",
+	}
+}
+
+type sdkFieldType = resourcemanager.ApiObjectDefinitionType
+
+// transform from sdk identity block to schema identity block, or reverse
+// N sdk model : 1 schema model, say there are 7 sdk identity types, but only 4 schema identity types
+var identityTransformers = map[sdkFieldType]transformer{
+	resourcemanager.LegacySystemAndUserAssignedIdentityMapApiObjectDefinitionType: newIdentityTransformer("ExpandLegacySystemAndUserAssignedMapFromModel", "FlattenLegacySystemAndUserAssignedMapToModel"),
+}
+
+// we can get schema type from mapping, so only the sdk type is needed
+// isExpand: true for expandFromModel, false for flattenToModel
+func patchIdentityTransform(sdkType sdkFieldType, isExpand bool, mapping resourcemanager.FieldMappingDefinition, sdkFieldName string) (code string, ok bool) {
+	transform, exists := identityTransformers[sdkType]
+	if !exists {
+		return "", false
+	}
+	// default as flatten: input sdk => output schema
+	inputAssignment := fmt.Sprintf("input.%s", mapping.DirectAssignment.SdkFieldPath)
+	outputAssignment := fmt.Sprintf("output.%s", mapping.DirectAssignment.SchemaFieldPath)
+	outputVariable := sdkFieldName
+
+	fn := transform.flattenFn
+	hint := "flattening"
+	if isExpand {
+		fn = transform.expandFn
+		hint = "expanding"
+		inputAssignment = fmt.Sprintf("input.%s", mapping.DirectAssignment.SchemaFieldPath)
+		outputAssignment = fmt.Sprintf("output.%s", mapping.DirectAssignment.SdkFieldPath)
+	}
+	code = fmt.Sprintf(`
+	%[1]s, err := identity.%[4]s(%[2]s)
+	if err != nil {
+		return fmt.Errorf("%[5]s call %[4]s: %%+v", err)
+	}
+	%[3]s = %[1]s
+`, outputVariable, inputAssignment, outputAssignment, fn, hint)
+
+	return code, true
+}

--- a/tools/generator-terraform/generator/mappings/assignment_direct_read_test.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct_read_test.go
@@ -3130,6 +3130,70 @@ func TestDirectAssignment_Read_Identity_UserAssigned_RequiredToOptional(t *testi
 	}
 }
 
+func TestDirectAssignment_Read_Identity_SystemAndUserAssigned_Legacy(t *testing.T) {
+	// when mapping a model to a model where the Schema field is Required but the SDK field is Optional
+	// and matching UserAssignedIdentity
+	testData := []struct {
+		schemaModelFieldType resourcemanager.TerraformSchemaFieldType
+		sdkFieldType         resourcemanager.ApiObjectDefinitionType
+		expected             string
+	}{
+		{
+			schemaModelFieldType: resourcemanager.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned,
+			sdkFieldType:         resourcemanager.LegacySystemAndUserAssignedIdentityMapApiObjectDefinitionType,
+			expected: fmt.Sprintf(`
+	identity, err := identity.FlattenLegacySystemAndUserAssignedMapToModel(input.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening call FlattenLegacySystemAndUserAssignedMapToModel: %%+v", err)
+	}
+	output.Identity = identity
+`),
+		},
+	}
+	for i, v := range testData {
+		t.Logf("Test %d - mapping %q to %q", i, string(v.schemaModelFieldType), string(v.sdkFieldType))
+		mapping := resourcemanager.FieldMappingDefinition{
+			Type: resourcemanager.DirectAssignmentMappingDefinitionType,
+			DirectAssignment: &resourcemanager.FieldMappingDirectAssignmentDefinition{
+				SchemaModelName: "FromModel",
+				SchemaFieldPath: "Identity",
+				SdkFieldPath:    "Identity",
+				SdkModelName:    "ToModel",
+			},
+		}
+		schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+			Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+				"Identity": {
+					ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: v.schemaModelFieldType,
+					},
+					HclName:  "identity",
+					Required: true,
+				},
+			},
+		}
+		sdkModel := resourcemanager.ModelDetails{
+			Fields: map[string]resourcemanager.FieldDetails{
+				"Identity": {
+					JsonName: "identity",
+					ObjectDefinition: resourcemanager.ApiObjectDefinition{
+						Type: v.sdkFieldType,
+					},
+					Optional: true,
+				},
+			},
+		}
+		actual, err := directAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil, "sdkresource")
+		if err != nil {
+			t.Fatalf("retrieving read assignment mapping: %+v", err)
+		}
+		if actual == nil {
+			t.Fatalf("retrieving read assignment mapping: `actual` was nil")
+		}
+		testhelpers.AssertTemplatedCodeMatches(t, v.expected, *actual)
+	}
+}
+
 func TestDirectAssignment_Read_Identity_UserAssigned_OptionalToRequired(t *testing.T) {
 	// when mapping a model to a model where the Schema field is Optional but the SDK field is Required
 	// this has to be mapped, so is a Schema error / we should raise an error

--- a/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent.go
+++ b/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent.go
@@ -34,10 +34,20 @@ func (modelFlattenPropertiesIntoParent) ProcessModel(modelName string, model res
 		}
 
 		nestedPropsModel := models[*fieldValue.ObjectDefinition.ReferenceName]
-		for nestedFieldName, nestedFieldValue := range nestedPropsModel.Fields {
-			fields[nestedFieldName] = nestedFieldValue
+		// flatten only when no name-conflict exists
+		var hasConflict bool
+		for nestedFieldName, _ := range nestedPropsModel.Fields {
+			if _, ok := model.Fields[nestedFieldName]; ok {
+				hasConflict = true
+				break
+			}
 		}
-		delete(fields, fieldName)
+		if !hasConflict {
+			for nestedFieldName, nestedFieldValue := range nestedPropsModel.Fields {
+				fields[nestedFieldName] = nestedFieldValue
+			}
+			delete(fields, fieldName)
+		}
 	}
 	model.Fields = fields
 	models[modelName] = model


### PR DESCRIPTION
1. importer: flatten top-level properties only when no name conflict
2. terraform generator: field transform compatible with legacy identity block

Fixes: https://github.com/hashicorp/pandora/issues/1825

works merged to https://github.com/hashicorp/pandora/pull/2497, close this.