### PR TITLE
tools/generator-go-sdk: moving the copyright headers up

### DIFF
--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -56,13 +56,13 @@ configureFunc(%[1]s.Client)
 
 	out := fmt.Sprintf(`package %[1]s
 
+%[2]s
+
 import (
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
-	%[2]s
+	%[3]s
 )
-
-%[3]s
 
 type Client struct {
 	%[4]s
@@ -75,6 +75,6 @@ func NewClientWithBaseURI(api environments.Api, configureFunc func(c *resourcema
 		%[6]s
 	}, nil
 }
-`, packageName, strings.Join(imports, "\n"), *copyrightLines, strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
+`, packageName, *copyrightLines, strings.Join(imports, "\n"), strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
 	return &out, nil
 }

--- a/tools/generator-go-sdk/generator/templater_meta_client_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client_autorest.go
@@ -54,12 +54,12 @@ configureAuthFunc(&%[1]s.Client)
 
 	out := fmt.Sprintf(`package %[1]s
 
+%[2]s
+
 import (
 	"github.com/Azure/go-autorest/autorest"
-	%[2]s
+	%[3]s
 )
-
-%[3]s
 
 type Client struct {
 	%[4]s
@@ -72,6 +72,6 @@ func NewClientWithBaseURI(endpoint string, configureAuthFunc func(c *autorest.Cl
 		%[6]s
 	}
 }
-`, packageName, strings.Join(imports, "\n"), *copyrightLines, strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
+`, packageName, *copyrightLines, strings.Join(imports, "\n"), strings.Join(fields, "\n"), strings.Join(clientInitialization, "\n"), strings.Join(assignments, "\n"))
 	return &out, nil
 }


### PR DESCRIPTION
This allows `hashicorp/copywrite` to detect them so these aren't auto-fixed - fixes the `resource-manager/` part of https://github.com/hashicorp/go-azure-sdk/pull/347/files#diff-5edeb24113b44f80e88fb1135e594743719a72e1b63c7cd15d738eda8d763784