### PR TITLE
Add `Kusto` version `2022-02-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -43,7 +43,7 @@ service "automation" {
 }
 service "azure-kusto" {
   name      = "Kusto"
-  available = ["2022-07-07", "2022-11-11", "2022-12-29"]
+  available = ["2022-02-01", "2022-07-07", "2022-11-11", "2022-12-29"]
 }
 service "azurestackhci" {
   name      = "AzureStackHCI"


### PR DESCRIPTION
Adding 2022-02-01 for upgrading to pandora sdk in azurerm project.
1. Swagger Link: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable
2. Doc Link: https://learn.microsoft.com/en-us/rest/api/azurerekusto/clusters/create-or-update?tabs=HTTP