### PR TITLE
tools/generator-go-sdk: normalizing the value of String constants during unmarshalling

### DIFF
--- a/tools/generator-go-sdk/featureflags/flags.go
+++ b/tools/generator-go-sdk/featureflags/flags.go
@@ -5,15 +5,6 @@ import (
 	"strings"
 )
 
-// GenerateNormalizationFunctionsForConstants specifies whether Normalization functions
-// should be generated for Constants. This means that APIs which return Constants in a
-// differing casing to those defined in the SDK will be automatically re-cased during
-// deserialization if they match a defined value. For example `standard` -> `Standard`.
-//
-// Values which are unmatched (e.g. new/undefined values) will be left as-is and just
-// unmarshalled as normal.
-const GenerateNormalizationFunctionsForConstants = false
-
 // GenerateCaseInsensitiveFunctions specifies whether case-insensitive Resource ID parsing
 // functions should be generated.
 const GenerateCaseInsensitiveFunctions = true

--- a/tools/generator-go-sdk/featureflags/flags.go
+++ b/tools/generator-go-sdk/featureflags/flags.go
@@ -5,6 +5,17 @@ import (
 	"strings"
 )
 
+// GenerateNormalizationFunctionsForConstants specifies whether Normalization functions
+// should be generated for Constants. This means that APIs which return Constants in a
+// differing casing to those defined in the SDK will be automatically re-cased during
+// deserialization if they match a defined value. For example `standard` -> `Standard`.
+//
+// Values which are unmatched (e.g. new/undefined values) will be left as-is and just
+// unmarshalled as normal.
+const GenerateNormalizationFunctionsForConstants = false
+
+// GenerateCaseInsensitiveFunctions specifies whether case-insensitive Resource ID parsing
+// functions should be generated.
 const GenerateCaseInsensitiveFunctions = true
 
 // SkipDiscriminatedParentTypes returns whether or not the feature for skipping generation of

--- a/tools/generator-go-sdk/generator/templater_constant.go
+++ b/tools/generator-go-sdk/generator/templater_constant.go
@@ -31,16 +31,10 @@ func templateForConstant(name string, details resourcemanager.ConstantDetails, g
 	possibleValuesFunction := t.possibleValuesFunction()
 	normalizationFunction := t.normalizationFunction()
 
-	parseFunction, err := t.parseFunction()
-	if err != nil {
-		return nil, fmt.Errorf("generating parse function: %+v", err)
-	}
-
 	out := strings.Join([]string{
 		constantDefinition,
 		possibleValuesFunction,
 		normalizationFunction,
-		*parseFunction,
 	}, "\n")
 	return &out, nil
 }
@@ -117,66 +111,6 @@ func PossibleValuesFor%[1]s() []%[2]s {
 	}
 }
 `, t.name, typeName, strings.Join(lines, "\n"))
-}
-
-func (t constantTemplater) parseFunction() (*string, error) {
-	valueKeys := make([]string, 0)
-	for key := range t.details.Values {
-		valueKeys = append(valueKeys, key)
-	}
-	sort.Strings(valueKeys)
-
-	if t.details.Type == resourcemanager.FloatConstant || t.details.Type == resourcemanager.IntegerConstant {
-		mapLines := make([]string, 0)
-		for _, constantKey := range valueKeys {
-			constantValue := t.details.Values[constantKey]
-			// whilst the key may look weird here, constantValue is a string containing the formatted int/float value
-			// as such we output that raw without any parsing/formatting
-			mapLines = append(mapLines, fmt.Sprintf("%s: %s%s,", strings.ToLower(constantValue), t.name, constantKey))
-		}
-		typeName := t.mapToGoType()
-
-		out := fmt.Sprintf(`
-func parse%[1]s(input %[3]s) (*%[1]s, error) {
-	vals := map[%[3]s]%[1]s{
-		%[2]s
-	}
-	if v, ok := vals[input]; ok {
-		return &v, nil
-	}
-
-	// otherwise presume it's an undefined value and best-effort it
-	out := %[1]s(input)
-	return &out, nil
-}
-`, t.name, strings.Join(mapLines, "\n"), typeName)
-		return &out, nil
-	}
-
-	if t.details.Type != resourcemanager.StringConstant {
-		return nil, fmt.Errorf("unimplemented constant type %q", string(t.details.Type))
-	}
-
-	mapLines := make([]string, 0)
-	for _, constantKey := range valueKeys {
-		constantValue := t.details.Values[constantKey]
-		mapLines = append(mapLines, fmt.Sprintf("%q: %s%s,", strings.ToLower(constantValue), t.name, constantKey))
-	}
-	out := fmt.Sprintf(`
-func parse%[1]s(input string) (*%[1]s, error) {
-	vals := map[string]%[1]s{
-		%[2]s
-	}
-	if v, ok := vals[strings.ToLower(input)]; ok {
-		return &v, nil
-	}
-
-	// otherwise presume it's an undefined value and best-effort it
-	out := %[1]s(input)
-	return &out, nil
-}
-`, t.name, strings.Join(mapLines, "\n"))
-	return &out, nil
 }
 
 func (t constantTemplater) mapToGoType() string {

--- a/tools/generator-go-sdk/generator/templater_constant_test.go
+++ b/tools/generator-go-sdk/generator/templater_constant_test.go
@@ -31,20 +31,6 @@ func PossibleValuesForMyConstant() []float64 {
         float64(MyConstantTwoPointSix),
 	}
 }
-
-func parseMyConstant(input float64) (*MyConstant, error) {
-	vals := map[float64]MyConstant{
-        4.2: MyConstantFourPointTwo,
-        2.6: MyConstantTwoPointSix,
-	}
-	if v, ok := vals[input]; ok {
-    	return &v, nil
-	}
-        
-	// otherwise presume it's an undefined value and best-effort it
-	out := MyConstant(input)
-	return &out, nil
-}
 `
 	assertTemplatedCodeMatches(t, expected, *actual)
 }
@@ -77,21 +63,6 @@ func PossibleValuesForMamboNumber() []int64 {
 		int64(MamboNumberTwo),
 	}
 }
-
-func parseMamboNumber(input int64) (*MamboNumber, error) {
-	vals := map[int64]MamboNumber{
-        5: MamboNumberFive,
-        16: MamboNumberTenSix,
-		2: MamboNumberTwo,
-	}
-	if v, ok := vals[input]; ok {
-    	return &v, nil
-	}
-        
-	// otherwise presume it's an undefined value and best-effort it
-	out := MamboNumber(input)
-	return &out, nil
-}
 `
 	assertTemplatedCodeMatches(t, expected, *actual)
 }
@@ -123,21 +94,6 @@ func PossibleValuesForCapital() []string {
         string(CapitalOslo),
         string(CapitalSydney),
 	}
-}
-
-func parseCapital(input string) (*Capital, error) {
-	vals := map[string]Capital{
-		"berlin": CapitalBerlin,
-        "oslo": CapitalOslo,
-        "sydney": CapitalSydney,
-	}
-	if v, ok := vals[strings.ToLower(input)]; ok {
-    	return &v, nil
-	}
-        
-	// otherwise presume it's an undefined value and best-effort it
-	out := Capital(input)
-	return &out, nil
 }
 `
 	assertTemplatedCodeMatches(t, expected, *actual)
@@ -185,21 +141,6 @@ func (s *Capital) UnmarshalJSON(bytes []byte) error {
 	}
 	*s = Capital(decoded)
 	return nil
-}
-
-func parseCapital(input string) (*Capital, error) {
-	vals := map[string]Capital{
-		"berlin": CapitalBerlin,
-        "oslo": CapitalOslo,
-        "sydney": CapitalSydney,
-	}
-	if v, ok := vals[strings.ToLower(input)]; ok {
-    	return &v, nil
-	}
-        
-	// otherwise presume it's an undefined value and best-effort it
-	out := Capital(input)
-	return &out, nil
 }
 `
 	assertTemplatedCodeMatches(t, expected, *actual)

--- a/tools/generator-go-sdk/generator/templater_constants.go
+++ b/tools/generator-go-sdk/generator/templater_constants.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"github.com/hashicorp/pandora/tools/generator-go-sdk/featureflags"
 	"sort"
 	"strings"
 
@@ -31,7 +30,11 @@ func (c constantsTemplater) template(data ServiceGeneratorData) (*string, error)
 	for _, constantName := range keys {
 		values := data.constants[constantName]
 
-		constantLines, err := c.constantTemplateFunc(constantName, values, featureflags.GenerateNormalizationFunctionsForConstants)
+		// the rollout of the Constant Normalization functions can be done at the same time as the
+		// rollout of the new base layer, to allow us to go gradually
+		generateNormalizationFunction := data.useNewBaseLayer
+
+		constantLines, err := c.constantTemplateFunc(constantName, values, generateNormalizationFunction)
 		if err != nil {
 			return nil, fmt.Errorf("generating template for constant %q: %+v", constantName, err)
 		}

--- a/tools/generator-go-sdk/generator/templater_constants.go
+++ b/tools/generator-go-sdk/generator/templater_constants.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"fmt"
+	"github.com/hashicorp/pandora/tools/generator-go-sdk/featureflags"
 	"sort"
 	"strings"
 
@@ -11,7 +12,7 @@ import (
 var _ templaterForResource = constantsTemplater{}
 
 type constantsTemplater struct {
-	constantTemplateFunc func(name string, details resourcemanager.ConstantDetails) (*string, error)
+	constantTemplateFunc func(name string, details resourcemanager.ConstantDetails, generateNormalizationFunction bool) (*string, error)
 }
 
 func (c constantsTemplater) template(data ServiceGeneratorData) (*string, error) {
@@ -30,7 +31,7 @@ func (c constantsTemplater) template(data ServiceGeneratorData) (*string, error)
 	for _, constantName := range keys {
 		values := data.constants[constantName]
 
-		constantLines, err := c.constantTemplateFunc(constantName, values)
+		constantLines, err := c.constantTemplateFunc(constantName, values, featureflags.GenerateNormalizationFunctionsForConstants)
 		if err != nil {
 			return nil, fmt.Errorf("generating template for constant %q: %+v", constantName, err)
 		}

--- a/tools/generator-go-sdk/generator/templater_constants_test.go
+++ b/tools/generator-go-sdk/generator/templater_constants_test.go
@@ -10,7 +10,7 @@ import (
 func TestTemplateConstantsSingle(t *testing.T) {
 	actual, err := constantsTemplater{
 		// output the bare minimum for testing
-		constantTemplateFunc: func(name string, details resourcemanager.ConstantDetails) (*string, error) {
+		constantTemplateFunc: func(name string, details resourcemanager.ConstantDetails, generateNormalizationFunction bool) (*string, error) {
 			out := fmt.Sprintf("// template for %s", name)
 			return &out, nil
 		},
@@ -43,7 +43,7 @@ func TestTemplateConstantsMultiple(t *testing.T) {
 	// asserting these are output alphabetically
 	actual, err := constantsTemplater{
 		// output the bare minimum for testing
-		constantTemplateFunc: func(name string, details resourcemanager.ConstantDetails) (*string, error) {
+		constantTemplateFunc: func(name string, details resourcemanager.ConstantDetails, generateNormalizationFunction bool) (*string, error) {
 			out := fmt.Sprintf("// template for %s", name)
 			return &out, nil
 		},


### PR DESCRIPTION
Skimming #758 I realised there's a far simpler way of doing this - hence this PR.

This PR introduces a custom unmarshal function for string constants, meaning that when we unmarshal the JSON response from the API, we'll try and normalize this value to match the casing defined within the API Specification.

As a hypothetical example, this means that is the API Specification defines `sku` with the values `Standard` and `Premium` - if the API response returns `standard` or `Standard` or `StAnDaRd` then we'll unmarshal this value consistently as `Standard`.

Notably, this change only takes effect at Unmarshal time, since we assume that the payload being provided in the HTTP Response is cased correctly, as in the Terraform Provider, the schema should be validating the value being provided matches the constant values.

Supersedes #758
Fixes #417