### PR TITLE
tools/generator-go-sdk: conditionally outputting the `parse[Constant]` functions

### DIFF
--- a/tools/generator-go-sdk/generator/templater_constant.go
+++ b/tools/generator-go-sdk/generator/templater_constant.go
@@ -31,10 +31,16 @@ func templateForConstant(name string, details resourcemanager.ConstantDetails, g
 	possibleValuesFunction := t.possibleValuesFunction()
 	normalizationFunction := t.normalizationFunction()
 
+	parseFunction, err := t.parseFunction()
+	if err != nil {
+		return nil, fmt.Errorf("generating parse function: %+v", err)
+	}
+
 	out := strings.Join([]string{
 		constantDefinition,
 		possibleValuesFunction,
 		normalizationFunction,
+		*parseFunction,
 	}, "\n")
 	return &out, nil
 }
@@ -111,6 +117,66 @@ func PossibleValuesFor%[1]s() []%[2]s {
 	}
 }
 `, t.name, typeName, strings.Join(lines, "\n"))
+}
+
+func (t constantTemplater) parseFunction() (*string, error) {
+	valueKeys := make([]string, 0)
+	for key := range t.details.Values {
+		valueKeys = append(valueKeys, key)
+	}
+	sort.Strings(valueKeys)
+
+	if t.details.Type == resourcemanager.FloatConstant || t.details.Type == resourcemanager.IntegerConstant {
+		mapLines := make([]string, 0)
+		for _, constantKey := range valueKeys {
+			constantValue := t.details.Values[constantKey]
+			// whilst the key may look weird here, constantValue is a string containing the formatted int/float value
+			// as such we output that raw without any parsing/formatting
+			mapLines = append(mapLines, fmt.Sprintf("%s: %s%s,", strings.ToLower(constantValue), t.name, constantKey))
+		}
+		typeName := t.mapToGoType()
+
+		out := fmt.Sprintf(`
+func parse%[1]s(input %[3]s) (*%[1]s, error) {
+	vals := map[%[3]s]%[1]s{
+		%[2]s
+	}
+	if v, ok := vals[input]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := %[1]s(input)
+	return &out, nil
+}
+`, t.name, strings.Join(mapLines, "\n"), typeName)
+		return &out, nil
+	}
+
+	if t.details.Type != resourcemanager.StringConstant {
+		return nil, fmt.Errorf("unimplemented constant type %q", string(t.details.Type))
+	}
+
+	mapLines := make([]string, 0)
+	for _, constantKey := range valueKeys {
+		constantValue := t.details.Values[constantKey]
+		mapLines = append(mapLines, fmt.Sprintf("%q: %s%s,", strings.ToLower(constantValue), t.name, constantKey))
+	}
+	out := fmt.Sprintf(`
+func parse%[1]s(input string) (*%[1]s, error) {
+	vals := map[string]%[1]s{
+		%[2]s
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := %[1]s(input)
+	return &out, nil
+}
+`, t.name, strings.Join(mapLines, "\n"))
+	return &out, nil
 }
 
 func (t constantTemplater) mapToGoType() string {

--- a/tools/generator-go-sdk/generator/templater_constant.go
+++ b/tools/generator-go-sdk/generator/templater_constant.go
@@ -88,7 +88,11 @@ func (s *%[1]s) UnmarshalJSON(bytes []byte) error {
 	if err := json.Unmarshal(bytes, &decoded); err != nil {
 		return fmt.Errorf("unmarshaling: %%+v", err)
 	}
-	*s = parse%[1]s(decoded)
+	out, err := parse%[1]s(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %%q: %%+v", decoded, err)
+	}
+	*s = *out
 	return nil
 }
 `, t.name)

--- a/tools/generator-go-sdk/generator/templater_constant_test.go
+++ b/tools/generator-go-sdk/generator/templater_constant_test.go
@@ -162,9 +162,9 @@ func TestTemplateStringConstant(t *testing.T) {
 		CaseInsensitive: false,
 		Type:            resourcemanager.StringConstant,
 		Values: map[string]string{
-			"Berlin": "berlin",
-			"Oslo":   "oslo",
-			"Sydney": "sydney",
+			"Berlin":   "berlin",
+			"Canberra": "canberra",
+			"Oslo":     "oslo",
 		},
 	}, false, false)
 	if err != nil {
@@ -174,23 +174,23 @@ func TestTemplateStringConstant(t *testing.T) {
 
 const (
 	CapitalBerlin Capital = "berlin"
+	CapitalCanberra Capital = "canberra"
 	CapitalOslo Capital = "oslo"
-	CapitalSydney Capital = "sydney"
 )
 
 func PossibleValuesForCapital() []string {
 	return []string{
 		string(CapitalBerlin),
+        string(CapitalCanberra),
         string(CapitalOslo),
-        string(CapitalSydney),
 	}
 }
 
 func parseCapital(input string) (*Capital, error) {
 	vals := map[string]Capital{
 		"berlin": CapitalBerlin,
+        "canberra": CapitalCanberra,
         "oslo": CapitalOslo,
-        "sydney": CapitalSydney,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
     	return &v, nil
@@ -210,9 +210,9 @@ func TestTemplateStringConstantUsedInAResourceID(t *testing.T) {
 		CaseInsensitive: false,
 		Type:            resourcemanager.StringConstant,
 		Values: map[string]string{
-			"Berlin": "berlin",
-			"Oslo":   "oslo",
-			"Sydney": "sydney",
+			"Berlin":   "berlin",
+			"Canberra": "canberra",
+			"Oslo":     "oslo",
 		},
 	}, false, true)
 	if err != nil {
@@ -222,23 +222,23 @@ func TestTemplateStringConstantUsedInAResourceID(t *testing.T) {
 
 const (
 	CapitalBerlin Capital = "berlin"
+	CapitalCanberra Capital = "canberra"
 	CapitalOslo Capital = "oslo"
-	CapitalSydney Capital = "sydney"
 )
 
 func PossibleValuesForCapital() []string {
 	return []string{
 		string(CapitalBerlin),
+        string(CapitalCanberra),
         string(CapitalOslo),
-        string(CapitalSydney),
 	}
 }
 
 func parseCapital(input string) (*Capital, error) {
 	vals := map[string]Capital{
 		"berlin": CapitalBerlin,
+        "canberra": CapitalCanberra,
         "oslo": CapitalOslo,
-        "sydney": CapitalSydney,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
     	return &v, nil
@@ -257,9 +257,9 @@ func TestTemplateStringConstantWithNormalizationFunction(t *testing.T) {
 		CaseInsensitive: false,
 		Type:            resourcemanager.StringConstant,
 		Values: map[string]string{
-			"Berlin": "berlin",
-			"Oslo":   "oslo",
-			"Sydney": "sydney",
+			"Berlin":   "berlin",
+			"Canberra": "canberra",
+			"Oslo":     "oslo",
 		},
 	}, true, true)
 	if err != nil {
@@ -269,15 +269,15 @@ func TestTemplateStringConstantWithNormalizationFunction(t *testing.T) {
 
 const (
 	CapitalBerlin Capital = "berlin"
+	CapitalCanberra Capital = "canberra"
 	CapitalOslo Capital = "oslo"
-	CapitalSydney Capital = "sydney"
 )
 
 func PossibleValuesForCapital() []string {
 	return []string{
 		string(CapitalBerlin),
+        string(CapitalCanberra),
         string(CapitalOslo),
-        string(CapitalSydney),
 	}
 }
 
@@ -297,8 +297,8 @@ func (s *Capital) UnmarshalJSON(bytes []byte) error {
 func parseCapital(input string) (*Capital, error) {
 	vals := map[string]Capital{
 		"berlin": CapitalBerlin,
+        "canberra": CapitalCanberra,
         "oslo": CapitalOslo,
-        "sydney": CapitalSydney,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
     	return &v, nil

--- a/tools/generator-go-sdk/generator/templater_constant_test.go
+++ b/tools/generator-go-sdk/generator/templater_constant_test.go
@@ -286,7 +286,11 @@ func (s *Capital) UnmarshalJSON(bytes []byte) error {
 	if err := json.Unmarshal(bytes, &decoded); err != nil {
 		return fmt.Errorf("unmarshaling: %+v", err)
 	}
-	*s = parseCapital(decoded)
+	out, err := parseCapital(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
 	return nil
 }
 

--- a/tools/generator-go-sdk/generator/templater_constant_test.go
+++ b/tools/generator-go-sdk/generator/templater_constant_test.go
@@ -31,6 +31,20 @@ func PossibleValuesForMyConstant() []float64 {
         float64(MyConstantTwoPointSix),
 	}
 }
+
+func parseMyConstant(input float64) (*MyConstant, error) {
+	vals := map[float64]MyConstant{
+        4.2: MyConstantFourPointTwo,
+        2.6: MyConstantTwoPointSix,
+	}
+	if v, ok := vals[input]; ok {
+    	return &v, nil
+	}
+        
+	// otherwise presume it's an undefined value and best-effort it
+	out := MyConstant(input)
+	return &out, nil
+}
 `
 	assertTemplatedCodeMatches(t, expected, *actual)
 }
@@ -63,6 +77,21 @@ func PossibleValuesForMamboNumber() []int64 {
 		int64(MamboNumberTwo),
 	}
 }
+
+func parseMamboNumber(input int64) (*MamboNumber, error) {
+	vals := map[int64]MamboNumber{
+        5: MamboNumberFive,
+        16: MamboNumberTenSix,
+		2: MamboNumberTwo,
+	}
+	if v, ok := vals[input]; ok {
+    	return &v, nil
+	}
+        
+	// otherwise presume it's an undefined value and best-effort it
+	out := MamboNumber(input)
+	return &out, nil
+}
 `
 	assertTemplatedCodeMatches(t, expected, *actual)
 }
@@ -94,6 +123,21 @@ func PossibleValuesForCapital() []string {
         string(CapitalOslo),
         string(CapitalSydney),
 	}
+}
+
+func parseCapital(input string) (*Capital, error) {
+	vals := map[string]Capital{
+		"berlin": CapitalBerlin,
+        "oslo": CapitalOslo,
+        "sydney": CapitalSydney,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+    	return &v, nil
+	}
+        
+	// otherwise presume it's an undefined value and best-effort it
+	out := Capital(input)
+	return &out, nil
 }
 `
 	assertTemplatedCodeMatches(t, expected, *actual)
@@ -141,6 +185,21 @@ func (s *Capital) UnmarshalJSON(bytes []byte) error {
 	}
 	*s = Capital(decoded)
 	return nil
+}
+
+func parseCapital(input string) (*Capital, error) {
+	vals := map[string]Capital{
+		"berlin": CapitalBerlin,
+        "oslo": CapitalOslo,
+        "sydney": CapitalSydney,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+    	return &v, nil
+	}
+        
+	// otherwise presume it's an undefined value and best-effort it
+	out := Capital(input)
+	return &out, nil
 }
 `
 	assertTemplatedCodeMatches(t, expected, *actual)

--- a/tools/generator-go-sdk/generator/templater_constants_test.go
+++ b/tools/generator-go-sdk/generator/templater_constants_test.go
@@ -10,7 +10,7 @@ import (
 func TestTemplateConstantsSingle(t *testing.T) {
 	actual, err := constantsTemplater{
 		// output the bare minimum for testing
-		constantTemplateFunc: func(name string, details resourcemanager.ConstantDetails, generateNormalizationFunction bool) (*string, error) {
+		constantTemplateFunc: func(name string, details resourcemanager.ConstantDetails, generateNormalizationFunction, usedInAResourceId bool) (*string, error) {
 			out := fmt.Sprintf("// template for %s", name)
 			return &out, nil
 		},
@@ -43,7 +43,7 @@ func TestTemplateConstantsMultiple(t *testing.T) {
 	// asserting these are output alphabetically
 	actual, err := constantsTemplater{
 		// output the bare minimum for testing
-		constantTemplateFunc: func(name string, details resourcemanager.ConstantDetails, generateNormalizationFunction bool) (*string, error) {
+		constantTemplateFunc: func(name string, details resourcemanager.ConstantDetails, generateNormalizationFunction, usedInAResourceId bool) (*string, error) {
 			out := fmt.Sprintf("// template for %s", name)
 			return &out, nil
 		},

--- a/tools/generator-go-sdk/go.mod
+++ b/tools/generator-go-sdk/go.mod
@@ -2,6 +2,9 @@ module github.com/hashicorp/pandora/tools/generator-go-sdk
 
 go 1.19
 
-require github.com/hashicorp/pandora/tools/sdk v0.0.0-00010101000000-000000000000
+require (
+	github.com/hashicorp/go-azure-helpers v0.55.0
+	github.com/hashicorp/pandora/tools/sdk v0.0.0-00010101000000-000000000000
+)
 
 replace github.com/hashicorp/pandora/tools/sdk => ../sdk

--- a/tools/generator-go-sdk/go.sum
+++ b/tools/generator-go-sdk/go.sum
@@ -1,0 +1,2 @@
+github.com/hashicorp/go-azure-helpers v0.55.0 h1:2A2KWPiaDC5kQWr6tYHTD/P1k9bO0HvflEb/Nc1yLeU=
+github.com/hashicorp/go-azure-helpers v0.55.0/go.mod h1:RQugkG8wEcNIjYmcBLHpuEI/u2mTJwO4r37rR/OKRpo=


### PR DESCRIPTION
These functions are needed in two cases:

1. When the Constant is a String, the `parse[Constant]` function is used during Normalization
2. When the Constant is used within a Resource ID, the `parse[Constant]` function is used within the Resource ID parse function

Whilst we could always output these parse functions, conditionally outputting these reduces the TLOC we're outputting, which keeps the Go Module size of `hashicorp/go-azure-sdk` down.

Fixes https://github.com/hashicorp/go-azure-sdk/actions/runs/4615982722?pr=400