### PR TITLE
Revert "resources: migrating to use the new base layer"

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -102,6 +102,7 @@ func main() {
 		"RedisEnterprise",
 		"Relay",
 		"ResourceConnector",
+		"Resources",
 		"Security",
 		"SecurityInsights",
 		"ServiceFabric",


### PR DESCRIPTION
Reverts hashicorp/pandora#2490

Blocked on https://github.com/hashicorp/go-retryablehttp/pull/194