### PR TITLE
2022-03-03 compute

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -77,7 +77,7 @@ service "communication" {
 }
 service "compute" {
   name      = "Compute"
-  available = ["2021-07-01", "2021-11-01", "2022-03-01", "2022-03-02"]
+  available = ["2021-07-01", "2021-11-01", "2022-03-01", "2022-03-02", "2022-03-03"]
 }
 service "confidentialledger" {
   name      = "ConfidentialLedger"


### PR DESCRIPTION
👋 I'm running into an issue  with the 2021-07-01 gallery images API within Compute requiring a location to build the resource ID and it always 404ing, I want to try and import the 2022-03-03 compute API as it contains the newest version of the gallery image/gallery image vesions API