### PR TITLE
`mariadb`: add `2018-06-01-preview`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -263,7 +263,7 @@ service "maps" {
 }
 service "mariadb" {
   name      = "MariaDB"
-  available = ["2018-06-01", "2020-01-01"]
+  available = ["2018-06-01", "2020-01-01", "2018-06-01-preview"]
 }
 service "mediaservices" {
   name      = "Media"


### PR DESCRIPTION
rationale: some SSL settings that people have been waiting for forever are only implemented in preview API. You can use those features in the portal, but not via GA API, so I wanna add preview SDK as well to be able to implement those features.