### PR TITLE
importer-rest-api-specs: remove `operations` from tags that we filter out

### DIFF
--- a/tools/importer-rest-api-specs/GNUmakefile
+++ b/tools/importer-rest-api-specs/GNUmakefile
@@ -23,7 +23,7 @@ import-with-api: build
 	dotnet format whitespace --verbosity quiet ../../data/Pandora.sln
 
 test: build
-	go test -v ./...
+	go test -v ./..
 
 tools:
 	@echo "==> installing required tooling..."

--- a/tools/importer-rest-api-specs/GNUmakefile
+++ b/tools/importer-rest-api-specs/GNUmakefile
@@ -23,7 +23,7 @@ import-with-api: build
 	dotnet format whitespace --verbosity quiet ../../data/Pandora.sln
 
 test: build
-	go test -v ./..
+	go test -v ./...
 
 tools:
 	@echo "==> installing required tooling..."

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags.go
@@ -6,9 +6,8 @@ import (
 )
 
 var tagsToIgnore = map[string]struct{}{
-	"tags":       {},
-	"operations": {},
-	"usage":      {},
+	"tags":  {},
+	"usage": {},
 }
 
 func (d *SwaggerDefinition) findTags() []string {
@@ -39,7 +38,7 @@ func tagShouldBeIgnored(tag string) bool {
 			return true
 		}
 
-		// suffixes e.g. `ComputeOperations`
+		// suffixes e.g. `ComputeUsage`
 		if strings.HasSuffix(lowered, strings.ToLower(key)) {
 			return true
 		}

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
@@ -70,7 +70,7 @@ func TestParsingOperationsOnResources(t *testing.T) {
 		t.Fatalf("expected 1 model but got %d", len(resource.Models))
 	}
 	if len(resource.Operations) != 3 {
-		t.Fatalf("expected 4 Operations but got %d", len(resource.Operations))
+		t.Fatalf("expected 3 Operations but got %d", len(resource.Operations))
 	}
 	if len(resource.ResourceIds) != 0 {
 		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))
@@ -99,7 +99,7 @@ func TestParsingOperationsOnResources(t *testing.T) {
 		t.Fatalf("expected 1 model but got %d", len(resource.Models))
 	}
 	if len(resourceOperation.Operations) != 1 {
-		t.Fatalf("expected 4 Operations but got %d", len(resource.Operations))
+		t.Fatalf("expected 1 Operations but got %d", len(resource.Operations))
 	}
 	if len(resourceOperation.ResourceIds) != 0 {
 		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
@@ -44,3 +44,69 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 		}
 	}
 }
+
+func TestParsingOperationsOnResources(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "operations_on_resources.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 2 {
+		t.Fatalf("expected 2 resource but got %d", len(result.Resources))
+	}
+
+	resource, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatal("the Resource 'Hello' was not found")
+	}
+
+	// sanity checking
+	if len(resource.Constants) != 0 {
+		t.Fatalf("expected 0 constants but got %d", len(resource.Constants))
+	}
+	if len(resource.Models) != 1 {
+		t.Fatalf("expected 1 model but got %d", len(resource.Models))
+	}
+	if len(resource.Operations) != 3 {
+		t.Fatalf("expected 4 Operations but got %d", len(resource.Operations))
+	}
+	if len(resource.ResourceIds) != 0 {
+		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))
+	}
+	expectedOperations := []string{
+		"First",
+		"PutBar",
+		"Second",
+	}
+	for _, expected := range expectedOperations {
+		if _, ok := resource.Operations[expected]; !ok {
+			t.Fatalf("expected there to be an operation named %q but didn't get one", expected)
+		}
+	}
+
+	resourceOperation, ok := result.Resources["HelloOperations"]
+	if !ok {
+		t.Fatal("the Resource 'HelloOperations' was not found")
+	}
+
+	// sanity checking
+	if len(resourceOperation.Constants) != 0 {
+		t.Fatalf("expected 0 constants but got %d", len(resource.Constants))
+	}
+	if len(resourceOperation.Models) != 1 {
+		t.Fatalf("expected 1 model but got %d", len(resource.Models))
+	}
+	if len(resourceOperation.Operations) != 1 {
+		t.Fatalf("expected 4 Operations but got %d", len(resource.Operations))
+	}
+	if len(resourceOperation.ResourceIds) != 0 {
+		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))
+	}
+
+	if _, ok := resourceOperation.Operations["HelloRestart"]; !ok {
+		t.Fatalf("expected there to be an operation named `Restart` but didn't get one")
+	}
+
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_on_resources.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_on_resources.json
@@ -1,0 +1,132 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/foo": {
+      "post": {
+        "tags": [
+          "HelloOperations"
+        ],
+        "operationId": "Hello_Restart",
+        "description": "Restarts a foo.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Example request object."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    },
+    "/bar": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_PutBar",
+        "description": "A PUT request with no body returned.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Example request object."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    },
+    "/some-other-uri": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_First",
+        "description": "A PUT request with no body returned.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Example request object."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "hello_Second",
+        "description": "A PATCH request with no body returned.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Example"
+            },
+            "description": "Example request object."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
Closes  #2268