### PR TITLE
tools/generator-go-sdk: checking both the service and api version for the new base layer flag

### DIFF
--- a/tools/generator-go-sdk/generator/settings.go
+++ b/tools/generator-go-sdk/generator/settings.go
@@ -1,23 +1,27 @@
 package generator
 
+import (
+	"fmt"
+)
+
 type Settings struct {
-	ServicesUsingNewBaseLayer map[string]struct{}
+	servicesUsingNewBaseLayer map[string]struct{}
 }
 
 func (s *Settings) UseNewBaseLayerFor(serviceNames ...string) {
-	if s.ServicesUsingNewBaseLayer == nil {
-		s.ServicesUsingNewBaseLayer = map[string]struct{}{}
+	if s.servicesUsingNewBaseLayer == nil {
+		s.servicesUsingNewBaseLayer = map[string]struct{}{}
 	}
 	for _, name := range serviceNames {
-		s.ServicesUsingNewBaseLayer[name] = struct{}{}
+		s.servicesUsingNewBaseLayer[name] = struct{}{}
 	}
 }
 
 func (s *Settings) ShouldUseNewBaseLayer(serviceName, version string) bool {
-	if _, ok := s.ServicesUsingNewBaseLayer[serviceName]; ok {
+	if _, ok := s.servicesUsingNewBaseLayer[serviceName]; ok {
 		return true
 	}
-	if _, ok := s.ServicesUsingNewBaseLayer[serviceName+"@"+version]; ok {
+	if _, ok := s.servicesUsingNewBaseLayer[fmt.Sprintf("%s@%s", serviceName, version)]; ok {
 		return true
 	}
 	return false

--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -34,9 +34,9 @@ func (m metaClientTemplater) template() (*string, error) {
 		fields = append(fields, fmt.Sprintf("%[1]s *%[2]s.%[1]sClient", resourceName, strings.ToLower(resourceName)))
 		clientInitializationTemplate := fmt.Sprintf(`%[1]s, err := %[2]s.New%[3]sClientWithBaseURI(api)
 if err != nil {
-	return nil, fmt.Errorf("building meta client for %[3]s: %%+v", err)
+	return nil, fmt.Errorf("building %[3]s client: %%+v", err)
 }
-configureAuthFunc(%[1]s.Client)
+configureFunc(%[1]s.Client)
 `, variableName, strings.ToLower(resourceName), resourceName)
 		clientInitialization = append(clientInitialization, clientInitializationTemplate)
 		assignments = append(assignments, fmt.Sprintf("%[1]s: %[2]s,", resourceName, variableName))
@@ -61,7 +61,7 @@ type Client struct {
 	%[3]s
 }
 
-func NewClientWithBaseURI(api environments.Api, configureAuthFunc func(c *resourcemanager.Client)) (*Client, error) {
+func NewClientWithBaseURI(api environments.Api, configureFunc func(c *resourcemanager.Client)) (*Client, error) {
 	%[4]s
 
 	return &Client{

--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -137,7 +137,7 @@ func run(input GeneratorInput) error {
 					Source:          versionDetails.Details.Source,
 				}
 				generatorData.UseNewBaseLayer = false
-				if _, ok := input.settings.ServicesUsingNewBaseLayer[serviceName]; ok {
+				if input.settings.ShouldUseNewBaseLayer(serviceName, versionNumber) {
 					generatorData.UseNewBaseLayer = true
 				}
 				log.Printf("[DEBUG] Generating Service %q / Version %q..", serviceName, versionNumber)


### PR DESCRIPTION
This PR fixes a bug introduced in #2112 where the Meta Client wasn't being output using the new base layer - since this is output separately to each Resource within an API Version and needs to be output separately.