### PR TITLE
`generator-go-sdk`: fix a bug when generating with discriminatedType

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -722,6 +722,9 @@ func (c %[1]s) responderFor%[2]s(resp *http.Response) (result %[5]s, err error) 
 		resp,
 		%[3]s)
 	result.HttpResponse = resp
+	if err != nil {
+		return
+	}
 	model, err := unmarshal%[4]sImplementation(respObj)
 	if err != nil {
 		return

--- a/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest_test.go
@@ -106,6 +106,9 @@ func TestTemplateMethodAutoRestDiscriminatedTypeResponder(t *testing.T) {
 			autorest.ByUnmarshallingJson(&respObj),
 			autorest.ByClosing())
 		result.HttpResponse = resp
+		if err != nil {
+			return
+		}
 		model, err := unmarshalPandaPopImplementation(respObj)
 		if err != nil {
 			return


### PR DESCRIPTION
fix https://github.com/hashicorp/go-azure-sdk/issues/354
related to https://github.com/hashicorp/terraform-provider-azurerm/issues/20811

the error from autorest was covered by the unmarshal func before.