### PR TITLE
tools/generator-go-sdk: disabling / feature-flagging the discriminator change from #2320 for now

### DIFF
--- a/tools/generator-go-sdk/featureflags/flags.go
+++ b/tools/generator-go-sdk/featureflags/flags.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+// OptionalDiscriminatorsShouldBeOutputWithoutOmitEmpty specifies whether a field which contains
+// a Discriminated Type that's Optional should be output as Optional without `omitempty` in the
+// JSON Tags - this means that we'll send a `null` value rather than omitting it.
+const OptionalDiscriminatorsShouldBeOutputWithoutOmitEmpty = false
+
 // GenerateCaseInsensitiveFunctions specifies whether case-insensitive Resource ID parsing
 // functions should be generated.
 const GenerateCaseInsensitiveFunctions = true

--- a/tools/generator-go-sdk/generator/templater_models.go
+++ b/tools/generator-go-sdk/generator/templater_models.go
@@ -81,7 +81,7 @@ func (c modelsTemplater) structCode(data ServiceGeneratorData) (*string, error) 
 		}
 		fieldTypeName = *fieldTypeVal
 
-		structLine, err := c.structLineForField(fieldName, fieldTypeName, fieldDetails)
+		structLine, err := c.structLineForField(fieldName, fieldTypeName, fieldDetails, data)
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +132,7 @@ func (c modelsTemplater) structCode(data ServiceGeneratorData) (*string, error) 
 				}
 				fieldTypeName = *fieldTypeVal
 
-				structLine, err := c.structLineForField(fieldName, fieldTypeName, fieldDetails)
+				structLine, err := c.structLineForField(fieldName, fieldTypeName, fieldDetails, data)
 				if err != nil {
 					return nil, err
 				}
@@ -184,10 +184,27 @@ func (c modelsTemplater) methods(data ServiceGeneratorData) (*string, error) {
 	return &output, nil
 }
 
-func (c modelsTemplater) structLineForField(fieldName, fieldType string, fieldDetails resourcemanager.FieldDetails) (*string, error) {
+func (c modelsTemplater) structLineForField(fieldName, fieldType string, fieldDetails resourcemanager.FieldDetails, data ServiceGeneratorData) (*string, error) {
 	jsonDetails := fieldDetails.JsonName
 
+	isOptional := false
 	if fieldDetails.Optional {
+		isOptional = true
+
+		// TODO: this'll want rolling out by Service Package (likely using the new base layer toggle, for now)
+		// but I'm disabling this entirely for the moment to workaround the issue.
+		if !featureflags.OptionalDiscriminatorsShouldBeOutputWithoutOmitEmpty {
+			// however if the immediate (not top-level) object definition is a Reference to a Parent it's Optional
+			// by default since Parent types are output as an interface (which is implied nullable)
+			if fieldDetails.ObjectDefinition.Type == resourcemanager.ReferenceApiObjectDefinitionType {
+				model, ok := data.models[*fieldDetails.ObjectDefinition.ReferenceName]
+				if ok && model.TypeHintIn != nil && model.ParentTypeName == nil {
+					isOptional = false
+				}
+			}
+		}
+	}
+	if isOptional {
 		fieldType = fmt.Sprintf("*%s", fieldType)
 		jsonDetails += ",omitempty"
 	}

--- a/tools/generator-go-sdk/generator/templater_models.go
+++ b/tools/generator-go-sdk/generator/templater_models.go
@@ -662,7 +662,7 @@ func (s *%[1]s) UnmarshalJSON(bytes []byte) error {`, c.name))
 		if err != nil {
 			return fmt.Errorf("unmarshaling field '%[1]s' for '%[3]s': %%+v", err)
 		}
-		s.%[1]s = &impl
+		s.%[1]s = impl
 	}`, fieldName, *topLevelObjectDef.ReferenceName, c.name, fieldDetails.JsonName))
 			}
 		}

--- a/tools/generator-go-sdk/generator/templater_models_discriminators_test.go
+++ b/tools/generator-go-sdk/generator/templater_models_discriminators_test.go
@@ -379,7 +379,7 @@ func (s *FirstImplementation) UnmarshalJSON(bytes []byte) error {
 		if err != nil {
 			return fmt.Errorf("unmarshaling field 'Serialization' for 'FirstImplementation': %+v", err)
 		}
-		s.Serialization = &impl
+		s.Serialization = impl
 	}
 
 	return nil


### PR DESCRIPTION
This change is impactful and needs to be rolled out Service Package by Service Package, as such we're going to temporarily disable this to allow us to update the SDK, and then once that's done we can look to enable this Service by Service by using the `new base layer` feature toggle to let us make those changes.