### PR TITLE
tools/importer-rest-api-specs: passing the Resource IDs for this Reso…

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/remove_unused_items.go
+++ b/tools/importer-rest-api-specs/components/parser/remove_unused_items.go
@@ -39,7 +39,7 @@ func removeUnusedItems(operations map[string]models.OperationDetails, resourceId
 		unusedModels = findUnusedModels(operations, result)
 	}
 
-	unusedConstants := findUnusedConstants(operations, resourceIds, result)
+	unusedConstants := findUnusedConstants(operations, resourceIdsForThisResource, result)
 	for len(unusedConstants) > 0 {
 		// remove those constants
 		for _, constantName := range unusedConstants {
@@ -47,7 +47,7 @@ func removeUnusedItems(operations map[string]models.OperationDetails, resourceId
 		}
 
 		// then go around again
-		unusedConstants = findUnusedConstants(operations, resourceIds, result)
+		unusedConstants = findUnusedConstants(operations, resourceIdsForThisResource, result)
 	}
 
 	return result, resourceIdsForThisResource


### PR DESCRIPTION
…urce into the "check for usages of constant" function

Else all constants that are used in a Resource ID are always output, which is unneeded.