### PR TITLE
tools/importer-rest-api-specs: accounting for Resources being named `…

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
@@ -13,7 +13,7 @@ var _ workaround = workaroundInconsistentlyDefinedSegments{}
 
 type workaroundInconsistentlyDefinedSegments struct{}
 
-func (workaroundInconsistentlyDefinedSegments) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundInconsistentlyDefinedSegments) IsApplicable(_ *models.AzureApiDefinition) bool {
 	return true
 }
 

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_invalid_go_package_names.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_invalid_go_package_names.go
@@ -1,0 +1,47 @@
+package dataworkarounds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundInvalidGoPackageNames{}
+
+type workaroundInvalidGoPackageNames struct{}
+
+func (workaroundInvalidGoPackageNames) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	for key := range apiDefinition.Resources {
+		if strings.EqualFold(key, "documentation") {
+			return true
+		}
+	}
+	return false
+}
+
+func (workaroundInvalidGoPackageNames) Name() string {
+	return "Workaround Invalid Go Package Names"
+}
+
+func (workaroundInvalidGoPackageNames) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resources := make(map[string]models.AzureApiResource, 0)
+
+	for resourceName := range apiDefinition.Resources {
+		originalName := resourceName
+		resource := apiDefinition.Resources[originalName]
+
+		// `documentation` is not a valid Go package name, so let's rename it to `DocumentationResource`
+		// double-checking that we're not overwriting anything
+		if strings.EqualFold(resourceName, "documentation") {
+			resourceName = "DocumentationResource"
+			if _, ok := apiDefinition.Resources[resourceName]; ok {
+				return nil, fmt.Errorf("the Resource %q is not valid as a Go Package Name - however the replacement name %q is already in use", originalName, resourceName)
+			}
+		}
+
+		resources[resourceName] = resource
+	}
+	apiDefinition.Resources = resources
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -17,6 +17,9 @@ var workarounds = []workaround{
 	// @tombuildsstuff: this is an odd place for this however this allows working around inconsistencies in the Swagger
 	// we should look at moving this into the `resourceids` package when time allows.
 	workaroundInconsistentlyDefinedSegments{},
+
+	// @tombuildsstuff: we also have to account for package names which aren't valid in Go:
+	workaroundInvalidGoPackageNames{},
 }
 
 func ApplyWorkarounds(input []models.AzureApiDefinition, logger hclog.Logger) (*[]models.AzureApiDefinition, error) {


### PR DESCRIPTION
…documentation` which isn't valid as a package name in Go

Instead we rename these to `DocumentationResource` for now, which whilst not great as a name, matches the convention used by the Azure Swaggers, so seems reasonable by the convention