### PR TITLE
Importer: TF example add up the provider block and the dependencies if any

### DIFF
--- a/data/Pandora.Definitions.ResourceManager/ContainerService/Terraform/KubernetesFleetManager-Resource-Tests.cs
+++ b/data/Pandora.Definitions.ResourceManager/ContainerService/Terraform/KubernetesFleetManager-Resource-Tests.cs
@@ -58,7 +58,6 @@ locals {
   primary_location = %[2]q
 }
 
-
 resource 'azurerm_resource_group' 'test' {
   name     = 'acctestrg-${local.random_integer}'
   location = local.primary_location

--- a/data/Pandora.Definitions.ResourceManager/ContainerService/Terraform/KubernetesFleetManager-Resource.cs
+++ b/data/Pandora.Definitions.ResourceManager/ContainerService/Terraform/KubernetesFleetManager-Resource.cs
@@ -14,7 +14,17 @@ public class KubernetesFleetManagerResource : TerraformResourceDefinition
 
 ~> **Note:** This Resource is in **Preview** to use this you must be opted into the Preview. You can do this by running `az feature register --namespace Microsoft.ContainerService --name FleetResourcePreview` and then `az provider register -n Microsoft.ContainerService`
 ";
-    public string ResourceExampleUsage => @"resource 'azurerm_kubernetes_fleet_manager' 'example' {
+    public string ResourceExampleUsage => @"provider 'azurerm' {
+  features {}
+}
+
+
+resource 'azurerm_resource_group' 'example' {
+  name     = 'examplerg'
+  location = 'West Europe'
+}
+
+resource 'azurerm_kubernetes_fleet_manager' 'example' {
 
   hub_profile {
     dns_prefix = 'example'

--- a/data/Pandora.Definitions.ResourceManager/LoadTestService/Terraform/LoadTest-Resource-Tests.cs
+++ b/data/Pandora.Definitions.ResourceManager/LoadTestService/Terraform/LoadTest-Resource-Tests.cs
@@ -49,7 +49,6 @@ locals {
   primary_location = %[2]q
 }
 
-
 resource 'azurerm_resource_group' 'test' {
   name     = 'acctestrg-${local.random_integer}'
   location = local.primary_location

--- a/data/Pandora.Definitions.ResourceManager/LoadTestService/Terraform/LoadTest-Resource.cs
+++ b/data/Pandora.Definitions.ResourceManager/LoadTestService/Terraform/LoadTest-Resource.cs
@@ -11,7 +11,17 @@ public class LoadTestResource : TerraformResourceDefinition
     public string ResourceLabel => "load_test";
     public string ResourceCategory => "Load Test";
     public string ResourceDescription => @"Manages a Load Test Service";
-    public string ResourceExampleUsage => @"resource 'azurerm_load_test' 'example' {
+    public string ResourceExampleUsage => @"provider 'azurerm' {
+  features {}
+}
+
+
+resource 'azurerm_resource_group' 'example' {
+  name     = 'examplerg'
+  location = 'West Europe'
+}
+
+resource 'azurerm_load_test' 'example' {
   location            = azurerm_resource_group.example.location
   name                = 'example'
   resource_group_name = azurerm_resource_group.example.name

--- a/data/Pandora.Definitions.ResourceManager/ManagedIdentity/Terraform/UserAssignedIdentity-Resource-Tests.cs
+++ b/data/Pandora.Definitions.ResourceManager/ManagedIdentity/Terraform/UserAssignedIdentity-Resource-Tests.cs
@@ -43,7 +43,6 @@ locals {
   primary_location = %[2]q
 }
 
-
 resource 'azurerm_resource_group' 'test' {
   name     = 'acctestrg-${local.random_integer}'
   location = local.primary_location

--- a/data/Pandora.Definitions.ResourceManager/ManagedIdentity/Terraform/UserAssignedIdentity-Resource.cs
+++ b/data/Pandora.Definitions.ResourceManager/ManagedIdentity/Terraform/UserAssignedIdentity-Resource.cs
@@ -11,7 +11,17 @@ public class UserAssignedIdentityResource : TerraformResourceDefinition
     public string ResourceLabel => "user_assigned_identity";
     public string ResourceCategory => "Authorization";
     public string ResourceDescription => @"Manages a User Assigned Identity";
-    public string ResourceExampleUsage => @"resource 'azurerm_user_assigned_identity' 'example' {
+    public string ResourceExampleUsage => @"provider 'azurerm' {
+  features {}
+}
+
+
+resource 'azurerm_resource_group' 'example' {
+  name     = 'examplerg'
+  location = 'West Europe'
+}
+
+resource 'azurerm_user_assigned_identity' 'example' {
   location            = azurerm_resource_group.example.location
   name                = 'example'
   resource_group_name = azurerm_resource_group.example.name

--- a/tools/importer-rest-api-specs/pipeline/task_generate_terraform_example_usage_test.go
+++ b/tools/importer-rest-api-specs/pipeline/task_generate_terraform_example_usage_test.go
@@ -76,7 +76,10 @@ resource "azurerm_load_test" "example" {
 		input := resourcemanager.TerraformResourceTestsDefinition{
 			BasicConfiguration: v.input,
 		}
-		actual := convertBasicTestToUsableExample(input)
+		actual, err := convertBasicTestToUsableExample(input)
+		if err != nil {
+			t.Fatal(err)
+		}
 		testhelpers.AssertTemplatedCodeMatches(t, v.expected, actual)
 	}
 }

--- a/tools/importer-rest-api-specs/pipeline/task_generate_terraform_tests.go
+++ b/tools/importer-rest-api-specs/pipeline/task_generate_terraform_tests.go
@@ -179,9 +179,7 @@ locals {
   random_integer   = %%[1]d
   primary_location = %%[2]q
 }
-
 %s
-`, strings.Join(components, "\n\n"))
-	output = strings.Replace(output, "\"", "'", -1)
+`, strings.Join(components, "\n"))
 	return &output
 }


### PR DESCRIPTION
Make the swagger import generated terraform examples to add up the provider block and the dependencies if any.