### PR TITLE
tools/importer-rest-api-specs: accounting for `azurerm_load_test` being a special-case when generating the examples

### DIFF
--- a/tools/importer-rest-api-specs/pipeline/task_generate_terraform_example_usage_test.go
+++ b/tools/importer-rest-api-specs/pipeline/task_generate_terraform_example_usage_test.go
@@ -56,6 +56,20 @@ resource "azurerm_resource_group" "example" {
 }
 `,
 		},
+		{
+			input: `
+resource "azurerm_load_test" "test" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+`,
+			expected: `
+resource "azurerm_load_test" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+`,
+		},
 	}
 	for _, v := range testData {
 		t.Logf("Testing Input %q", v.input)


### PR DESCRIPTION
I looked into using `hclwrite` and `hclparse` here, whilst we should take that approach it's significantly more involved and likely wants to instead be done at the same time as the test generation itself - as such for now this is a special-case for the `azurerm_load_test` resource.

Fixes https://github.com/hashicorp/terraform-provider-azurerm/pull/20389