### PR TITLE
Add 2021-04-01 Resources API

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -403,7 +403,7 @@ service "resourceconnector" {
 }
 service "resources" {
   name      = "Resources"
-  available = ["2020-05-01", "2020-06-01", "2020-10-01", "2022-06-01", "2022-09-01"]
+  available = ["2020-05-01", "2020-06-01", "2020-10-01", "2021-04-01", "2022-06-01", "2022-09-01"]
 }
 service "search" {
   name      = "Search"


### PR DESCRIPTION
Imports the 2021-04-01 version of resources API so that I can leverage https://learn.microsoft.com/en-us/rest/api/resources/deployment-operations List endpoint