### PR TITLE
tools/importer-rest-api-specs: only flattening the nested model when the key name is unique

### DIFF
--- a/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent.go
+++ b/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent.go
@@ -35,6 +35,12 @@ func (modelFlattenPropertiesIntoParent) ProcessModel(modelName string, model res
 
 		nestedPropsModel := models[*fieldValue.ObjectDefinition.ReferenceName]
 		for nestedFieldName, nestedFieldValue := range nestedPropsModel.Fields {
+			if _, hasExisting := fields[nestedFieldName]; hasExisting {
+				// if the top level model contains a field with the same name then we shouldn't be flattening
+				// the nested model into it, otherwise we'll have naming conflicts
+				return &models, &mappings, nil
+			}
+
 			fields[nestedFieldName] = nestedFieldValue
 		}
 		delete(fields, fieldName)

--- a/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent_test.go
+++ b/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent_test.go
@@ -268,10 +268,135 @@ func TestProcessModel_FlattenPropertiesIntoParent_Invalid(t *testing.T) {
 				// TODO: add me
 			},
 		},
+		{
+			// in this example the same field exists at both the top level and in the nested model
+			// as such whilst the nested model is _technically_ eligible to be flattened, it's
+			// intentionally _not_ due to the naming conflicts.
+
+			modelNameInput: "PandaProperties",
+			modelsInput: map[string]resourcemanager.TerraformSchemaModelDefinition{
+				"Panda": {
+					Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+						"Name": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeString,
+							},
+						},
+						"Properties": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+								ReferenceName: stringPointer("PandaProperties"),
+							},
+						},
+					},
+				},
+				"PandaProperties": {
+					Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+						"Age": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+							},
+						},
+						"Weight": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+							},
+						},
+						"CutenessProperties": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+								ReferenceName: stringPointer("CutenessProperties"),
+							},
+						},
+					},
+				},
+				"CutenessProperties": {
+					Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+						"Age": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+							},
+						},
+						"Cuddliness": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeString,
+							},
+						},
+						"AwwwFactor": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeString,
+							},
+						},
+					},
+				},
+			},
+			mappingsInput: resourcemanager.MappingDefinition{
+				// TODO: add me
+			},
+			expectedModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+				"Panda": {
+					Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+						"Name": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeString,
+							},
+						},
+						"Properties": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+								ReferenceName: stringPointer("PandaProperties"),
+							},
+						},
+					},
+				},
+				"PandaProperties": {
+					Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+						"Age": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+							},
+						},
+						"Weight": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+							},
+						},
+						"CutenessProperties": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+								ReferenceName: stringPointer("CutenessProperties"),
+							},
+						},
+					},
+				},
+				"CutenessProperties": {
+					Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+						"Age": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+							},
+						},
+						"Cuddliness": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeString,
+							},
+						},
+						"AwwwFactor": {
+							ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+								Type: resourcemanager.TerraformSchemaFieldTypeString,
+							},
+						},
+					},
+				},
+			},
+			expectedMappings: resourcemanager.MappingDefinition{
+				// TODO: add me
+			},
+		},
 	}
 
-	for _, v := range testData {
-		t.Logf("[DEBUG] Testing %s", v.modelNameInput)
+	for i, v := range testData {
+		t.Logf("[DEBUG] Iteration %d - testing %s", i, v.modelNameInput)
 
 		actualModels, actualMappings, err := modelFlattenPropertiesIntoParent{}.ProcessModel(v.modelNameInput, v.modelsInput[v.modelNameInput], v.modelsInput, v.mappingsInput)
 		if err != nil {


### PR DESCRIPTION
This avoids an issue where the same field (say `identity`) may be used both as a top level model and within the nested model - therefore flattening this would replace the top-level object

Fixes #1825