### PR TITLE
Config: add Mysql@2022-01-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -329,7 +329,7 @@ service "msi" {
 }
 service "mysql" {
   name      = "MySql"
-  available = ["2021-05-01", "2021-12-01-preview"]
+  available = ["2021-05-01", "2021-12-01-preview", "2022-01-01"]
 }
 service "netapp" {
   name      = "NetApp"


### PR DESCRIPTION
I intend to support AAD for MySQL Flexible Server. This is the [API](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/mysql/resource-manager/Microsoft.DBforMySQL/AAD/stable/2022-01-01/AzureADAdministrator.json).