### PR TITLE
Config: add `network@2022-11-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -337,8 +337,7 @@ service "netapp" {
 }
 service "network" {
   name      = "Network"
-  available = ["2022-09-01"]
-  ignore    = ["2022-11-01"]
+  available = ["2022-09-01","2022-11-01"]
 }
 service "networkfunction" {
   name      = "NetworkFunction"


### PR DESCRIPTION
This fix only patched `2022-11-01` https://github.com/Azure/azure-rest-api-specs/pull/23738

The ignore was added on https://github.com/hashicorp/pandora/pull/2462, not sure if it has been unblocked.