### PR TITLE
Config: add `mediaservices@2022-07-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -279,7 +279,7 @@ service "mariadb" {
 }
 service "mediaservices" {
   name      = "Media"
-  available = ["2021-11-01", "2022-08-01"]
+  available = ["2021-11-01", "2022-07-01", "2022-08-01"]
 }
 service "migrate" {
   name      = "Migrate"


### PR DESCRIPTION
swagger: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/mediaservices/resource-manager/Microsoft.Media/Encoding/stable/2022-07-01/Encoding.json

Resources using `2021-11-01`:
1. `azurerm_media_transform` and `azurerm_media_job`,  will be upgraded to `2022-07-01` after this PR.
2. `azurerm_media_services_account`, will be upgraded to `2023-01-01` in the future.