### PR TITLE
tools/generator-go-sdk: updating `keyvault` to use the new base layer

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -75,7 +75,6 @@ func main() {
 		"HybridKubernetes",
 		"Insights",
 		"IoTCentral",
-		"KeyVault",
 		"KubernetesConfiguration",
 		"Kusto",
 		"LabServices",


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/terraform-provider-azurerm/pull/21621

Will enable fixing https://github.com/hashicorp/terraform-provider-azurerm/pull/21464