### PR TITLE
`generator-go-sdk`: ServicesUsingNewBaseLayer support with specific api version

### DIFF
--- a/tools/generator-go-sdk/generator/data.go
+++ b/tools/generator-go-sdk/generator/data.go
@@ -66,10 +66,7 @@ func (i ServiceGeneratorInput) generatorData(settings Settings) ServiceGenerator
 	resourceOutputPath := filepath.Join(versionOutputPath, resourcePackageName)
 	idsPath := filepath.Join(versionOutputPath, "ids")
 
-	useNewBaseLayer := false
-	if _, ok := settings.ServicesUsingNewBaseLayer[i.ServiceName]; ok {
-		useNewBaseLayer = true
-	}
+	useNewBaseLayer := settings.ShouldUseNewBaseLayer(i.ServiceName, i.VersionName)
 
 	return ServiceGeneratorData{
 		apiVersion:         i.VersionName,

--- a/tools/generator-go-sdk/generator/settings.go
+++ b/tools/generator-go-sdk/generator/settings.go
@@ -3,3 +3,22 @@ package generator
 type Settings struct {
 	ServicesUsingNewBaseLayer map[string]struct{}
 }
+
+func (s *Settings) UseNewBaseLayerFor(serviceNames ...string) {
+	if s.ServicesUsingNewBaseLayer == nil {
+		s.ServicesUsingNewBaseLayer = map[string]struct{}{}
+	}
+	for _, name := range serviceNames {
+		s.ServicesUsingNewBaseLayer[name] = struct{}{}
+	}
+}
+
+func (s *Settings) ShouldUseNewBaseLayer(serviceName, version string) bool {
+	if _, ok := s.ServicesUsingNewBaseLayer[serviceName]; ok {
+		return true
+	}
+	if _, ok := s.ServicesUsingNewBaseLayer[serviceName+"@"+version]; ok {
+		return true
+	}
+	return false
+}

--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -15,10 +15,6 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/services"
 )
 
-var servicesUsingNewBaseLayer = map[string]struct{}{
-	"ChaosStudio": {},
-}
-
 type GeneratorInput struct {
 	apiServerEndpoint string
 	outputDirectory   string
@@ -28,10 +24,13 @@ type GeneratorInput struct {
 
 func main() {
 	input := GeneratorInput{
-		settings: generator.Settings{
-			ServicesUsingNewBaseLayer: servicesUsingNewBaseLayer,
-		},
+		settings: generator.Settings{},
 	}
+
+	input.settings.UseNewBaseLayerFor(
+		"ChaosStudio",
+		"Automation@2022-08-08",
+	)
 
 	var serviceNames string
 


### PR DESCRIPTION
And add Automation@2022-08-08 with the new base layer. this version has not been used in `azurerm` for the current main and it will fix some SDK issues when working with https://github.com/hashicorp/go-azure-sdk/pull/298.