### PR TITLE
data: removing `maintenance` @ `2023-04-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -281,7 +281,7 @@ service "machinelearningservices" {
 }
 service "maintenance" {
   name      = "Maintenance"
-  available = ["2021-05-01", "2022-07-01-preview", "2023-04-01"]
+  available = ["2021-05-01", "2022-07-01-preview"]
 }
 service "managedservices" {
   name      = "ManagedServices"


### PR DESCRIPTION
Breaking change in https://github.com/Azure/azure-rest-api-specs/pull/23923 since this [got merged when it shouldn't have been](https://github.com/Azure/azure-rest-api-specs/pull/23832#issuecomment-1542321700)