### PR TITLE
tools/generator-go-sdk: support for top level discriminated types

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods.go
+++ b/tools/generator-go-sdk/generator/templater_methods.go
@@ -549,6 +549,11 @@ func (c methodsPandoraTemplater) unmarshalerTemplate(data ServiceGeneratorData) 
 
 		discriminatedTypeParentName := ""
 		if model, ok := data.models[typeName]; ok {
+			// it's either a parent model
+			if model.TypeHintIn != nil {
+				discriminatedTypeParentName = typeName
+			}
+			// or an implementation referencing a parent
 			if model.ParentTypeName != nil {
 				discriminatedTypeParentName = *model.ParentTypeName
 			}

--- a/tools/generator-go-sdk/generator/templater_methods_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_test.go
@@ -368,7 +368,108 @@ func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, id Panda
 
 }
 
-func TestTemplateMethodsTopLevelDiscriminator(t *testing.T) {
+func TestTemplateMethodsTopLevelDiscriminatorReferencingParentType(t *testing.T) {
+	input := ServiceGeneratorData{
+		packageName:       "chubbypandas",
+		serviceClientName: "pandaClient",
+		source:            AccTestLicenceType,
+		models: map[string]resourcemanager.ModelDetails{
+			"FizzyDrink": {
+				TypeHintIn: stringPointer("Type"),
+				Fields: map[string]resourcemanager.FieldDetails{
+					"Type": {
+						ObjectDefinition: resourcemanager.ApiObjectDefinition{
+							Type: resourcemanager.StringApiObjectDefinitionType,
+						},
+						Required: true,
+					},
+				},
+			},
+		},
+		useNewBaseLayer: true,
+	}
+
+	actual, err := methodsPandoraTemplater{
+		operation: resourcemanager.ApiOperation{
+			ExpectedStatusCodes: []int{
+				http.StatusOK,
+			},
+			Method: "GET",
+			ResponseObject: &resourcemanager.ApiObjectDefinition{
+				Type:          resourcemanager.ReferenceApiObjectDefinitionType,
+				ReferenceName: stringPointer("FizzyDrink"),
+			},
+			UriSuffix: stringPointer("/thing"),
+		},
+		operationName: "Get",
+	}.template(input)
+
+	if err != nil {
+		t.Fatalf("err %+v", err)
+	}
+
+	expected := `
+package chubbypandas
+import (
+"context"
+"fmt"
+"net/http"
+"net/url"
+"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+"github.com/hashicorp/go-azure-sdk/sdk/client"
+"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+// acctests licence placeholder
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData *odata.OData
+	Model *FizzyDrink
+}
+
+// Get ...
+func (c pandaClient) Get(ctx context.Context ) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path: "/thing",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var respObj json.RawMessage
+	if err = resp.Unmarshal(&respObj); err != nil {
+		return
+	}
+	model, err := unmarshalFizzyDrinkImplementation(respObj)
+	if err != nil {
+		return
+	}
+	result.Model = &model
+	return
+}`
+
+	assertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestTemplateMethodsTopLevelDiscriminatorReferencingImplementation(t *testing.T) {
 	input := ServiceGeneratorData{
 		packageName:       "chubbypandas",
 		serviceClientName: "pandaClient",


### PR DESCRIPTION
I've vendored the generated output of this into `terraform-provider-azurerm`, enabling the new base layer for `DataShare` and the test passes when updating the client:

```
 $ TF_ACC=1 envchain azurerm go test -v ./internal/services/datashare/... -run=TestAccDataShareDatasetDataLakeGen2DataSource_basic
=== RUN   TestAccDataShareDatasetDataLakeGen2DataSource_basic
=== PAUSE TestAccDataShareDatasetDataLakeGen2DataSource_basic
=== CONT  TestAccDataShareDatasetDataLakeGen2DataSource_basic
--- PASS: TestAccDataShareDatasetDataLakeGen2DataSource_basic (357.76s)
```

Fixes https://github.com/hashicorp/go-azure-sdk/issues/437