### PR TITLE
tools/generator-terraform: output the sdk client using the new base layer/add an error to the old base layer method

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -32,6 +32,9 @@ func main() {
 		// instead of the base layer from `Azure/go-autorest` - as such this list is for compatibility purposes
 		// with services already used in `terraform-provider-azurerm`. These services will be gradually removed
 		// from this list to ensure they're migrated across to using `hashicorp/go-azure-sdk`s base layer.
+
+		// NOTE: also see the list in ./tools/generator-terraform/generator/definitions/template_service_client.go
+		// for services/resources which are auto-generated
 		"AAD",
 		"Advisor",
 		"AlertsManagement",

--- a/tools/generator-terraform/generator/definitions/template_client_registration.go
+++ b/tools/generator-terraform/generator/definitions/template_client_registration.go
@@ -53,8 +53,9 @@ type autoClient struct {
 	%[3]s
 }
 
-func buildAutoClients(client *autoClient, o *common.ClientOptions) {
+func buildAutoClients(client *autoClient, o *common.ClientOptions) error {
 	%[4]s
+	return nil
 }
 `, input.ProviderPrefix, strings.Join(importLines, "\n"), strings.Join(structFields, "\n"), strings.Join(assignmentLines, "\n"))
 	return strings.TrimSpace(output)

--- a/tools/generator-terraform/generator/definitions/template_client_registration.go
+++ b/tools/generator-terraform/generator/definitions/template_client_registration.go
@@ -25,7 +25,11 @@ func codeForClientsRegistration(input models.ServicesInput) string {
 		structField := fmt.Sprintf(`%[1]s   *%[2]s_%[3]s.Client`, serviceName, sdkPackageName, sdkApiVersion)
 		structFields = append(structFields, structField)
 
-		assignmentLine := fmt.Sprintf(`client.%[1]s = %[2]s.NewClient(o)`, serviceName, service.ServicePackageName)
+		assignmentLine := fmt.Sprintf(`
+		if client.%[1]s, err = %[2]s.NewClient(o) {
+			return fmt.Errorf("building client for %[1]s: %%+v", err)
+		}
+`, serviceName, service.ServicePackageName)
 		assignmentLines = append(assignmentLines, assignmentLine)
 	}
 

--- a/tools/generator-terraform/generator/definitions/template_client_registration_test.go
+++ b/tools/generator-terraform/generator/definitions/template_client_registration_test.go
@@ -72,8 +72,12 @@ type autoClient struct {
 }
 
 func buildAutoClients(client *autoClient, o *common.ClientOptions) {
-	client.Compute = compute.NewClient(o)
-	client.Resource = resources.NewClient(o)
+	if client.Compute, err = compute.NewClient(o) {
+		return fmt.Errorf("building client for Compute: %+v", err)
+	}
+	if client.Resource, err = resources.NewClient(o) {
+		return fmt.Errorf("building client for Resource: %+v", err)
+	}
 }
 `
 	testhelpers.AssertTemplatedCodeMatches(t, expected, actual)

--- a/tools/generator-terraform/generator/definitions/template_client_registration_test.go
+++ b/tools/generator-terraform/generator/definitions/template_client_registration_test.go
@@ -28,7 +28,8 @@ import (
 type autoClient struct {
 }
 
-func buildAutoClients(client *autoClient, o *common.ClientOptions) {
+func buildAutoClients(client *autoClient, o *common.ClientOptions) error {
+	return nil
 }
 `
 	testhelpers.AssertTemplatedCodeMatches(t, expected, actual)
@@ -71,13 +72,14 @@ type autoClient struct {
 	Resource   *resources_v2015_11_01_preview.Client
 }
 
-func buildAutoClients(client *autoClient, o *common.ClientOptions) {
+func buildAutoClients(client *autoClient, o *common.ClientOptions) error {
 	if client.Compute, err = compute.NewClient(o) {
 		return fmt.Errorf("building client for Compute: %+v", err)
 	}
 	if client.Resource, err = resources.NewClient(o) {
 		return fmt.Errorf("building client for Resource: %+v", err)
 	}
+	return nil
 }
 `
 	testhelpers.AssertTemplatedCodeMatches(t, expected, actual)

--- a/tools/generator-terraform/generator/definitions/template_service_client.go
+++ b/tools/generator-terraform/generator/definitions/template_service_client.go
@@ -7,22 +7,50 @@ import (
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
 )
 
+var servicesUsingOldBaseLayer = map[string]struct{}{
+	// these should be lower-cased
+	"containerservice": {},
+	"loadtestservice":  {},
+	"managedidentity":  {},
+}
+
 func templateForServiceClient(input models.ServiceInput) string {
 	output := fmt.Sprintf(`
 package client
 
 import (
-	"github.com/Azure/go-autorest/autorest"
 	%[1]s_%[2]s "github.com/hashicorp/go-azure-sdk/resource-manager/%[1]s/%[3]s"
 	"github.com/hashicorp/terraform-provider-%[4]s/internal/common"
 )
 
-func NewClient(o *common.ClientOptions) *%[1]s_%[2]s.Client {
+func NewClient(o *common.ClientOptions) (*%[1]s_%[2]s.Client, error) {
+	client, err := %[1]s_%[2]s.NewClientWithBaseURI(o.Environment.ResourceManager, func(c *resourcemanager.Client) {
+		o.Configure(c, o.Authorizers.ResourceManager)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("building client for %[1]s %[2]s: %%+v", err)
+	}
+
+	return &client, nil
+}
+`, strings.ToLower(input.SdkServiceName), namespaceForApiVersion(input.ApiVersion), input.ApiVersion, input.ProviderPrefix)
+
+	if _, ok := servicesUsingOldBaseLayer[strings.ToLower(input.SdkServiceName)]; ok {
+		output = fmt.Sprintf(`
+package client
+import (
+	"github.com/Azure/go-autorest/autorest"
+	%[1]s_%[2]s "github.com/hashicorp/go-azure-sdk/resource-manager/%[1]s/%[3]s"
+	"github.com/hashicorp/terraform-provider-%[4]s/internal/common"
+)
+func NewClient(o *common.ClientOptions) (*%[1]s_%[2]s.Client, error) {
 	client := %[1]s_%[2]s.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
 		c.Authorizer = o.ResourceManagerAuthorizer
 	})
-	return &client
+	return &client, nil
 }
 `, strings.ToLower(input.SdkServiceName), namespaceForApiVersion(input.ApiVersion), input.ApiVersion, input.ProviderPrefix)
+	}
+
 	return strings.TrimSpace(output)
 }

--- a/tools/generator-terraform/generator/definitions/template_service_client_test.go
+++ b/tools/generator-terraform/generator/definitions/template_service_client_test.go
@@ -20,16 +20,45 @@ func TestTemplateForServiceClient(t *testing.T) {
 package client
 
 import (
-	"github.com/Azure/go-autorest/autorest"
 	resources_v2015_11_01_preview "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01-preview"
 	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
 )
 
-func NewClient(o *common.ClientOptions) *resources_v2015_11_01_preview.Client {
-	client := resources_v2015_11_01_preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
+func NewClient(o *common.ClientOptions) (*resources_v2015_11_01_preview.Client, error) {
+	client, err := resources_v2015_11_01_preview.NewClientWithBaseURI(o.Environment.ResourceManager, func(c *resourcemanager.Client) {
+		o.Configure(c, o.Authorizers.ResourceManager)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("building client for resources v2015_11_01_preview: %+v", err)
+	}
+	return &client, nil
+}
+`
+	testhelpers.AssertTemplatedCodeMatches(t, expected, actual)
+}
+
+func TestTemplateForServiceClient_GoAutoRest(t *testing.T) {
+	input := models.ServiceInput{
+		ApiVersion:         "2015-11-01-preview",
+		ProviderPrefix:     "myprovider", // intentionally not used, since this is `client`
+		SdkServiceName:     "loadtestservice",
+		ServicePackageName: "mypackage",
+	}
+	actual := templateForServiceClient(input)
+	expected := `
+package client
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	loadtestservice_v2015_11_01_preview "github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2015-11-01-preview"
+	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
+)
+
+func NewClient(o *common.ClientOptions) (*loadtestservice_v2015_11_01_preview.Client, error) {
+	client := loadtestservice_v2015_11_01_preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
 		c.Authorizer = o.ResourceManagerAuthorizer
 	})
-	return &client
+	return &client, nil
 }
 `
 	testhelpers.AssertTemplatedCodeMatches(t, expected, actual)


### PR DESCRIPTION
This PR adds support for the generated resources using either `Azure/go-autorest` or `hashicorp/go-azure-sdk` by conditionally calling the correct Meta Client.

This'll need a little coordination in `terraform-provider-azurerm`, since [the `buildAutoClients` method](https://github.com/hashicorp/terraform-provider-azurerm/blob/6c991f7808ad32cfd77d085f604d08cad584069e/internal/clients/client.go#L260) will need to raise the error.