### PR TITLE
`tools/importer-rest-api-specs`: outputting the list of Constants and Models used in each API Resource

### DIFF
--- a/data/Pandora.Definitions/Interfaces/ResourceDefinition.cs
+++ b/data/Pandora.Definitions/Interfaces/ResourceDefinition.cs
@@ -2,9 +2,32 @@ using System.Collections.Generic;
 
 namespace Pandora.Definitions.Interfaces;
 
+/// <summary>
+/// A ResourceDefinition is a grouping of Resources within a given API Version
+/// which contains related operations. For example the API Resource `VirtualMachines`
+/// exists within API Version `2020-01-01` within the Service `Compute` which may support
+/// Create and Start/Stop as Operations.
+/// </summary>
 public interface ResourceDefinition
 {
+    // Name specifies the name of this API Resource
     string Name { get; }
 
+    // Operations is a list of ApiOperations present within this API Resource
     IEnumerable<ApiOperation> Operations { get; }
+
+    // @tombuildsstuff: in the near future we'll add this to the interface:
+    // which will support loading these values from this list, rather than using reflection to do so.
+    //
+    // /// <summary>
+    // /// Constants defines the list of Constants Types used within this API Resource - including any
+    // /// used in either the Options payload/Resource ID too.
+    // /// </summary>
+    // IEnumerable<System.Type> Constants { get; }
+    //
+    // /// <summary>
+    // /// Models defines the list of Model Types used within this API Resource - including the discriminated
+    // /// types too.
+    // /// </summary>
+    // IEnumerable<System.Type> Models { get; }
 }

--- a/tools/importer-rest-api-specs/components/dataapigenerator/package.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/package.go
@@ -85,7 +85,7 @@ func (s Generator) generateResources(resourceName, namespace string, resource mo
 	}
 
 	s.logger.Debug("Generating Package Definition..")
-	packageDefinitionCode := codeForPackageDefinition(namespace, resourceName, resource.Operations)
+	packageDefinitionCode := codeForPackageDefinition(namespace, resourceName, resource)
 	packageDefinitionFileName := path.Join(workingDirectory, "Definition.cs")
 	if err := writeToFile(packageDefinitionFileName, packageDefinitionCode); err != nil {
 		return fmt.Errorf("writing package definition for %q: %+v", packageDefinitionFileName, err)

--- a/tools/importer-rest-api-specs/components/dataapigenerator/templater_package_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigenerator/templater_package_definition.go
@@ -8,32 +8,62 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func codeForPackageDefinition(namespace, resourceName string, operations map[string]models.OperationDetails) string {
+func codeForPackageDefinition(namespace, resourceName string, input models.AzureApiResource) string {
 	operationNames := make([]string, 0)
-	for operation := range operations {
+	for operation := range input.Operations {
 		operationNames = append(operationNames, operation)
 	}
 	sort.Strings(operationNames)
 
-	lines := make([]string, 0)
+	operationLines := make([]string, 0)
 	for _, operationName := range operationNames {
-		lines = append(lines, fmt.Sprintf("\t\tnew %sOperation(),", operationName))
+		operationLines = append(operationLines, fmt.Sprintf("\t\tnew %sOperation(),", operationName))
+	}
+
+	constantNames := make([]string, 0)
+	for k := range input.Constants {
+		constantNames = append(constantNames, k)
+	}
+	sort.Strings(constantNames)
+
+	constantLines := make([]string, 0)
+	for _, constantName := range constantNames {
+		constantLines = append(constantLines, fmt.Sprintf("\t\ttypeof(%sConstant),", constantName))
+	}
+
+	modelNames := make([]string, 0)
+	for k := range input.Models {
+		modelNames = append(modelNames, k)
+	}
+	sort.Strings(modelNames)
+
+	modelLines := make([]string, 0)
+	for _, modelName := range modelNames {
+		modelLines = append(modelLines, fmt.Sprintf("\t\ttypeof(%sModel),", modelName))
 	}
 
 	return fmt.Sprintf(`using System.Collections.Generic;
 using Pandora.Definitions.Interfaces;
 
-%[4]s
+%[1]s
 
-namespace %[1]s;
+namespace %[2]s;
 
 internal class Definition : ResourceDefinition
 {
-	public string Name => "%[2]s";
+	public string Name => %[3]q;
 	public IEnumerable<Interfaces.ApiOperation> Operations => new List<Interfaces.ApiOperation>
 	{
-%[3]s
+%[4]s
+	};
+	public IEnumerable<System.Type> Constants => new List<System.Type>
+	{
+%[5]s
+	};
+	public IEnumerable<System.Type> Models => new List<System.Type>
+	{
+%[6]s
 	};
 }
-`, namespace, resourceName, strings.Join(lines, "\n"), restApiSpecsLicence)
+`, restApiSpecsLicence, namespace, resourceName, strings.Join(operationLines, "\n"), strings.Join(constantLines, "\n"), strings.Join(modelLines, "\n"))
 }


### PR DESCRIPTION
This PR introduces a little more overhead at compile-time to save time at run-time - by statically defining the list of Constants and Models used in each API Resource, we can avoid using reflection to pull this out.

I've intentionally split this change out from the separate change in the Data API since it's going to require a change to the entire `./data/Pandora.Definitions.ResourceManager` package, so by merging this change first we can add this data, then add these new fields to the interface (in the next PR) and make use of this information.

The associated change for this in the Data API should be fairly minimal (see below), however this will necessitate rewriting the unit tests to account for these models now being defined by the Resource Definition, rather than being looked up via reflection:

```diff
 $ git diff Pandora.Data/Transformers/ResourceDefinition.cs                                                                                                                            diff --git a/data/Pandora.Data/Transformers/ResourceDefinition.cs b/data/Pandora.Data/Transformers/ResourceDefinition.cs
index fa7f7f23a..3cee57e65 100644
--- a/data/Pandora.Data/Transformers/ResourceDefinition.cs
+++ b/data/Pandora.Data/Transformers/ResourceDefinition.cs
@@ -18,8 +18,8 @@ public static class ResourceDefinition
                 throw new NotSupportedException($"API Version {input.GetType().Name} has no operations");
             }

-            var constantDefinitions = operations.SelectMany(ConstantsForOperation).ToList();
-            var modelDefinitions = operations.SelectMany(ModelsForOperation).Distinct(new ModelComparer()).ToList();
+            var constantDefinitions = input.Constants.Select(Constant.FromEnum).ToList();
+            var modelDefinitions = input.Models.SelectMany(Model.Map).Distinct(new ModelComparer()).ToList();
             var operationDefinitions = operations.Select(Operation.Map).ToList();
             var resourceIds = operations.SelectMany(ResourceIdsForOperation).Distinct(new ResourceIDComparer()).ToList();

@@ -54,44 +54,4 @@ public static class ResourceDefinition

         return output;
     }
-
-    private static List<ConstantDefinition> ConstantsForOperation(ApiOperation input)
-    {
-        var definitions = new List<ConstantDefinition>();
-
-        if (input.RequestObject() != null)
-        {
-            definitions.AddRange(Constant.WithinObject(input.RequestObject()!));
-        }
-
-        if (input.ResponseObject() != null)
-        {
-            definitions.AddRange(Constant.WithinObject(input.ResponseObject()!));
-        }
-
-        // pull out any constants which are referenced against the Options block
-        if (input.OptionsObject() != null)
-        {
-            definitions.AddRange(Constant.WithinObject(input.OptionsObject()!));
-        }
-
-        return definitions.Distinct(new ConstantComparer()).ToList();
-    }
-
-    private static List<ModelDefinition> ModelsForOperation(ApiOperation input)
-    {
-        var definitions = new List<ModelDefinition>();
-
-        if (input.RequestObject() != null)
-        {
-            definitions.AddRange(Model.Map(input.RequestObject()!));
-        }
-
-        if (input.ResponseObject() != null)
-        {
-            definitions.AddRange(Model.Map(input.ResponseObject()!));
-        }
-
-        return definitions.Distinct(new ModelComparer()).ToList();
-    }
 }
```