### PR TITLE
tools/importer-rest-api-specs: supporting using Common IDs for Key Vault and Key Vault Key

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdKeyVault{}
+
+type commonIdKeyVault struct{}
+
+func (c commonIdKeyVault) id() models.ParsedResourceId {
+	name := "KeyVault"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			models.StaticResourceIDSegment("vaults", "vaults"),
+			models.UserSpecifiedResourceIDSegment("vaultName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key.go
@@ -1,0 +1,30 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdKeyVaultKey{}
+
+type commonIdKeyVaultKey struct{}
+
+func (c commonIdKeyVaultKey) id() models.ParsedResourceId {
+	name := "KeyVaultKey"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			models.StaticResourceIDSegment("vaults", "vaults"),
+			models.UserSpecifiedResourceIDSegment("vaultName"),
+			models.StaticResourceIDSegment("keys", "keys"),
+			models.UserSpecifiedResourceIDSegment("keyName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -46,6 +46,10 @@ var commonIdTypes = []commonIdMatcher{
 	// Misc data fixes
 	commonIdAutomationCompilationJob{}, // (@stephybun) CompilationJobId segment is defined in three different ways `jobId`, `compilationJobId` and `compilationJobName`
 	commonIdProvisioningService{},      // (@jackofallops): Inconsistent user specified fields in the swagger - `provisioningServices/{resourceName}` vs `provisioningServices/{provisioningServiceName}`
+
+	// Key Vault
+	commonIdKeyVault{},
+	commonIdKeyVaultKey{},
 }
 
 func switchOutCommonResourceIDsAsNeeded(input []models.ParsedResourceId) []models.ParsedResourceId {


### PR DESCRIPTION
Should fix the flip-flopping seen in https://github.com/hashicorp/pandora/pull/2181/