### PR TITLE
tools/generator-go-sdk: updating the ID Parsers to use the new `SegmentNotFound` error type available in https://github.com/hashicorp/go-azure-helpers/pull/155

### DIFF
--- a/tools/generator-go-sdk/generator/templater_id_parser.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser.go
@@ -278,7 +278,7 @@ func (r resourceIdTemplater) parseFunction(nameWithoutSuffix string, caseSensiti
 
 	if v, ok := parsed.Parsed[%[1]q]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment '%[1]s' was not found in the resource id %%q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, %[1]q, *parsed)
 		}
 
 		%[1]s, err := parse%[3]s(v)
@@ -295,7 +295,7 @@ func (r resourceIdTemplater) parseFunction(nameWithoutSuffix string, caseSensiti
 			{
 				lines = append(lines, fmt.Sprintf(`
 	if id.%[2]s, ok = parsed.Parsed[%[1]q]; !ok {
-		return nil, fmt.Errorf("the segment '%[1]s' was not found in the resource id %%q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, %[1]q, *parsed)
 	}
 `, segment.Name, strings.Title(segment.Name)))
 

--- a/tools/generator-go-sdk/generator/templater_id_parser_test.go
+++ b/tools/generator-go-sdk/generator/templater_id_parser_test.go
@@ -74,7 +74,7 @@ var _ resourceids.ResourceId = BasicTestId{}
         var ok bool
         id := BasicTestId{}
         if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-			return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
         }
 
         return &id, nil
@@ -92,7 +92,7 @@ var _ resourceids.ResourceId = BasicTestId{}
         var ok bool
         id := BasicTestId{}
         if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-	        return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+            return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
         }
 
         return &id, nil
@@ -222,7 +222,7 @@ func ParseConstantOnlyID(input string) (*ConstantOnlyId, error) {
 
 	if v, ok := parsed.Parsed["thingId"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'thingId' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "thingId", *parsed)
 		}
 
 		thingId, err := parseThing(v)
@@ -248,7 +248,7 @@ func ParseConstantOnlyIDInsensitively(input string) (*ConstantOnlyId, error) {
 
 	if v, ok := parsed.Parsed["thingId"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'thingId' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "thingId", *parsed)
 		}
 
 		thingId, err := parseThing(v)


### PR DESCRIPTION
…ntNotFound` error type available in https://github.com/hashicorp/go-azure-helpers/pull/155

This should allow providing more context on errors when parsing Resource ID types

Dependent on https://github.com/hashicorp/go-azure-helpers/pull/155