### PR TITLE
Add status code 201 to the base class for patch operations

### DIFF
--- a/data/Pandora.Definitions/Operations/PatchOperation.cs
+++ b/data/Pandora.Definitions/Operations/PatchOperation.cs
@@ -17,6 +17,7 @@ public abstract class PatchOperation : ApiOperation
     {
         return new List<HttpStatusCode>
         {
+            HttpStatusCode.Created,
             HttpStatusCode.OK,
         };
     }


### PR DESCRIPTION
API spec for ContainerRegistry 2021-08-01-preview has a long running PATCH operation that can return two response codes:
https://github.com/Azure/azure-rest-api-specs/blob/main/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/preview/2021-08-01-preview/containerregistry.json#L1332-L1382