### PR TITLE
tools/generator-go-sdk: adding the missing copyright lines to the ID Parsers, Tests, Predicates and Meta Clients

### DIFF
--- a/tools/generator-go-sdk/generator/templater_id_parser.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser.go
@@ -19,6 +19,11 @@ type resourceIdTemplater struct {
 }
 
 func (r resourceIdTemplater) template(data ServiceGeneratorData) (*string, error) {
+	copyrightLines, err := copyrightLinesForSource(data.source)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving copyright lines: %+v", err)
+	}
+
 	structBody, err := r.structBody()
 	if err != nil {
 		return nil, fmt.Errorf("generating struct body: %+v", err)
@@ -40,7 +45,8 @@ import (
 
 %[2]s
 %[3]s
-`, data.packageName, *structBody, *methods)
+%[4]s
+`, data.packageName, *copyrightLines, *structBody, *methods)
 	return &out, nil
 }
 

--- a/tools/generator-go-sdk/generator/templater_id_parser_test.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser_test.go
@@ -32,6 +32,7 @@ func TestTemplateIdParserBasic(t *testing.T) {
 			},
 		},
 		packageName: "somepackage",
+		source:      AccTestLicenceType,
 	})
 	if err != nil {
 		t.Fatal(err.Error())
@@ -45,6 +46,9 @@ import (
 
     "github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
+
+// acctests licence placeholder
+
 var _ resourceids.ResourceId = BasicTestId{}
 
 	// BasicTestId is a struct representing the Resource ID for a Basic Test
@@ -174,6 +178,7 @@ func TestTemplateIdParserConstantsOnly(t *testing.T) {
 			},
 		},
 		packageName: "somepackage",
+		source:      AccTestLicenceType,
 	})
 	if err != nil {
 		t.Fatal(err.Error())
@@ -188,6 +193,8 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
+
+// acctests licence placeholder
 
 var _ resourceids.ResourceId = ConstantOnlyId{}
 

--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -17,6 +17,11 @@ type metaClientTemplater struct {
 }
 
 func (m metaClientTemplater) template() (*string, error) {
+	copyrightLines, err := copyrightLinesForSource(m.source)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving copyright lines: %+v", err)
+	}
+
 	resourceNames := make([]string, 0)
 	for k := range m.resources {
 		resourceNames = append(resourceNames, k)
@@ -57,17 +62,19 @@ import (
 	%[2]s
 )
 
+%[3]s
+
 type Client struct {
-	%[3]s
+	%[4]s
 }
 
 func NewClientWithBaseURI(api environments.Api, configureFunc func(c *resourcemanager.Client)) (*Client, error) {
-	%[4]s
+	%[5]s
 
 	return &Client{
-		%[5]s
+		%[6]s
 	}, nil
 }
-`, packageName, strings.Join(imports, "\n"), strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
+`, packageName, strings.Join(imports, "\n"), *copyrightLines, strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
 	return &out, nil
 }

--- a/tools/generator-go-sdk/generator/templater_meta_client_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client_autorest.go
@@ -17,6 +17,11 @@ type metaClientAutorestTemplater struct {
 }
 
 func (m metaClientAutorestTemplater) template() (*string, error) {
+	copyrightLines, err := copyrightLinesForSource(m.source)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving copyright lines: %+v", err)
+	}
+
 	resourceNames := make([]string, 0)
 	for k := range m.resources {
 		resourceNames = append(resourceNames, k)
@@ -54,17 +59,19 @@ import (
 	%[2]s
 )
 
+%[3]s
+
 type Client struct {
-	%[3]s
+	%[4]s
 }
 
 func NewClientWithBaseURI(endpoint string, configureAuthFunc func(c *autorest.Client)) Client {
-	%[4]s
+	%[5]s
 
 	return Client{
-		%[5]s
+		%[6]s
 	}
 }
-`, packageName, strings.Join(imports, "\n"), strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
+`, packageName, strings.Join(imports, "\n"), *copyrightLines, strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
 	return &out, nil
 }

--- a/tools/generator-go-sdk/generator/templater_predicates.go
+++ b/tools/generator-go-sdk/generator/templater_predicates.go
@@ -31,10 +31,16 @@ func (p predicateTemplater) template(data ServiceGeneratorData) (*string, error)
 		output = append(output, *templated)
 	}
 
+	copyrightLines, err := copyrightLinesForSource(data.source)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving copyright lines: %+v", err)
+	}
+
 	template := fmt.Sprintf(`package %[1]s
 
 %[2]s
-`, data.packageName, strings.Join(output, "\n"))
+%[3]s
+`, data.packageName, *copyrightLines, strings.Join(output, "\n"))
 	return &template, nil
 }
 


### PR DESCRIPTION
This PR fixes a few issues spotted in https://github.com/hashicorp/go-azure-sdk/pull/337 where the ID Parsers, ID Parser Tests, Predicates and Meta Client files weren't being output with the expected copyright headers.

Once this PR is merged, `hashicorp/go-azure-sdk` will be regenerated to include these changes, meaning that https://github.com/hashicorp/go-azure-sdk/pull/337 will also get regenerated to only target the `.github` folder (which is fine) - so we can close https://github.com/hashicorp/go-azure-sdk/pull/337 in favour of this PR (which, once merged will generate the same fixes)