### PR TITLE
tools/generator-go-sdk: updating `databricks` to use the new base layer

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -51,7 +51,6 @@ func main() {
 		"Consumption",
 		"ContainerApps",
 		"ContainerInstance",
-		"ContainerService",
 		"CosmosDB",
 		"CostManagement",
 		"CustomProviders",
@@ -64,7 +63,6 @@ func main() {
 		"DataMigration",
 		"DataProtection",
 		"DataShare",
-		"Databricks",
 		"DesktopVirtualization",
 		"DevTestLab",
 		"DeviceProvisioningServices",
@@ -88,12 +86,10 @@ func main() {
 		"KubernetesConfiguration",
 		"Kusto",
 		"LabServices",
-		"LoadTestService",
 		"Logic",
 		"Logz",
 		"MachineLearningServices",
 		"Maintenance",
-		"ManagedIdentity",
 		"ManagedServices",
 		"ManagementGroups",
 		"MariaDB",
@@ -150,6 +146,11 @@ func main() {
 		"Automation@2019-06-01",
 		"Automation@2020-01-13-preview",
 		"Automation@2021-06-22",
+
+		// @tombuildsstuff: there's generated resources associated with these three - please check before removing these
+		"ContainerService",
+		"LoadTestService",
+		"ManagedIdentity",
 	)
 
 	var serviceNames string


### PR DESCRIPTION
Since it's a little late in the week for it, we'll merge this after this weeks release