### PR TITLE
tools/generator-go-sdk: updating Search to use the new base layer

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -109,7 +109,6 @@ func main() {
 		"Relay",
 		"ResourceConnector",
 		"Resources",
-		"Search",
 		"Security",
 		"SecurityInsights",
 		"ServiceFabric",


### PR DESCRIPTION
The constant recasing will fix the Azure API issue outlined in https://github.com/hashicorp/terraform-provider-azurerm/issues/21630