### PR TITLE
Config: Add container-instance 2021-09-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -84,7 +84,7 @@ service "consumption" {
 }
 service "containerinstance" {
   name      = "ContainerInstance"
-  available = ["2021-10-01", "2022-09-01"]
+  available = ["2021-09-01", "2021-10-01", "2022-09-01"]
 }
 service "containerservice" {
   name      = "ContainerService"


### PR DESCRIPTION
Related issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/20604

I'm gonna add a check and use the corresponding client for usgovernment only for the container group resource, but I hesitate about whether that is the right (maintainable) thing to do...