### PR TITLE
tools/importer: fixing a crash when there's no files for a given API Version

### DIFF
--- a/tools/importer-rest-api-specs/pipeline/run_importer.go
+++ b/tools/importer-rest-api-specs/pipeline/run_importer.go
@@ -91,6 +91,9 @@ func runImportForService(input RunInput, serviceName string, apiVersionsForServi
 			if err != nil {
 				return fmt.Errorf("parsing data for Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err)
 			}
+			if tempDataForApiVersion == nil {
+				continue
+			}
 			for name, resource := range tempDataForApiVersion.Resources {
 				dataForApiVersion.Resources[name] = resource
 			}


### PR DESCRIPTION
When a service is split-up into different sub-groupings within the Swagger, we need to account for the fact that an API version may not be available in all of the sub-groups.

This fixes an issue introduced in https://github.com/Azure/azure-rest-api-specs/pull/22428 where the Media Service has introduced a new sub-group with no Swagger files, meaning importing this currently panics:

```
2023-02-08T11:36:08.401Z [INFO]  Importer for Service "Media".Importer for API Version "2022-08-01": 😵 Service "Media" / Api Version "2022-08-01" contains no resources, skipping.
215
panic: runtime error: invalid memory address or nil pointer dereference
216
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xac65d4]
217

218
goroutine 1 [running]:
219
github.com/hashicorp/pandora/tools/importer-rest-api-specs/pipeline.runImportForService({{0xca2f0d, 0x21}, 0x0, 0x0, 0x0, {0xdde440, 0xc000187710}, {0xc8a2a1, 0xb}, {0xc87687, ...}, ...}, ...)
220
	/home/runner/work/pandora/pandora/tools/importer-rest-api-specs/pipeline/run_importer.go:94 +0x1094
221
github.com/hashicorp/pandora/tools/importer-rest-api-specs/pipeline.runImporter({{0xca2f0d, 0x21}, 0x0, 0x0, 0x0, {0xdde440, 0xc000187710}, {0xc8a2a1, 0xb}, {0xc87687, ...}, ...}, ...)
222
	/home/runner/work/pandora/pandora/tools/importer-rest-api-specs/pipeline/run_importer.go:39 +0x3b9
223
github.com/hashicorp/pandora/tools/importer-rest-api-specs/pipeline.Run({{0xca2f0d, 0x21}, 0x0, 0x0, 0x0, {0xdde440, 0xc000187710}, {0xc8a2a1, 0xb}, {0xc87687, ...}, ...})
224
	/home/runner/work/pandora/pandora/tools/importer-rest-api-specs/pipeline/interface.go:66 +0x4a5
225
github.com/hashicorp/pandora/tools/importer-rest-api-specs/cmd.ImportCommand.Run({{0xc8a2a1, 0xb}, {0xca2f0d, 0x21}, {0xc8be69, 0xd}, {0xc96634, 0x17}}, {0xc000124010, 0x0, ...})
226
	/home/runner/work/pandora/pandora/tools/importer-rest-api-specs/cmd/import.go:85 +0x4c5
227
github.com/mitchellh/cli.(*CLI).Run(0xc0003492c0)
228
	/home/runner/go/pkg/mod/github.com/mitchellh/cli@v1.1.4/cli.go:262 +0x5f8
229
main.main()
230
	/home/runner/work/pandora/pandora/tools/importer-rest-api-specs/main.go:31 +0x353
```