### PR TITLE
`importer-rest-api-specs`: have to update the `ParsedOperation.ResourceIdName` when name conflicts in resourceID

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
@@ -122,7 +122,7 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, log hclog.Logg
 
 		if _, ok := conflictUniqNames[k]; ok {
 			for idx, v2 := range uri2ResourceId {
-				if v2.ResourceId.ID() == v.ID() && (v2.ResourceIdName != nil && *v2.ResourceIdName != key) {
+				if v2.ResourceId != nil && v2.ResourceId.ID() == v.ID() && (v2.ResourceIdName != nil && *v2.ResourceIdName != key) {
 					v2.ResourceIdName = &key
 					uri2ResourceId[idx] = v2
 				}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (p *Parser) generateNamesForResourceIds(input []models.ParsedResourceId, uri2ResourceId map[string]ParsedOperation) (*map[string]models.ParsedResourceId, error) {
-	return generateNamesForResourceIds(input, p.logger, uri2ResourceId)
+func (p *Parser) generateNamesForResourceIds(input []models.ParsedResourceId, uriToResourceId map[string]ParsedOperation) (*map[string]models.ParsedResourceId, error) {
+	return generateNamesForResourceIds(input, p.logger, uriToResourceId)
 }
 
 func generateNamesForResourceIds(input []models.ParsedResourceId, log hclog.Logger, uriToResourceId map[string]ParsedOperation) (*map[string]models.ParsedResourceId, error) {

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
@@ -433,7 +433,7 @@ var redisPatchSchedulesResourceId = models.ParsedResourceId{
 }
 
 func TestResourceIDNamingEmpty(t *testing.T) {
-	actualNamesToIds, err := generateNamesForResourceIds([]models.ParsedResourceId{}, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds([]models.ParsedResourceId{}, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -452,7 +452,7 @@ func TestResourceIDNamingSubscriptionId(t *testing.T) {
 		"SubscriptionId": subscriptionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -473,7 +473,7 @@ func TestResourceIDNamingSubscriptionIdAndSuffix(t *testing.T) {
 		"SubscriptionId": subscriptionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -492,7 +492,7 @@ func TestResourceIDNamingResourceGroupId(t *testing.T) {
 		"ResourceGroupId": resourceGroupResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -513,7 +513,7 @@ func TestResourceIDNamingResourceGroupIdAndSuffix(t *testing.T) {
 		"ResourceGroupId": resourceGroupResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -532,7 +532,7 @@ func TestResourceIDNamingManagementGroupId(t *testing.T) {
 		"ManagementGroupId": managementGroupResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -553,7 +553,7 @@ func TestResourceIDNamingManagementGroupIdAndSuffix(t *testing.T) {
 		"ManagementGroupId": managementGroupResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -572,7 +572,7 @@ func TestResourceIDNamingEventHubSkuId(t *testing.T) {
 		"SkuId": eventHubSkuResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -601,7 +601,7 @@ func TestResourceIDNamingTopLevelScope(t *testing.T) {
 		"ScopeId": scopeResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -671,7 +671,7 @@ func TestResourceIDNamingContainingAConstant(t *testing.T) {
 		"RecordTypeId": dnsResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -743,7 +743,7 @@ func TestResourceIDNamingContainingAConstantAndSuffix(t *testing.T) {
 		"RecordTypeId": dnsResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -762,7 +762,7 @@ func TestResourceIdNamingTopLevelResourceId(t *testing.T) {
 		"VirtualMachineId": virtualMachineResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -783,7 +783,7 @@ func TestResourceIdNamingTopLevelAndNestedResourceId(t *testing.T) {
 		"ExtensionId":      virtualMachineExtensionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -802,7 +802,7 @@ func TestResourceIdNamingNestedResourceId(t *testing.T) {
 		"ExtensionId": virtualMachineExtensionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -821,7 +821,7 @@ func TestResourceIdNamingResourceUnderScope(t *testing.T) {
 		"ScopedExtensionId": scopedMonitorResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -842,7 +842,7 @@ func TestResourceIdNamingConflictingTwoLevels(t *testing.T) {
 		"ExtensionId":               virtualNetworkExtensionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -1136,7 +1136,7 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 		"ModuleId":             instanceProcessModuleResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -1155,7 +1155,7 @@ func TestResourceIdNamingSignalRId(t *testing.T) {
 		"SignalRId": signalRResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -1174,7 +1174,7 @@ func TestResourceIdNamingTrafficManagerEndpoint(t *testing.T) {
 		"EndpointTypeId": trafficManagerProfileResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -1193,7 +1193,7 @@ func TestResourceIDNamingRedisDefaultId(t *testing.T) {
 		"DefaultId": redisPatchSchedulesResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger())
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
@@ -434,7 +434,8 @@ var redisPatchSchedulesResourceId = models.ParsedResourceId{
 }
 
 func TestResourceIDNamingEmpty(t *testing.T) {
-	actualNamesToIds, err := generateNamesForResourceIds([]models.ParsedResourceId{}, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds([]models.ParsedResourceId{}, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -453,7 +454,8 @@ func TestResourceIDNamingSubscriptionId(t *testing.T) {
 		"SubscriptionId": subscriptionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -474,7 +476,8 @@ func TestResourceIDNamingSubscriptionIdAndSuffix(t *testing.T) {
 		"SubscriptionId": subscriptionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -493,7 +496,8 @@ func TestResourceIDNamingResourceGroupId(t *testing.T) {
 		"ResourceGroupId": resourceGroupResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -514,7 +518,8 @@ func TestResourceIDNamingResourceGroupIdAndSuffix(t *testing.T) {
 		"ResourceGroupId": resourceGroupResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -533,7 +538,8 @@ func TestResourceIDNamingManagementGroupId(t *testing.T) {
 		"ManagementGroupId": managementGroupResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -554,7 +560,8 @@ func TestResourceIDNamingManagementGroupIdAndSuffix(t *testing.T) {
 		"ManagementGroupId": managementGroupResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -573,7 +580,8 @@ func TestResourceIDNamingEventHubSkuId(t *testing.T) {
 		"SkuId": eventHubSkuResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -602,7 +610,8 @@ func TestResourceIDNamingTopLevelScope(t *testing.T) {
 		"ScopeId": scopeResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -672,7 +681,8 @@ func TestResourceIDNamingContainingAConstant(t *testing.T) {
 		"RecordTypeId": dnsResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -744,7 +754,8 @@ func TestResourceIDNamingContainingAConstantAndSuffix(t *testing.T) {
 		"RecordTypeId": dnsResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -763,7 +774,8 @@ func TestResourceIdNamingTopLevelResourceId(t *testing.T) {
 		"VirtualMachineId": virtualMachineResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -784,7 +796,8 @@ func TestResourceIdNamingTopLevelAndNestedResourceId(t *testing.T) {
 		"ExtensionId":      virtualMachineExtensionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -803,7 +816,8 @@ func TestResourceIdNamingNestedResourceId(t *testing.T) {
 		"ExtensionId": virtualMachineExtensionResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -822,7 +836,8 @@ func TestResourceIdNamingResourceUnderScope(t *testing.T) {
 		"ScopedExtensionId": scopedMonitorResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -843,7 +858,7 @@ func TestResourceIdNamingConflictingTwoLevels(t *testing.T) {
 		"ExtensionId":               virtualNetworkExtensionResourceId,
 	}
 
-	var uriToParsedOperation map[string]ParsedOperation
+	uriToParsedOperation := map[string]ParsedOperation{}
 	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
@@ -1176,7 +1191,8 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 		"ModuleId":             instanceProcessModuleResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -1195,7 +1211,8 @@ func TestResourceIdNamingSignalRId(t *testing.T) {
 		"SignalRId": signalRResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -1214,7 +1231,8 @@ func TestResourceIdNamingTrafficManagerEndpoint(t *testing.T) {
 		"EndpointTypeId": trafficManagerProfileResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -1233,7 +1251,8 @@ func TestResourceIDNamingRedisDefaultId(t *testing.T) {
 		"DefaultId": redisPatchSchedulesResourceId,
 	}
 
-	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), nil)
+	uriToParsedOperation := map[string]ParsedOperation{}
+	actualNamesToIds, err := generateNamesForResourceIds(input, hclog.NewNullLogger(), uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return

--- a/tools/importer-rest-api-specs/components/parser/resourceids/models.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/models.go
@@ -91,7 +91,8 @@ func (r *ParseResult) Append(other ParseResult, logger hclog.Logger) error {
 			}
 		}
 
-		namesToResourceIds, err := generateNamesForResourceIds(combinedResourceIds, logger)
+		// this may cause rename for name conflict, so have to modify the name in OriginalUrisToResourceIDs too
+		namesToResourceIds, err := generateNamesForResourceIds(combinedResourceIds, logger, r.OriginalUrisToResourceIDs)
 		if err != nil {
 			return fmt.Errorf("regenerating Names : Resource IDs for combined list: %+v", err)
 		}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parser.go
@@ -23,7 +23,7 @@ func (p *Parser) Parse() (*ParseResult, error) {
 	resourceIds := switchOutCommonResourceIDsAsNeeded(uniqueResourceIds)
 
 	p.logger.Trace("Generating Names for Resource IDs..")
-	namesToResourceIds, err := p.generateNamesForResourceIds(resourceIds)
+	namesToResourceIds, err := p.generateNamesForResourceIds(resourceIds, nil)
 	if err != nil {
 		return nil, fmt.Errorf("generating Names for Resource IDs: %+v", err)
 	}


### PR DESCRIPTION
should resolves: #2265

because the importer tool will find the resource id definition by resource id name when process one tag(Line 260):

https://github.com/hashicorp/pandora/blob/64e4990f726856ce548d5ab3c25f941c5f583211/tools/importer-rest-api-specs/components/parser/remove_unused_items.go#L253-L262

the generated SDK as expected:

![image](https://user-images.githubusercontent.com/2633022/228761022-98cbff26-c5e5-479a-bf7e-764b530e80e6.png)
