### PR TITLE
tools/generator-go-sdk: reverting `Portal` from using the new base layer for now

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -109,6 +109,7 @@ func main() {
 		"OperationsManagement",
 		"Orbital",
 		"PolicyInsights",
+		"Portal",
 		"PostgreSql",
 		"PostgreSqlHSC",
 		"PowerBIDedicated",


### PR DESCRIPTION
Can be revisited once https://github.com/hashicorp/go-azure-sdk/issues/356 has been fixed