### PR TITLE
WIP `tools/terraform-generator`: fix issues in loadTestService

### DIFF
--- a/config/resources/loadtestservice.hcl
+++ b/config/resources/loadtestservice.hcl
@@ -1,7 +1,7 @@
 service "LoadTestService" {
   terraform_package = "loadtestservice"
 
-  api "2021-12-01-preview" {
+  api "2022-12-01" {
     package "LoadTests" {
       definition "load_test" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LoadTestService/loadTests/{loadTestName}"

--- a/tools/generator-terraform/generator/mappings/assignment_direct.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct.go
@@ -654,12 +654,13 @@ func (d directAssignmentLine) sdkToSchemaMappingBetweenFieldAndBlock(mapping res
 		return nil, fmt.Errorf("expected a schema reference name, but it was nil")
 	}
 
-	line := fmt.Sprintf(`tmp%[1]s := &%[3]s{}
-	if err := r.map%[2]sTo%[3]s(input, tmp%[1]s); err != nil {
-		return err
-	} else {
-		output.%[1]s = make([]%[3]s, 0)
-		output.%[1]s = append(output.%[1]s, *tmp%[1]s)
+	line := fmt.Sprintf(`if input.%[1]s != nil {
+		tmp%[1]s := &%[3]s{}
+		if err := r.map%[2]sTo%[3]s(input, tmp%[1]s); err != nil {
+			return err
+		} else {
+			output.%[1]s = append(output.%[1]s, *tmp%[1]s)
+		}
 	}`, mapping.DirectAssignment.SdkFieldPath, mapping.DirectAssignment.SdkModelName, *schemaField.ObjectDefinition.ReferenceName)
 	return &line, nil
 }

--- a/tools/generator-terraform/generator/mappings/assignment_direct.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct.go
@@ -341,7 +341,7 @@ func (d directAssignmentLine) schemaToSdkMappingBetweenFieldAndBlock(mapping res
 		if err := r.map%[2]sTo%[3]s(input.%[1]s[0], output); err != nil {
 			return err
 		}
-	}`, mapping.DirectAssignment.SdkFieldPath, *schemaField.ObjectDefinition.ReferenceName, mapping.DirectAssignment.SdkModelName)
+	}`, mapping.DirectAssignment.SchemaFieldPath, *schemaField.ObjectDefinition.ReferenceName, mapping.DirectAssignment.SdkModelName)
 	return &line, nil
 }
 
@@ -659,9 +659,9 @@ func (d directAssignmentLine) sdkToSchemaMappingBetweenFieldAndBlock(mapping res
 		if err := r.map%[2]sTo%[3]s(input, tmp%[1]s); err != nil {
 			return err
 		} else {
-			output.%[1]s = append(output.%[1]s, *tmp%[1]s)
+			output.%[4]s = append(output.%[4]s, *tmp%[1]s)
 		}
-	}`, mapping.DirectAssignment.SdkFieldPath, mapping.DirectAssignment.SdkModelName, *schemaField.ObjectDefinition.ReferenceName)
+	}`, mapping.DirectAssignment.SdkFieldPath, mapping.DirectAssignment.SdkModelName, *schemaField.ObjectDefinition.ReferenceName, mapping.DirectAssignment.SchemaFieldPath)
 	return &line, nil
 }
 

--- a/tools/generator-terraform/generator/mappings/assignment_direct.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct.go
@@ -54,8 +54,15 @@ func (d directAssignmentLine) assignmentForCreateUpdateMapping(mapping resourcem
 	}
 
 	// check if it requires a custom transform
-	if v, ok := transformTypes[schemaField.ObjectDefinition.Type]; ok && v == sdkField.ObjectDefinition.Type {
-		return d.schemaToSdkMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
+	if v, ok := transformTypes[schemaField.ObjectDefinition.Type]; ok {
+		if sdkType := sdkField.ObjectDefinition.Type; v == sdkType {
+			return d.schemaToSdkMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
+		} else {
+			// patch for legacy identity blocks
+			if code, ok := patchIdentityTransform(sdkType, true, mapping, sdkField.JsonName); ok {
+				return &code, nil
+			}
+		}
 	}
 
 	// check the assignment type - if it's a List these are special-cased
@@ -96,8 +103,16 @@ func (d directAssignmentLine) assignmentForReadMapping(mapping resourcemanager.F
 	}
 
 	// check if it requires a custom transform
-	if v, ok := transformTypes[schemaField.ObjectDefinition.Type]; ok && v == sdkField.ObjectDefinition.Type {
-		return d.sdkToSchemaMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
+	if v, ok := transformTypes[schemaField.ObjectDefinition.Type]; ok {
+		if sdkType := sdkField.ObjectDefinition.Type; v == sdkType {
+			return d.sdkToSchemaMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
+		} else {
+			// patch for legacy identity blocks
+			code, ok := patchIdentityTransform(sdkType, false, mapping, sdkField.JsonName)
+			if ok {
+				return &code, nil
+			}
+		}
 	}
 
 	// check the assignment type - if it's a List these are special-cased

--- a/tools/generator-terraform/generator/mappings/assignment_direct.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct.go
@@ -59,7 +59,7 @@ func (d directAssignmentLine) assignmentForCreateUpdateMapping(mapping resourcem
 			return d.schemaToSdkMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
 		} else {
 			// patch for legacy identity blocks
-			if code, ok := patchIdentityTransform(sdkType, true, mapping, sdkField.JsonName); ok {
+			if code, done := patchIdentityTransformExpand(sdkType, mapping, sdkField.JsonName); done {
 				return &code, nil
 			}
 		}
@@ -108,8 +108,7 @@ func (d directAssignmentLine) assignmentForReadMapping(mapping resourcemanager.F
 			return d.sdkToSchemaMappingRequiringTransform(mapping, schemaField, sdkField, sdkConstant, apiResourcePackageName)
 		} else {
 			// patch for legacy identity blocks
-			code, ok := patchIdentityTransform(sdkType, false, mapping, sdkField.JsonName)
-			if ok {
+			if code, done := patchIdentityTransformFlatten(sdkType, mapping, sdkField.JsonName); done {
 				return &code, nil
 			}
 		}

--- a/tools/generator-terraform/generator/mappings/assignment_direct_identity.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct_identity.go
@@ -1,0 +1,62 @@
+package mappings
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+// handle all kind of identity block transform: expand and flatten
+
+type transformer struct {
+	expandFn    string
+	flattenFn   string
+	packageName string
+}
+
+func newIdentityTransformer(expandFn string, flattenFn string) transformer {
+	return transformer{
+		expandFn:    expandFn,
+		flattenFn:   flattenFn,
+		packageName: "identity",
+	}
+}
+
+type sdkFieldType = resourcemanager.ApiObjectDefinitionType
+
+// transform from sdk identity block to schema identity block, or reverse
+// N sdk model : 1 schema model, say there are 7 sdk identity types, but only 4 schema identity types
+var identityTransformers = map[sdkFieldType]transformer{
+	resourcemanager.LegacySystemAndUserAssignedIdentityMapApiObjectDefinitionType: newIdentityTransformer("ExpandLegacySystemAndUserAssignedMapFromModel", "FlattenLegacySystemAndUserAssignedMapToModel"),
+}
+
+// we can get schema type from mapping, so only the sdk type is needed
+// isExpand: true for expandFromModel, false for flattenToModel
+func patchIdentityTransform(sdkType sdkFieldType, isExpand bool, mapping resourcemanager.FieldMappingDefinition, sdkFieldName string) (code string, ok bool) {
+	transform, exists := identityTransformers[sdkType]
+	if !exists {
+		return "", false
+	}
+	// default as flatten: input sdk => output schema
+	inputAssignment := fmt.Sprintf("input.%s", mapping.DirectAssignment.SdkFieldPath)
+	outputAssignment := fmt.Sprintf("output.%s", mapping.DirectAssignment.SchemaFieldPath)
+	outputVariable := sdkFieldName
+
+	fn := transform.flattenFn
+	hint := "flattening"
+	if isExpand {
+		fn = transform.expandFn
+		hint = "expanding"
+		inputAssignment = fmt.Sprintf("input.%s", mapping.DirectAssignment.SchemaFieldPath)
+		outputAssignment = fmt.Sprintf("output.%s", mapping.DirectAssignment.SdkFieldPath)
+	}
+	code = fmt.Sprintf(`
+	%[1]s, err := identity.%[4]s(%[2]s)
+	if err != nil {
+		return fmt.Errorf("%[5]s call %[4]s: %%+v", err)
+	}
+	%[3]s = %[1]s
+`, outputVariable, inputAssignment, outputAssignment, fn, hint)
+
+	return code, true
+}

--- a/tools/generator-terraform/generator/mappings/assignment_direct_read_test.go
+++ b/tools/generator-terraform/generator/mappings/assignment_direct_read_test.go
@@ -3130,6 +3130,70 @@ func TestDirectAssignment_Read_Identity_UserAssigned_RequiredToOptional(t *testi
 	}
 }
 
+func TestDirectAssignment_Read_Identity_SystemAndUserAssigned_Legacy(t *testing.T) {
+	// when mapping a model to a model where the Schema field is Required but the SDK field is Optional
+	// and matching UserAssignedIdentity
+	testData := []struct {
+		schemaModelFieldType resourcemanager.TerraformSchemaFieldType
+		sdkFieldType         resourcemanager.ApiObjectDefinitionType
+		expected             string
+	}{
+		{
+			schemaModelFieldType: resourcemanager.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned,
+			sdkFieldType:         resourcemanager.LegacySystemAndUserAssignedIdentityMapApiObjectDefinitionType,
+			expected: fmt.Sprintf(`
+	identity, err := identity.FlattenLegacySystemAndUserAssignedMapToModel(input.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening call FlattenLegacySystemAndUserAssignedMapToModel: %%+v", err)
+	}
+	output.Identity = identity
+`),
+		},
+	}
+	for i, v := range testData {
+		t.Logf("Test %d - mapping %q to %q", i, string(v.schemaModelFieldType), string(v.sdkFieldType))
+		mapping := resourcemanager.FieldMappingDefinition{
+			Type: resourcemanager.DirectAssignmentMappingDefinitionType,
+			DirectAssignment: &resourcemanager.FieldMappingDirectAssignmentDefinition{
+				SchemaModelName: "FromModel",
+				SchemaFieldPath: "Identity",
+				SdkFieldPath:    "Identity",
+				SdkModelName:    "ToModel",
+			},
+		}
+		schemaModel := resourcemanager.TerraformSchemaModelDefinition{
+			Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+				"Identity": {
+					ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+						Type: v.schemaModelFieldType,
+					},
+					HclName:  "identity",
+					Required: true,
+				},
+			},
+		}
+		sdkModel := resourcemanager.ModelDetails{
+			Fields: map[string]resourcemanager.FieldDetails{
+				"Identity": {
+					JsonName: "identity",
+					ObjectDefinition: resourcemanager.ApiObjectDefinition{
+						Type: v.sdkFieldType,
+					},
+					Optional: true,
+				},
+			},
+		}
+		actual, err := directAssignmentLine{}.assignmentForReadMapping(mapping, schemaModel, sdkModel, nil, "sdkresource")
+		if err != nil {
+			t.Fatalf("retrieving read assignment mapping: %+v", err)
+		}
+		if actual == nil {
+			t.Fatalf("retrieving read assignment mapping: `actual` was nil")
+		}
+		testhelpers.AssertTemplatedCodeMatches(t, v.expected, *actual)
+	}
+}
+
 func TestDirectAssignment_Read_Identity_UserAssigned_OptionalToRequired(t *testing.T) {
 	// when mapping a model to a model where the Schema field is Optional but the SDK field is Required
 	// this has to be mapped, so is a Schema error / we should raise an error

--- a/tools/generator-terraform/generator/mappings/assignment_model_to_model.go
+++ b/tools/generator-terraform/generator/mappings/assignment_model_to_model.go
@@ -74,11 +74,10 @@ func (m modelToModelAssignmentLine) assignmentForReadMapping(mapping resourceman
 `, mapping.ModelToModel.SchemaModelName, outputModelName, mapping.ModelToModel.SdkFieldName)
 	if sdkField.Optional {
 		output = fmt.Sprintf(`
-		if input.%[3]s == nil {
-			input.%[3]s = &%[4]s{}
-		}
-		if err := r.map%[2]sTo%[1]s(*input.%[3]s, output); err != nil {
-			return fmt.Errorf("mapping SDK Field %%q / Model %%q to Schema: %%+v", %[2]q, %[3]q, err)
+		if input.%[3]s != nil {
+			if err := r.map%[2]sTo%[1]s(*input.%[3]s, output); err != nil {
+				return fmt.Errorf("mapping SDK Field %%q / Model %%q to Schema: %%+v", %[2]q, %[3]q, err)
+			}
 		}
 `, mapping.ModelToModel.SchemaModelName, outputModelName, mapping.ModelToModel.SdkFieldName, *sdkFieldType)
 	}

--- a/tools/generator-terraform/generator/resource/component_resource_test_generate.go
+++ b/tools/generator-terraform/generator/resource/component_resource_test_generate.go
@@ -193,7 +193,7 @@ func (r %[1]sTestResource) requiresImport(data acceptance.TestData) string {
 func (r %[1]sTestResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf('
 %[5]s
-', data.RandomInteger, data.Locations.Primary)
+', data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 `, input.ResourceTypeName, basicConfig, importConfig, strings.Join(functions, "\n"), template)
 	output = strings.ReplaceAll(output, "'", "`")

--- a/tools/generator-terraform/generator/resource/resource.go
+++ b/tools/generator-terraform/generator/resource/resource.go
@@ -52,11 +52,12 @@ func Resource(input models.ResourceInput) error {
 	return nil
 }
 
+// skip generate file if NOT CONTAINS 'manual changes will be overwritten' in file content
 func shouldSkipGenFile(file string) bool {
 	if f, err := os.Open(file); err == nil {
 		var buf = make([]byte, 512)
 		if _, err := f.Read(buf); err == nil {
-			return bytes.Contains(buf, []byte("manual changes will be overwritten"))
+			return !bytes.Contains(buf, []byte("manual changes will be overwritten"))
 		}
 	}
 	return false

--- a/tools/generator-terraform/generator/resource/resource.go
+++ b/tools/generator-terraform/generator/resource/resource.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -23,22 +24,40 @@ func Resource(input models.ResourceInput) error {
 	writeToPath(resourceFilePath, *resourceCode)
 
 	// then generate the Tests
+	// skip overwrite if test file exists because auto-generated test configuration cannot work most time,
+	// they need to be updated manually
 	testFilePath := fmt.Sprintf("%s/%s_resource_gen_test.go", serviceDirectory, input.ResourceLabel)
-	// remove the file if it already exists
-	os.Remove(testFilePath)
-	testFileContents, err := componentsForResourceTest(input)
-	writeToPath(testFilePath, *testFileContents)
+	if !shouldSkipGenFile(testFilePath) {
+		_ = os.Remove(testFilePath)
+		testFileContents, err := componentsForResourceTest(input)
+		if err != nil {
+			return fmt.Errorf("building test code for resource: %+v", err)
+		}
+		writeToPath(testFilePath, *testFileContents)
+	}
 
 	// then generate the documentation
 	websiteResourcesDirectory := fmt.Sprintf("%s/website/docs/r/", input.RootDirectory)
-	os.MkdirAll(websiteResourcesDirectory, 0755)
 	documentationFilePath := fmt.Sprintf("%s/%s.html.markdown", websiteResourcesDirectory, input.ResourceLabel)
-	os.Remove(documentationFilePath)
-	documentationForResource, err := docs.ComponentsForResource(input)
-	if err != nil {
-		return fmt.Errorf("building documentation for resource: %+v", err)
+	if !shouldSkipGenFile(documentationFilePath) {
+		os.MkdirAll(websiteResourcesDirectory, 0755)
+		os.Remove(documentationFilePath)
+		documentationForResource, err := docs.ComponentsForResource(input)
+		if err != nil {
+			return fmt.Errorf("building documentation for resource: %+v", err)
+		}
+		writeToPath(documentationFilePath, *documentationForResource)
 	}
-	writeToPath(documentationFilePath, *documentationForResource)
 
 	return nil
+}
+
+func shouldSkipGenFile(file string) bool {
+	if f, err := os.Open(file); err == nil {
+		var buf = make([]byte, 512)
+		if _, err := f.Read(buf); err == nil {
+			return bytes.Contains(buf, []byte("manual changes will be overwritten"))
+		}
+	}
+	return false
 }

--- a/tools/generator-terraform/generator/resource/resource.go
+++ b/tools/generator-terraform/generator/resource/resource.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 
@@ -24,41 +23,22 @@ func Resource(input models.ResourceInput) error {
 	writeToPath(resourceFilePath, *resourceCode)
 
 	// then generate the Tests
-	// skip overwrite if test file exists because auto-generated test configuration cannot work most time,
-	// they need to be updated manually
 	testFilePath := fmt.Sprintf("%s/%s_resource_gen_test.go", serviceDirectory, input.ResourceLabel)
-	if !shouldSkipGenFile(testFilePath) {
-		_ = os.Remove(testFilePath)
-		testFileContents, err := componentsForResourceTest(input)
-		if err != nil {
-			return fmt.Errorf("building test code for resource: %+v", err)
-		}
-		writeToPath(testFilePath, *testFileContents)
-	}
+	// remove the file if it already exists
+	os.Remove(testFilePath)
+	testFileContents, err := componentsForResourceTest(input)
+	writeToPath(testFilePath, *testFileContents)
 
 	// then generate the documentation
 	websiteResourcesDirectory := fmt.Sprintf("%s/website/docs/r/", input.RootDirectory)
+	os.MkdirAll(websiteResourcesDirectory, 0755)
 	documentationFilePath := fmt.Sprintf("%s/%s.html.markdown", websiteResourcesDirectory, input.ResourceLabel)
-	if !shouldSkipGenFile(documentationFilePath) {
-		os.MkdirAll(websiteResourcesDirectory, 0755)
-		os.Remove(documentationFilePath)
-		documentationForResource, err := docs.ComponentsForResource(input)
-		if err != nil {
-			return fmt.Errorf("building documentation for resource: %+v", err)
-		}
-		writeToPath(documentationFilePath, *documentationForResource)
+	os.Remove(documentationFilePath)
+	documentationForResource, err := docs.ComponentsForResource(input)
+	if err != nil {
+		return fmt.Errorf("building documentation for resource: %+v", err)
 	}
+	writeToPath(documentationFilePath, *documentationForResource)
 
 	return nil
-}
-
-// skip generate file if NOT CONTAINS 'manual changes will be overwritten' in file content
-func shouldSkipGenFile(file string) bool {
-	if f, err := os.Open(file); err == nil {
-		var buf = make([]byte, 512)
-		if _, err := f.Read(buf); err == nil {
-			return !bytes.Contains(buf, []byte("manual changes will be overwritten"))
-		}
-	}
-	return false
 }

--- a/tools/importer-rest-api-specs/components/schema/fields_nested.go
+++ b/tools/importer-rest-api-specs/components/schema/fields_nested.go
@@ -162,7 +162,7 @@ func (b Builder) identifyFieldsWithinPropertiesBlock(schemaModelName string, inp
 		mappings.Fields = append(mappings.Fields, modelToModelMappingBetween(schemaModelName, input.readModelName, fieldName))
 	}
 	if input.updatePayload != nil && fieldExists(*input.updatePayload, fieldName) {
-		if input.updatePayload != nil && input.createModelName != *input.updateModelName && input.readModelName != *input.updateModelName {
+		if input.createModelName != *input.updateModelName && input.readModelName != *input.updateModelName {
 			mappings.Fields = append(mappings.Fields, modelToModelMappingBetween(schemaModelName, *input.updateModelName, fieldName))
 		}
 	}

--- a/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent.go
+++ b/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent.go
@@ -2,6 +2,7 @@ package processors
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
@@ -13,15 +14,23 @@ type modelFlattenPropertiesIntoParent struct{}
 
 func (modelFlattenPropertiesIntoParent) ProcessModel(modelName string, model resourcemanager.TerraformSchemaModelDefinition, models map[string]resourcemanager.TerraformSchemaModelDefinition, mappings resourcemanager.MappingDefinition) (*map[string]resourcemanager.TerraformSchemaModelDefinition, *resourcemanager.MappingDefinition, error) {
 	fields := make(map[string]resourcemanager.TerraformSchemaFieldDefinition)
+	// add fields that are not properties, and remember fields that need flatten
+	// to do not let flatten field overwrite existing top-level field
+	var flattenKeys []string
 	for fieldName, fieldValue := range model.Fields {
-		fields[fieldName] = fieldValue
-
-		// Skip Properties field in the top level model
-		if strings.EqualFold(fieldName, "Properties") {
-			continue
+		if strings.EqualFold(fieldName, "Properties") || fieldValue.ObjectDefinition.Type != resourcemanager.TerraformSchemaFieldTypeReference {
+			fields[fieldName] = fieldValue
+		} else if !strings.HasSuffix(*fieldValue.ObjectDefinition.ReferenceName, "Properties") {
+			fields[fieldName] = fieldValue
+		} else {
+			flattenKeys = append(flattenKeys, fieldName)
 		}
+	}
 
-		if fieldValue.ObjectDefinition.Type != resourcemanager.TerraformSchemaFieldTypeReference {
+	sort.Strings(flattenKeys) // sort for a stable loop
+	for _, fieldName := range flattenKeys {
+		fieldValue := model.Fields[fieldName]
+		if _, ok := fields[fieldName]; ok {
 			continue
 		}
 
@@ -29,27 +38,46 @@ func (modelFlattenPropertiesIntoParent) ProcessModel(modelName string, model res
 			return nil, nil, fmt.Errorf("processing model %q: had no reference for field %q", modelName, fieldName)
 		}
 
-		if !strings.HasSuffix(*fieldValue.ObjectDefinition.ReferenceName, "Properties") {
+		referenceName := *fieldValue.ObjectDefinition.ReferenceName
+		if !strings.HasSuffix(referenceName, "Properties") {
 			continue
 		}
 
-		nestedPropsModel := models[*fieldValue.ObjectDefinition.ReferenceName]
-		// flatten only when no name-conflict exists
-		var hasConflict bool
-		for nestedFieldName, _ := range nestedPropsModel.Fields {
-			if _, ok := model.Fields[nestedFieldName]; ok {
-				hasConflict = true
-				break
+		nestedPropsModel := models[referenceName]
+		for nestedFieldName, nestedFieldValue := range nestedPropsModel.Fields {
+			flattenFieldName := nestedFieldName
+			if _, ok := fields[nestedFieldName]; ok {
+				// rename field if name conflict exists
+				flattenFieldName = fmt.Sprintf("%s%s", fieldName, nestedFieldName)
+			}
+			fields[flattenFieldName] = nestedFieldValue
+			// also update mappings: delete old mapping and add new one
+			updateMappings(mappings, modelName, flattenFieldName, referenceName, nestedFieldName)
+		}
+		delete(fields, fieldName)
+		// find old filedName mapping and modify to new nested mapping
+		// add a model2model mapping of schemaModel to sdk filed of parent
+		for _, field := range mappings.Fields {
+			if fd := field.DirectAssignment; fd != nil {
+				if fd.SchemaModelName == modelName && fd.SchemaFieldPath == fieldName {
+					mappings.Fields = append(mappings.Fields, resourcemanager.ModelToModelMappingBetween(modelName, fd.SdkModelName, fd.SdkFieldPath))
+				}
 			}
 		}
-		if !hasConflict {
-			for nestedFieldName, nestedFieldValue := range nestedPropsModel.Fields {
-				fields[nestedFieldName] = nestedFieldValue
-			}
-			delete(fields, fieldName)
-		}
+		mappings.RemoveField(modelName, fieldName)
 	}
 	model.Fields = fields
 	models[modelName] = model
 	return &models, &mappings, nil
+}
+
+func updateMappings(mappings resourcemanager.MappingDefinition, modelName, newFieldName string, nestedModelName, nestedFieldName string) {
+	for idx, field := range mappings.Fields {
+		if fd := field.DirectAssignment; fd != nil {
+			if fd.SchemaModelName == nestedModelName && fd.SchemaFieldPath == nestedFieldName {
+				mappings.Fields[idx].DirectAssignment.SchemaModelName = modelName
+				mappings.Fields[idx].DirectAssignment.SchemaFieldPath = newFieldName
+			}
+		}
+	}
 }

--- a/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent.go
+++ b/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent.go
@@ -34,10 +34,20 @@ func (modelFlattenPropertiesIntoParent) ProcessModel(modelName string, model res
 		}
 
 		nestedPropsModel := models[*fieldValue.ObjectDefinition.ReferenceName]
-		for nestedFieldName, nestedFieldValue := range nestedPropsModel.Fields {
-			fields[nestedFieldName] = nestedFieldValue
+		// flatten only when no name-conflict exists
+		var hasConflict bool
+		for nestedFieldName, _ := range nestedPropsModel.Fields {
+			if _, ok := model.Fields[nestedFieldName]; ok {
+				hasConflict = true
+				break
+			}
 		}
-		delete(fields, fieldName)
+		if !hasConflict {
+			for nestedFieldName, nestedFieldValue := range nestedPropsModel.Fields {
+				fields[nestedFieldName] = nestedFieldValue
+			}
+			delete(fields, fieldName)
+		}
 	}
 	model.Fields = fields
 	models[modelName] = model

--- a/tools/importer-rest-api-specs/components/testattributes/test_attr_workaround.go
+++ b/tools/importer-rest-api-specs/components/testattributes/test_attr_workaround.go
@@ -1,0 +1,101 @@
+package testattributes
+
+import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (h TestAttributesHelpers) workaround(resourceLabel string, input resourcemanager.TerraformSchemaFieldDefinition, requiredOnly bool, hclBody *hclwrite.Body) (done bool) {
+	refName := pointer.From(input.ObjectDefinition.ReferenceName)
+	switch resourceLabel {
+	case "load_test":
+		// for reference
+		switch refName {
+		case "LoadTestResourceEncryptionPropertiesIdentity":
+			hclBody.AppendNewline()
+			identityBody := *hclBody.AppendNewBlock(input.HclName, nil).Body()
+			identityBody.SetAttributeValue("type", cty.StringVal("UserAssigned"))
+
+			identityBody.SetAttributeRaw("resource_id", hclwrite.TokensForTuple([]hclwrite.Tokens{
+				hclwrite.TokensForTraversal(hcl.Traversal{
+					hcl.TraverseRoot{
+						Name: userAssignedIdentity.RefValue(), // "azurerm_user_assigned_identity.test.id",
+					},
+				})}))
+			h.AllDeps.Add(userAssignedIdentity)
+			return true
+		}
+
+		// for literal field
+		switch input.HclName {
+		case "key_url":
+			kvDep := newKeyVaultDep(`
+  name                       = "acctestkv-${local.random_str}"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "Rotate",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_user_assigned_identity.test.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "Get",
+      "WrapKey",
+      "UnwrapKey",
+      "GetRotationPolicy",
+      "Decrypt",
+      "Encrypt",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+`)
+			h.AllDeps.Add(kvDep)
+			h.AllDeps.Add(keyVaultKeyDep)
+			setHclWithRef(hclBody, input.HclName, keyVaultKeyDep.RefValue())
+			return true
+		}
+	}
+	return false
+
+}
+
+func setHclWithRef(hclBody *hclwrite.Body, hclName, value string) {
+	hclBody.SetAttributeTraversal(hclName, hcl.Traversal{
+		hcl.TraverseRoot{
+			Name: value,
+		},
+	})
+}

--- a/tools/importer-rest-api-specs/components/testattributes/test_attr_workaround.go
+++ b/tools/importer-rest-api-specs/components/testattributes/test_attr_workaround.go
@@ -16,15 +16,10 @@ func (h TestAttributesHelpers) workaround(resourceLabel string, input resourcema
 		switch refName {
 		case "LoadTestResourceEncryptionPropertiesIdentity":
 			hclBody.AppendNewline()
-			identityBody := *hclBody.AppendNewBlock(input.HclName, nil).Body()
+			identityBody := hclBody.AppendNewBlock(input.HclName, nil).Body()
 			identityBody.SetAttributeValue("type", cty.StringVal("UserAssigned"))
 
-			identityBody.SetAttributeRaw("resource_id", hclwrite.TokensForTuple([]hclwrite.Tokens{
-				hclwrite.TokensForTraversal(hcl.Traversal{
-					hcl.TraverseRoot{
-						Name: userAssignedIdentity.RefValue(), // "azurerm_user_assigned_identity.test.id",
-					},
-				})}))
+			setHclWithRef(identityBody, "resource_id", userAssignedIdentity.RefValue())
 			h.AllDeps.Add(userAssignedIdentity)
 			return true
 		}
@@ -82,8 +77,7 @@ func (h TestAttributesHelpers) workaround(resourceLabel string, input resourcema
     environment = "Production"
   }
 `)
-			h.AllDeps.Add(kvDep)
-			h.AllDeps.Add(keyVaultKeyDep)
+			h.AllDeps.Add(keyVaultKeyDep.WithDeps(kvDep))
 			setHclWithRef(hclBody, input.HclName, keyVaultKeyDep.RefValue())
 			return true
 		}

--- a/tools/importer-rest-api-specs/components/testattributes/test_dependency.go
+++ b/tools/importer-rest-api-specs/components/testattributes/test_dependency.go
@@ -1,0 +1,303 @@
+package testattributes
+
+import (
+	"fmt"
+	"strings"
+)
+
+type TestDep interface {
+	Name() string
+	GenConfig() string
+	RefValue(field ...string) string
+	Deps() []TestDep
+}
+
+type AllDeps struct {
+	Items        []TestDep
+	basicSnap    []TestDep
+	CompleteSnap []TestDep
+}
+
+func (a *AllDeps) Add(item TestDep) {
+	for _, dep := range a.Items {
+		if dep.Name() == item.Name() {
+			return
+		}
+	}
+	a.Items = append(a.Items, item)
+}
+
+func (a *AllDeps) collectAll() []TestDep {
+	var res []TestDep
+	var collect func(t TestDep)
+	collect = func(t TestDep) {
+		res = append(res, t)
+		for _, dep := range t.Deps() {
+			collect(dep)
+		}
+	}
+	for _, item := range a.Items {
+		collect(item)
+	}
+	var dedup []TestDep
+	for idx := len(res) - 1; idx >= 0; idx-- {
+		var isDup bool
+		for _, item := range dedup {
+			if item.Name() == res[idx].Name() {
+				isDup = true
+				break
+			}
+		}
+		if !isDup {
+			dedup = append(dedup, res[idx])
+		}
+	}
+	return dedup
+}
+
+// GenTemplateConfig use basic dependency as template
+func (a *AllDeps) GenTemplateConfig() string {
+	var bs strings.Builder
+	bs.WriteString(`
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  random_integer   = %[1]d
+  primary_location = %[2]q
+}
+
+`)
+
+	allDeps := a.collectAll()
+	a.basicSnap = allDeps
+	for _, item := range allDeps {
+		bs.WriteString(item.GenConfig())
+		bs.WriteString("\n\n")
+	}
+	str := bs.String()
+	return strings.Replace(str, `"`, "'", -1)
+}
+
+func (a *AllDeps) GenConfig() string {
+	var bs strings.Builder
+
+	allDeps := a.collectAll()
+	// remove templated dependencies
+	var dedup []TestDep
+	for _, item := range allDeps {
+		var skip = false
+		for _, temp := range a.basicSnap {
+			if item.Name() == temp.Name() {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			for _, existing := range dedup {
+				if item.Name() == existing.Name() {
+					skip = true
+					break
+				}
+			}
+		}
+		if !skip {
+			dedup = append(dedup, item)
+		}
+	}
+	for _, item := range dedup {
+		bs.WriteString(item.GenConfig())
+		bs.WriteString("\n\n")
+	}
+	str := bs.String()
+	return strings.Replace(str, `"`, "'", -1)
+}
+
+var _, _ TestDep = DepResource{}, DepDataSource{}
+
+type DepResource struct {
+	name    string
+	label   string
+	Content string
+	deps    []TestDep // this resource dependent on others
+}
+
+func NewDepResource(name, content string, deps ...TestDep) DepResource {
+	return DepResource{
+		name:    name,
+		label:   "test", // default label as 'test'
+		Content: content,
+		deps:    deps,
+	}
+}
+
+func (d DepResource) content() string {
+	return fmt.Sprintf(`"%s" "%s" {
+%s
+}`, d.name, d.label, d.Content)
+}
+
+func (d DepResource) GenConfig() string {
+	return fmt.Sprintf(`resource %s`, d.content())
+}
+
+func (d DepResource) Deps() []TestDep {
+	return d.deps
+}
+
+func (d DepResource) Name() string {
+	return d.name + "." + d.label
+}
+
+func (d DepResource) RefValue(field ...string) string {
+	key := "id"
+	if len(field) > 0 {
+		key = field[0]
+	}
+	return fmt.Sprintf("%s.%s.%s", d.name, d.label, key)
+}
+
+type DepDataSource struct {
+	DepResource
+}
+
+func NewDepDateSource(name, content string, deps ...TestDep) DepDataSource {
+	return DepDataSource{
+		DepResource: NewDepResource(name, content, deps...),
+	}
+}
+
+func (d DepDataSource) RefValue(field ...string) string {
+	key := "id"
+	if len(field) > 0 {
+		key = field[0]
+	}
+	return fmt.Sprintf("data.%s.%s.%s", d.name, d.label, key)
+}
+
+func (d DepDataSource) GenConfig() string {
+	return fmt.Sprintf(`data %s`, d.content())
+}
+
+var (
+	edgeZoneDep TestDep = NewDepDateSource("azurerm_extended_locations",
+		`location = azurerm_resource_group.test.location`,
+		resourceGroupDep,
+	)
+
+	clientConfigDep = DepResource{
+		name:  "azurerm_client_config",
+		label: "current",
+	}
+
+	resourceGroupDep = NewDepResource(
+		"azurerm_resource_group",
+		`name     = "acctestrg-${local.random_integer}"
+		location = local.primary_location`,
+	)
+
+	publicIPDep = NewDepResource(
+		"azurerm_public_ip",
+		`name                = "acctest-${local.random_integer}"
+		location            = azurerm_resource_group.test.location
+		resource_group_name = azurerm_resource_group.test.name
+		allocation_method   = "Dynamic"`,
+		resourceGroupDep,
+	)
+
+	userAssignedIdentity = NewDepResource(
+		"azurerm_user_assigned_identity",
+		`name                = "acctest-${local.random_integer}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location`,
+		resourceGroupDep,
+	)
+
+	virtualNetworkDep = NewDepResource(
+		"azurerm_virtual_network",
+		`name                = "acctest-${local.random_integer}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.0.0.0/16"]`,
+		resourceGroupDep,
+	)
+
+	subNetDep = NewDepResource(
+		"azurerm_subnet",
+		`name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]`,
+		resourceGroupDep, virtualNetworkDep,
+	)
+
+	keyVaultDep = newKeyVaultDep(
+		`
+  name                       = "acctestkv-${local.random_str}"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "SetRotationPolicy",
+      "GetRotationPolicy",
+      "Rotate",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+`,
+	)
+
+	keyVaultKeyDep = newKeyVaultKeyDep(
+		`name         = "key-${local.random_str}"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]`)
+)
+
+func newKeyVaultDep(content string) DepResource {
+	return NewDepResource("azurerm_key_vault", content, clientConfigDep, resourceGroupDep)
+}
+
+func newKeyVaultKeyDep(content string, dep ...TestDep) DepResource {
+	if len(dep) == 0 {
+	}
+	dep = []TestDep{keyVaultDep}
+
+	return NewDepResource(
+		"azurerm_key_vault_key",
+		content,
+		dep...)
+}

--- a/tools/importer-rest-api-specs/components/testattributes/test_dependency.go
+++ b/tools/importer-rest-api-specs/components/testattributes/test_dependency.go
@@ -66,6 +66,7 @@ provider "azurerm" {
 locals {
   random_integer   = %[1]d
   primary_location = %[2]q
+  random_str       = %[3]q
 }
 
 `)
@@ -121,6 +122,16 @@ type DepResource struct {
 	label   string
 	Content string
 	deps    []TestDep // this resource dependent on others
+}
+
+func (d DepResource) WithDeps(deps ...TestDep) DepResource {
+	d.deps = deps
+	return d
+}
+
+func (d DepResource) WithLabel(label string) DepResource {
+	d.label = label
+	return d
 }
 
 func NewDepResource(name, content string, deps ...TestDep) DepResource {
@@ -186,9 +197,8 @@ var (
 		resourceGroupDep,
 	)
 
-	clientConfigDep = DepResource{
-		name:  "azurerm_client_config",
-		label: "current",
+	clientConfigDep = DepDataSource{
+		NewDepResource("azurerm_client_config", "").WithLabel("current"),
 	}
 
 	resourceGroupDep = NewDepResource(

--- a/tools/sdk/resourcemanager/field_mapping.go
+++ b/tools/sdk/resourcemanager/field_mapping.go
@@ -1,0 +1,24 @@
+package resourcemanager
+
+func DirectAssignmentMappingBetween(fromModel string, fromField string, toModel string, toField string) FieldMappingDefinition {
+	return FieldMappingDefinition{
+		Type: DirectAssignmentMappingDefinitionType,
+		DirectAssignment: &FieldMappingDirectAssignmentDefinition{
+			SchemaModelName: fromModel,
+			SchemaFieldPath: fromField,
+			SdkModelName:    toModel,
+			SdkFieldPath:    toField,
+		},
+	}
+}
+
+func ModelToModelMappingBetween(fromModel string, toModel string, toField string) FieldMappingDefinition {
+	return FieldMappingDefinition{
+		Type: ModelToModelMappingDefinitionType,
+		ModelToModel: &FieldMappingModelToModelDefinition{
+			SchemaModelName: fromModel,
+			SdkModelName:    toModel,
+			SdkFieldName:    toField,
+		},
+	}
+}

--- a/tools/sdk/resourcemanager/terraform.go
+++ b/tools/sdk/resourcemanager/terraform.go
@@ -257,6 +257,28 @@ type MappingDefinition struct {
 	ResourceId []ResourceIdMappingDefinition `json:"resourceId"`
 }
 
+// RemoveField we need to remove some field when one nested property is flattened
+func (m *MappingDefinition) RemoveField(schemaModel, schemaPath string) {
+	var resultField []FieldMappingDefinition
+	for _, field := range m.Fields {
+		if fd := field.DirectAssignment; fd != nil {
+			if fd.SchemaModelName == schemaModel &&
+				fd.SchemaFieldPath == schemaPath {
+				// remove
+				continue
+			}
+		} else if fd := field.ModelToModel; fd != nil {
+			if fd.SchemaModelName == schemaModel &&
+				"" == schemaPath {
+				// remove
+				continue
+			}
+		}
+		resultField = append(resultField, field)
+	}
+	m.Fields = resultField
+}
+
 type TerraformResourceDetails struct {
 	// ApiVersion specifies the version of the Api which should be used for
 	// this resource.


### PR DESCRIPTION
This PR is to fix some issues of the terraform generator tool.

1. rename schema field if there is a field with the same name exists when flattenning properties.
2. support transform legacy identity type when generate mapping functions.
3. should not set schema state if the field of sdk model is nil. resolves #2483
4. add model2model mappings of nestedItems. or generated resource will missing mapXXX functions.
5. add an acc test dependency management and fix acc test config generation.
