### PR TITLE
tools/generator-terraform: outputting `identity` as blocks in the attributes/arguments - and updating the `block reference`

### DIFF
--- a/tools/generator-terraform/generator/resource/docs/component_arguments.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments.go
@@ -2,21 +2,12 @@ package docs
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
-
-var objectDefinitionsWhichShouldBeSurfacedAsBlocks = map[resourcemanager.TerraformSchemaFieldType]struct{}{
-	resourcemanager.TerraformSchemaFieldTypeReference: {},
-
-	// The Identity types should be output as blocks, since these are blocks within commonschema
-	resourcemanager.TerraformSchemaFieldTypeIdentitySystemAssigned:        {},
-	resourcemanager.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned: {},
-	resourcemanager.TerraformSchemaFieldTypeIdentitySystemOrUserAssigned:  {},
-	resourcemanager.TerraformSchemaFieldTypeIdentityUserAssigned:          {},
-}
 
 func codeForArgumentsReference(input models.ResourceInput) (*string, error) {
 
@@ -38,74 +29,93 @@ The following arguments are supported:
 }
 
 func getArguments(model resourcemanager.TerraformSchemaModelDefinition, resourceName string) (*string, error) {
-
 	requiredLines := make([]string, 0)
 	optionalLines := make([]string, 0)
 
 	sortedFieldNames := sortFieldNamesAlphabetically(model)
 
+	// first process the Required Arguments
 	for _, fieldName := range sortedFieldNames {
 		field := model.Fields[fieldName]
 
-		// skip attributes
-		if field.Computed && !field.Optional && !field.Required {
+		// we only want Required attributes
+		if !field.Required || field.Optional || field.Computed {
 			continue
 		}
 
-		components := make([]string, 0)
-		components = append(components, fmt.Sprintf("* `%s` -", field.HclName))
-
-		if field.Required {
-			components = append(components, "(Required)")
-		} else if field.Optional {
-			components = append(components, "(Optional)")
+		docs, err := documentationLineForArgument(field, "")
+		if err != nil {
+			return nil, fmt.Errorf("building documentation line for required argument/field %q: %+v", fieldName, err)
 		}
-
-		// TODO: when it's a List/Set, we should output `A list of XXX` or `One or more of XXX` (or something)
-
-		// identify block
-		if _, ok := objectDefinitionsWhichShouldBeSurfacedAsBlocks[field.ObjectDefinition.Type]; ok {
-			fieldBeginsWithVowel, err := beginsWithVowel(field.HclName)
-			if err != nil {
-				return nil, err
-			}
-			if fieldBeginsWithVowel {
-				components = append(components, "An")
-			} else {
-				components = append(components, "A")
-			}
-			components = append(components, fmt.Sprintf("`%s` block as defined below.", field.HclName))
-		}
-
-		components = append(components, field.Documentation.Markdown)
-
-		// TODO update to include ranges
-		if field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeBoolean {
-			components = append(components, "Possible values are `true` and `false`.")
-		} else if field.Validation != nil {
-			if field.Validation.Type == resourcemanager.TerraformSchemaValidationTypePossibleValues {
-				if values := field.Validation.PossibleValues.Values; values != nil {
-					possibleValues := wordifyPossibleValues(values)
-					components = append(components, possibleValues)
-				}
-			}
-		}
-
-		// TODO set default if applicable?
-
-		if field.ForceNew {
-			components = append(components, fmt.Sprintf("Changing this forces a new %s to be created.", resourceName))
-		}
-
-		line := removeExtraSpaces(strings.Join(components, " "))
-
-		// sort required and optional
-		if field.Required {
-			requiredLines = append(requiredLines, line)
-		} else {
-			optionalLines = append(optionalLines, line)
-		}
+		requiredLines = append(requiredLines, *docs)
 	}
+
+	// then process the Optional Arguments
+	for _, fieldName := range sortedFieldNames {
+		field := model.Fields[fieldName]
+
+		// we only want Optional fields (which includes Optional + Computed fields)
+		if !field.Optional || field.Required {
+			continue
+		}
+
+		docs, err := documentationLineForArgument(field, resourceName)
+		if err != nil {
+			return nil, fmt.Errorf("building documentation line for optional argument/field %q: %+v", fieldName, err)
+		}
+		optionalLines = append(optionalLines, *docs)
+	}
+
 	out := strings.Join(append(requiredLines, optionalLines...), "\n\n")
 	return &out, nil
+}
+
+func documentationLineForArgument(field resourcemanager.TerraformSchemaFieldDefinition, resourceName string) (*string, error) {
+	components := make([]string, 0)
+	components = append(components, fmt.Sprintf("* `%s` -", field.HclName))
+
+	if field.Required {
+		components = append(components, "(Required)")
+	} else if field.Optional {
+		components = append(components, "(Optional)")
+	}
+
+	// TODO: when it's a List/Set, we should output `A list of XXX` or `One or more of XXX` (or something)
+
+	// identify block
+	if _, ok := objectDefinitionsWhichShouldBeSurfacedAsBlocks[field.ObjectDefinition.Type]; ok {
+		fieldBeginsWithVowel, err := beginsWithVowel(field.HclName)
+		if err != nil {
+			return nil, err
+		}
+		if fieldBeginsWithVowel {
+			components = append(components, "An")
+		} else {
+			components = append(components, "A")
+		}
+		components = append(components, fmt.Sprintf("`%s` block as defined below.", field.HclName))
+	}
+
+	components = append(components, field.Documentation.Markdown)
+
+	// TODO update to include ranges
+	if field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeBoolean {
+		components = append(components, "Possible values are `true` and `false`.")
+	} else if field.Validation != nil {
+		if field.Validation.Type == resourcemanager.TerraformSchemaValidationTypePossibleValues {
+			if values := field.Validation.PossibleValues.Values; values != nil {
+				possibleValues := wordifyPossibleValues(values)
+				components = append(components, possibleValues)
+			}
+		}
+	}
+
+	// TODO set default if applicable?
+
+	if field.ForceNew {
+		components = append(components, fmt.Sprintf("Changing this forces a new %s to be created.", resourceName))
+	}
+
+	line := removeExtraSpaces(strings.Join(components, " "))
+	return pointer.To(line), nil
 }

--- a/tools/generator-terraform/generator/resource/docs/component_arguments.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments.go
@@ -94,13 +94,19 @@ func documentationLineForArgument(field resourcemanager.TerraformSchemaFieldDefi
 		if err != nil {
 			return nil, err
 		}
+
+		fieldLocation := "below"
+		if nestedWithin != "" && field.HclName <= nestedWithin {
+			fieldLocation = "above"
+		}
+
 		if isList {
-			components = append(components, fmt.Sprintf("A list of `%s` blocks as defined below.", field.HclName))
+			components = append(components, fmt.Sprintf("A list of `%s` blocks as defined %s.", field.HclName, fieldLocation))
 		} else {
 			if fieldBeginsWithVowel {
-				components = append(components, fmt.Sprintf("An `%s` block as defined below.", field.HclName))
+				components = append(components, fmt.Sprintf("An `%s` block as defined %s.", field.HclName, fieldLocation))
 			} else {
-				components = append(components, fmt.Sprintf("A `%s` block as defined below.", field.HclName))
+				components = append(components, fmt.Sprintf("A `%s` block as defined %s.", field.HclName, fieldLocation))
 			}
 		}
 	}

--- a/tools/generator-terraform/generator/resource/docs/component_arguments.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments.go
@@ -8,6 +8,16 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
+var objectDefinitionsWhichShouldBeSurfacedAsBlocks = map[resourcemanager.TerraformSchemaFieldType]struct{}{
+	resourcemanager.TerraformSchemaFieldTypeReference: {},
+
+	// The Identity types should be output as blocks, since these are blocks within commonschema
+	resourcemanager.TerraformSchemaFieldTypeIdentitySystemAssigned:        {},
+	resourcemanager.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned: {},
+	resourcemanager.TerraformSchemaFieldTypeIdentitySystemOrUserAssigned:  {},
+	resourcemanager.TerraformSchemaFieldTypeIdentityUserAssigned:          {},
+}
+
 func codeForArgumentsReference(input models.ResourceInput) (*string, error) {
 
 	topLevelArgs, err := getArguments(input.SchemaModels[input.SchemaModelName], input.Details.DisplayName)
@@ -52,7 +62,7 @@ func getArguments(model resourcemanager.TerraformSchemaModelDefinition, resource
 		}
 
 		// identify block
-		if field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeReference {
+		if _, ok := objectDefinitionsWhichShouldBeSurfacedAsBlocks[field.ObjectDefinition.Type]; ok {
 			fieldBeginsWithVowel, err := beginsWithVowel(field.HclName)
 			if err != nil {
 				return nil, err

--- a/tools/generator-terraform/generator/resource/docs/component_arguments.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments.go
@@ -61,6 +61,8 @@ func getArguments(model resourcemanager.TerraformSchemaModelDefinition, resource
 			components = append(components, "(Optional)")
 		}
 
+		// TODO: when it's a List/Set, we should output `A list of XXX` or `One or more of XXX` (or something)
+
 		// identify block
 		if _, ok := objectDefinitionsWhichShouldBeSurfacedAsBlocks[field.ObjectDefinition.Type]; ok {
 			fieldBeginsWithVowel, err := beginsWithVowel(field.HclName)

--- a/tools/generator-terraform/generator/resource/docs/component_arguments.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments.go
@@ -2,15 +2,14 @@ package docs
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func codeForArgumentsReference(input models.ResourceInput) (*string, error) {
-
 	topLevelArgs, err := getArguments(input.SchemaModels[input.SchemaModelName], input.Details.DisplayName)
 	if err != nil {
 		return nil, err

--- a/tools/generator-terraform/generator/resource/docs/component_arguments.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments.go
@@ -38,12 +38,13 @@ func getArguments(model resourcemanager.TerraformSchemaModelDefinition, resource
 	for _, fieldName := range sortedFieldNames {
 		field := model.Fields[fieldName]
 
-		// we only want Required attributes
+		// we only want Required Arguments
 		if !field.Required || field.Optional || field.Computed {
 			continue
 		}
 
-		docs, err := documentationLineForArgument(field, "")
+		nestedWithin := "" // top-level so not nested
+		docs, err := documentationLineForArgument(field, nestedWithin, resourceName)
 		if err != nil {
 			return nil, fmt.Errorf("building documentation line for required argument/field %q: %+v", fieldName, err)
 		}
@@ -54,12 +55,13 @@ func getArguments(model resourcemanager.TerraformSchemaModelDefinition, resource
 	for _, fieldName := range sortedFieldNames {
 		field := model.Fields[fieldName]
 
-		// we only want Optional fields (which includes Optional + Computed fields)
+		// we only want Optional Arguments (which includes Optional + Computed fields)
 		if !field.Optional || field.Required {
 			continue
 		}
 
-		docs, err := documentationLineForArgument(field, resourceName)
+		nestedWithin := "" // top-level so not nested
+		docs, err := documentationLineForArgument(field, nestedWithin, resourceName)
 		if err != nil {
 			return nil, fmt.Errorf("building documentation line for optional argument/field %q: %+v", fieldName, err)
 		}
@@ -70,7 +72,8 @@ func getArguments(model resourcemanager.TerraformSchemaModelDefinition, resource
 	return &out, nil
 }
 
-func documentationLineForArgument(field resourcemanager.TerraformSchemaFieldDefinition, resourceName string) (*string, error) {
+// TODO: perhaps we should have specific tests covering each line (to validate things like above/below/validation etc?)
+func documentationLineForArgument(field resourcemanager.TerraformSchemaFieldDefinition, nestedWithin, resourceName string) (*string, error) {
 	components := make([]string, 0)
 	components = append(components, fmt.Sprintf("* `%s` -", field.HclName))
 

--- a/tools/generator-terraform/generator/resource/docs/component_arguments_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments_test.go
@@ -10,9 +10,6 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
 )
 
-// TODO: lists of items
-// TODO: lists of duplicate named blocks (top-level and nested should be fine)
-
 // NOTE: in all of these we should only be outputting the top-level arguments, the blocks themselves need to be output
 // in the blocks section
 
@@ -795,5 +792,72 @@ The following arguments are supported:
 * 'some_nested_item' - (Optional) A 'some_nested_item' block as defined below.
 `, "'", "`")
 
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForArgument_ReferencingAModel(t *testing.T) {
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			ReferenceName: pointer.To("Other"),
+			Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+		},
+		Computed: false,
+		ForceNew: false,
+		HclName:  "some_item",
+		Optional: true,
+		Required: false,
+	}
+	actual, err := documentationLineForArgument(input, "", "Example Resource")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `some_item` - (Optional) A `some_item` block as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForArgument_ReferencingAList(t *testing.T) {
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type: resourcemanager.TerraformSchemaFieldTypeList,
+			NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+				ReferenceName: pointer.To("Other"),
+				Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			},
+		},
+		Computed: false,
+		ForceNew: false,
+		HclName:  "some_item",
+		Optional: true,
+		Required: false,
+	}
+	actual, err := documentationLineForArgument(input, "", "Example Resource")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `some_item` - (Optional) A list of `some_item` blocks as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForArgument_ReferencingASet(t *testing.T) {
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type: resourcemanager.TerraformSchemaFieldTypeSet,
+			NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+				ReferenceName: pointer.To("Other"),
+				Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			},
+		},
+		Computed: false,
+		ForceNew: false,
+		HclName:  "some_item",
+		Optional: true,
+		Required: false,
+	}
+	actual, err := documentationLineForArgument(input, "", "Example Resource")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	// Sets are technically different internally, but still exposed to users in the same fashion, so we reuse `List` here
+	expected := "* `some_item` - (Optional) A list of `some_item` blocks as defined below."
 	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
 }

--- a/tools/generator-terraform/generator/resource/docs/component_arguments_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments_test.go
@@ -861,3 +861,56 @@ func TestDocumentationLineForArgument_ReferencingASet(t *testing.T) {
 	expected := "* `some_item` - (Optional) A list of `some_item` blocks as defined below."
 	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
 }
+
+func TestDocumentationLineForArgument_LocationAbove(t *testing.T) {
+	// The block `person` contains a field `animal`
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			ReferenceName: pointer.To("Animal"),
+		},
+		HclName:  "animal",
+		Optional: true,
+	}
+	actual, err := documentationLineForArgument(input, "person", "Some Resource")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `animal` - (Optional) An `animal` block as defined above."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForArgument_LocationBelow(t *testing.T) {
+	// The block `cat` contains a field `napping_place`
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			ReferenceName: pointer.To("NappingPlace"),
+		},
+		HclName:  "napping_place",
+		Optional: true,
+	}
+	actual, err := documentationLineForArgument(input, "cat", "Some Resource")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `napping_place` - (Optional) A `napping_place` block as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForArgument_LocationForTopLevelItemShouldAlwaysSayBelow(t *testing.T) {
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			ReferenceName: pointer.To("Animal"),
+		},
+		HclName:  "animal",
+		Optional: true,
+	}
+	actual, err := documentationLineForArgument(input, "", "Some Resource")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `animal` - (Optional) An `animal` block as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}

--- a/tools/generator-terraform/generator/resource/docs/component_arguments_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_arguments_test.go
@@ -6,11 +6,146 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
-
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
 )
 
-func TestComponentArguments(t *testing.T) {
+// TODO: lists of items
+// TODO: lists of duplicate named blocks (top-level and nested should be fine)
+
+// NOTE: in all of these we should only be outputting the top-level arguments, the blocks themselves need to be output
+// in the blocks section
+
+func TestComponentArguments_TopLevelOnly(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredInteger": {
+						HclName: "required_integer",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for required_integer.",
+						},
+						Validation: &resourcemanager.TerraformSchemaValidationDefinition{
+							Type: "PossibleValues",
+							PossibleValues: &resourcemanager.TerraformSchemaValidationPossibleValuesDefinition{
+								Values: []interface{}{1, 2, 3},
+							},
+						},
+					},
+					"OptionalInteger": {
+						HclName: "optional_integer",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for optional_integer.",
+						},
+						Validation: &resourcemanager.TerraformSchemaValidationDefinition{
+							Type: "PossibleValues",
+							PossibleValues: &resourcemanager.TerraformSchemaValidationPossibleValuesDefinition{
+								Values: []interface{}{4, 5, 6},
+							},
+						},
+					},
+					"ComputedInteger": {
+						HclName: "computed_integer",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+						},
+						Computed: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for computed_integer.",
+						},
+					},
+					"RequiredString": {
+						HclName: "required_string",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for required_string.",
+						},
+						Validation: &resourcemanager.TerraformSchemaValidationDefinition{
+							Type: "PossibleValues",
+							PossibleValues: &resourcemanager.TerraformSchemaValidationPossibleValuesDefinition{
+								Values: []interface{}{"string1", "string2", "string3"},
+							},
+						},
+					},
+					"BooleanItem": {
+						HclName: "boolean_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for boolean_item.",
+						},
+					},
+					"OptionalString": {
+						HclName: "optional_string",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for optional_string.",
+						},
+						Validation: &resourcemanager.TerraformSchemaValidationDefinition{
+							Type: "PossibleValues",
+							PossibleValues: &resourcemanager.TerraformSchemaValidationPossibleValuesDefinition{
+								Values: []interface{}{"string1", "string2", "string3"},
+							},
+						},
+					},
+					"ComputedString": {
+						HclName: "computed_string",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Computed: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for computed_string.",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForArgumentsReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`
+## Arguments Reference
+
+The following arguments are supported:
+
+* 'required_integer' - (Required) Description for required_integer. Possible values are '1', '2' and '3'.
+
+* 'required_string' - (Required) Description for required_string. Possible values are 'string1', 'string2' and 'string3'.
+
+* 'boolean_item' - (Optional) Description for boolean_item. Possible values are 'true' and 'false'.
+
+* 'optional_integer' - (Optional) Description for optional_integer. Possible values are '4', '5' and '6'.
+
+* 'optional_string' - (Optional) Description for optional_string. Possible values are 'string1', 'string2' and 'string3'.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentArguments_WithNestedBlocks(t *testing.T) {
 	input := models.ResourceInput{
 		ResourceTypeName: "Example",
 		SchemaModelName:  "TopLevelModelResourceSchema",
@@ -250,6 +385,7 @@ func TestComponentArguments(t *testing.T) {
 		t.Fatalf("error: %+v", err)
 	}
 
+	// NOTE: the nested blocks are intentionally not output, since these should be output within the `blocks reference` section
 	expected := strings.ReplaceAll(`
 ## Arguments Reference
 
@@ -268,10 +404,396 @@ The following arguments are supported:
 * 'optional_nested_item' - (Optional) An 'optional_nested_item' block as defined below. 
 
 * 'optional_string' - (Optional) Description for optional_string. Possible values are 'string1', 'string2' and 'string3'.
-
 `, "'", "`")
 
-	if *actual != expected {
-		t.Fatalf("Expected %s but got %s", expected, *actual)
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentArguments_WithIdentitySystemAssigned(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Identity": {
+						Optional: true,
+						HclName:  "identity",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentitySystemAssigned,
+						},
+					},
+					"MakeSounds": {
+						Required: true,
+						HclName:  "make_sounds",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Specifies whether this blobby instance makes sounds.",
+						},
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+					},
+					"NumberOfSpots": {
+						Optional: true,
+						HclName:  "number_of_spots",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Specifies the number of spots this blobby instance should have.",
+						},
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+						},
+					},
+				},
+			},
+		},
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "blobby instance",
+		},
 	}
+	actual, err := codeForArgumentsReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`
+## Arguments Reference
+
+The following arguments are supported:
+
+* 'make_sounds' - (Required) Specifies whether this blobby instance makes sounds. Possible values are 'true' and 'false'.
+
+* 'identity' - (Optional) An 'identity' block as defined below.
+
+* 'number_of_spots' - (Optional) Specifies the number of spots this blobby instance should have.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentArguments_WithIdentitySystemAndUserAssigned(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Identity": {
+						Optional: true,
+						HclName:  "identity",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned,
+						},
+					},
+					"MakeSounds": {
+						Required: true,
+						HclName:  "make_sounds",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Specifies whether this blobby instance makes sounds.",
+						},
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+					},
+					"NumberOfSpots": {
+						Optional: true,
+						HclName:  "number_of_spots",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Specifies the number of spots this blobby instance should have.",
+						},
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+						},
+					},
+				},
+			},
+		},
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "blobby instance",
+		},
+	}
+	actual, err := codeForArgumentsReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`
+## Arguments Reference
+
+The following arguments are supported:
+
+* 'make_sounds' - (Required) Specifies whether this blobby instance makes sounds. Possible values are 'true' and 'false'.
+
+* 'identity' - (Optional) An 'identity' block as defined below.
+
+* 'number_of_spots' - (Optional) Specifies the number of spots this blobby instance should have.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentArguments_WithIdentitySystemOrUserAssigned(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Identity": {
+						Optional: true,
+						HclName:  "identity",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentitySystemOrUserAssigned,
+						},
+					},
+					"MakeSounds": {
+						Required: true,
+						HclName:  "make_sounds",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Specifies whether this blobby instance makes sounds.",
+						},
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+					},
+					"NumberOfSpots": {
+						Optional: true,
+						HclName:  "number_of_spots",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Specifies the number of spots this blobby instance should have.",
+						},
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+						},
+					},
+				},
+			},
+		},
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "blobby instance",
+		},
+	}
+	actual, err := codeForArgumentsReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`
+## Arguments Reference
+
+The following arguments are supported:
+
+* 'make_sounds' - (Required) Specifies whether this blobby instance makes sounds. Possible values are 'true' and 'false'.
+
+* 'identity' - (Optional) An 'identity' block as defined below.
+
+* 'number_of_spots' - (Optional) Specifies the number of spots this blobby instance should have.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentArguments_WithIdentityUserAssigned(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Identity": {
+						Optional: true,
+						HclName:  "identity",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentityUserAssigned,
+						},
+					},
+					"MakeSounds": {
+						Required: true,
+						HclName:  "make_sounds",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Specifies whether this blobby instance makes sounds.",
+						},
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+					},
+					"NumberOfSpots": {
+						Optional: true,
+						HclName:  "number_of_spots",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Specifies the number of spots this blobby instance should have.",
+						},
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeInteger,
+						},
+					},
+				},
+			},
+		},
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "blobby instance",
+		},
+	}
+	actual, err := codeForArgumentsReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`
+## Arguments Reference
+
+The following arguments are supported:
+
+* 'make_sounds' - (Required) Specifies whether this blobby instance makes sounds. Possible values are 'true' and 'false'.
+
+* 'identity' - (Optional) An 'identity' block as defined below.
+
+* 'number_of_spots' - (Optional) Specifies the number of spots this blobby instance should have.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentArguments_WithTheSameModelUsedAtTheTopLevelAndInMultipleNestedBlocks(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Blobby": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("BlobbySchema"),
+						},
+						Optional: true,
+						HclName:  "blobby",
+					},
+					"OptionalNestedItem": {
+						Optional: true,
+						HclName:  "optional_nested_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("NestedSchema"),
+						},
+					},
+				},
+			},
+			"NestedSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Blobby": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("BlobbySchema"),
+						},
+						Optional: true,
+						HclName:  "blobby",
+					},
+				},
+			},
+			"BlobbySchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"MakesSounds": {
+						HclName: "makes_sounds",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for makes_sounds.",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForArgumentsReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	// we should only output the block names, the blocks themselves are output via the `blocks reference` section
+	expected := strings.ReplaceAll(`
+## Arguments Reference
+
+The following arguments are supported:
+
+* 'blobby' - (Optional) A 'blobby' block as defined below.
+
+* 'optional_nested_item' - (Optional) An 'optional_nested_item' block as defined below.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentArguments_WithTheSameModelUsedInMultipleNestedBlocks(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"SomeNestedItem": {
+						Optional: true,
+						HclName:  "some_nested_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("NestedSchema"),
+						},
+					},
+					"OtherNestedItem": {
+						Optional: true,
+						HclName:  "other_nested_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("NestedSchema"),
+						},
+					},
+				},
+			},
+			"NestedSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Blobby": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("BlobbySchema"),
+						},
+						Optional: true,
+						HclName:  "blobby",
+					},
+				},
+			},
+			"BlobbySchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"MakesSounds": {
+						HclName: "makes_sounds",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for makes_sounds.",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForArgumentsReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	// we should only output the block names, the blocks themselves are output via the `blocks reference` section
+
+	expected := strings.ReplaceAll(`
+## Arguments Reference
+
+The following arguments are supported:
+
+* 'other_nested_item' - (Optional) An 'other_nested_item' block as defined below.
+
+* 'some_nested_item' - (Optional) A 'some_nested_item' block as defined below.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
 }

--- a/tools/generator-terraform/generator/resource/docs/component_attributes.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes.go
@@ -41,6 +41,8 @@ func getAttributes(model resourcemanager.TerraformSchemaModelDefinition) (*strin
 			components := make([]string, 0)
 			components = append(components, fmt.Sprintf("* `%s` -", field.HclName))
 
+			// TODO: when it's a List/Set, we should output `A list of XXX` or `One or more of XXX` (or something)
+
 			// identify block
 			if _, ok := objectDefinitionsWhichShouldBeSurfacedAsBlocks[field.ObjectDefinition.Type]; ok {
 				fieldBeginsWithVowel, err := beginsWithVowel(field.HclName)

--- a/tools/generator-terraform/generator/resource/docs/component_attributes.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes.go
@@ -63,13 +63,19 @@ func documentationLineForAttribute(field resourcemanager.TerraformSchemaFieldDef
 		if err != nil {
 			return nil, err
 		}
+
+		fieldLocation := "below"
+		if nestedWithin != "" && field.HclName <= nestedWithin {
+			fieldLocation = "above"
+		}
+
 		if isList {
-			components = append(components, fmt.Sprintf("A list of `%s` blocks as defined below.", field.HclName))
+			components = append(components, fmt.Sprintf("A list of `%s` blocks as defined %s.", field.HclName, fieldLocation))
 		} else {
 			if fieldBeginsWithVowel {
-				components = append(components, fmt.Sprintf("An `%s` block as defined below.", field.HclName))
+				components = append(components, fmt.Sprintf("An `%s` block as defined %s.", field.HclName, fieldLocation))
 			} else {
-				components = append(components, fmt.Sprintf("A `%s` block as defined below.", field.HclName))
+				components = append(components, fmt.Sprintf("A `%s` block as defined %s.", field.HclName, fieldLocation))
 			}
 		}
 	}

--- a/tools/generator-terraform/generator/resource/docs/component_attributes.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes.go
@@ -36,7 +36,7 @@ func getAttributes(model resourcemanager.TerraformSchemaModelDefinition) (*strin
 	for _, fieldName := range sortedFieldNames {
 		field := model.Fields[fieldName]
 		if field.Computed && !field.Optional && !field.Required {
-			line, err := documentationLineForAttribute(field)
+			line, err := documentationLineForAttribute(field, "")
 			if err != nil {
 				return nil, fmt.Errorf("building documentation line for attribute field %q: %+v", fieldName, err)
 			}
@@ -47,7 +47,8 @@ func getAttributes(model resourcemanager.TerraformSchemaModelDefinition) (*strin
 	return &out, nil
 }
 
-func documentationLineForAttribute(field resourcemanager.TerraformSchemaFieldDefinition) (*string, error) {
+// TODO: perhaps we should have specific tests covering each line (to validate things like above/below/validation etc?)
+func documentationLineForAttribute(field resourcemanager.TerraformSchemaFieldDefinition, nestedWithin string) (*string, error) {
 	components := make([]string, 0)
 	components = append(components, fmt.Sprintf("* `%s` -", field.HclName))
 
@@ -64,6 +65,7 @@ func documentationLineForAttribute(field resourcemanager.TerraformSchemaFieldDef
 		} else {
 			components = append(components, "A")
 		}
+
 		components = append(components, fmt.Sprintf("`%s` block as defined below.", field.HclName))
 	}
 	components = append(components, field.Documentation.Markdown)

--- a/tools/generator-terraform/generator/resource/docs/component_attributes.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes.go
@@ -42,7 +42,7 @@ func getAttributes(model resourcemanager.TerraformSchemaModelDefinition) (*strin
 			components = append(components, fmt.Sprintf("* `%s` -", field.HclName))
 
 			// identify block
-			if field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeReference {
+			if _, ok := objectDefinitionsWhichShouldBeSurfacedAsBlocks[field.ObjectDefinition.Type]; ok {
 				fieldBeginsWithVowel, err := beginsWithVowel(field.HclName)
 				if err != nil {
 					return nil, err

--- a/tools/generator-terraform/generator/resource/docs/component_attributes.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes.go
@@ -47,26 +47,31 @@ func getAttributes(model resourcemanager.TerraformSchemaModelDefinition) (*strin
 	return &out, nil
 }
 
-// TODO: perhaps we should have specific tests covering each line (to validate things like above/below/validation etc?)
 func documentationLineForAttribute(field resourcemanager.TerraformSchemaFieldDefinition, nestedWithin string) (*string, error) {
 	components := make([]string, 0)
 	components = append(components, fmt.Sprintf("* `%s` -", field.HclName))
 
-	// TODO: when it's a List/Set, we should output `A list of XXX` or `One or more of XXX` (or something)
+	isList := false
+	if field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeList || field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeSet {
+		isList = true
+	}
+	objectDefinition := topLevelObjectDefinition(field.ObjectDefinition)
 
 	// identify block
-	if _, ok := objectDefinitionsWhichShouldBeSurfacedAsBlocks[field.ObjectDefinition.Type]; ok {
+	if _, ok := objectDefinitionsWhichShouldBeSurfacedAsBlocks[objectDefinition.Type]; ok {
 		fieldBeginsWithVowel, err := beginsWithVowel(field.HclName)
 		if err != nil {
 			return nil, err
 		}
-		if fieldBeginsWithVowel {
-			components = append(components, "An")
+		if isList {
+			components = append(components, fmt.Sprintf("A list of `%s` blocks as defined below.", field.HclName))
 		} else {
-			components = append(components, "A")
+			if fieldBeginsWithVowel {
+				components = append(components, fmt.Sprintf("An `%s` block as defined below.", field.HclName))
+			} else {
+				components = append(components, fmt.Sprintf("A `%s` block as defined below.", field.HclName))
+			}
 		}
-
-		components = append(components, fmt.Sprintf("`%s` block as defined below.", field.HclName))
 	}
 	components = append(components, field.Documentation.Markdown)
 

--- a/tools/generator-terraform/generator/resource/docs/component_attributes_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes_test.go
@@ -1,13 +1,13 @@
 package docs
 
 import (
-	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
 )
 
 func TestComponentAttributes_TopLevelOnly(t *testing.T) {

--- a/tools/generator-terraform/generator/resource/docs/component_attributes_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes_test.go
@@ -1114,3 +1114,56 @@ func TestDocumentationLineForAttribute_ReferencingASet(t *testing.T) {
 	expected := "* `some_item` - A list of `some_item` blocks as defined below."
 	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
 }
+
+func TestDocumentationLineForAttribute_LocationAbove(t *testing.T) {
+	// The block `person` contains a field `animal`
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			ReferenceName: pointer.To("Animal"),
+		},
+		HclName:  "animal",
+		Optional: true,
+	}
+	actual, err := documentationLineForAttribute(input, "person")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `animal` - An `animal` block as defined above."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForAttribute_LocationBelow(t *testing.T) {
+	// The block `cat` contains a field `napping_place`
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			ReferenceName: pointer.To("NappingPlace"),
+		},
+		HclName:  "napping_place",
+		Optional: true,
+	}
+	actual, err := documentationLineForAttribute(input, "cat")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `napping_place` - A `napping_place` block as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForAttribute_LocationForTopLevelItemShouldAlwaysSayBelow(t *testing.T) {
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			ReferenceName: pointer.To("Animal"),
+		},
+		HclName:  "animal",
+		Optional: true,
+	}
+	actual, err := documentationLineForAttribute(input, "")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `animal` - An `animal` block as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}

--- a/tools/generator-terraform/generator/resource/docs/component_attributes_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_attributes_test.go
@@ -1047,3 +1047,70 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
 }
+
+func TestDocumentationLineForAttribute_ReferencingAModel(t *testing.T) {
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			ReferenceName: pointer.To("Other"),
+			Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+		},
+		Computed: false,
+		ForceNew: false,
+		HclName:  "some_item",
+		Optional: true,
+		Required: false,
+	}
+	actual, err := documentationLineForAttribute(input, "")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `some_item` - A `some_item` block as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForAttribute_ReferencingAList(t *testing.T) {
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type: resourcemanager.TerraformSchemaFieldTypeList,
+			NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+				ReferenceName: pointer.To("Other"),
+				Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			},
+		},
+		Computed: false,
+		ForceNew: false,
+		HclName:  "some_item",
+		Optional: true,
+		Required: false,
+	}
+	actual, err := documentationLineForAttribute(input, "")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "* `some_item` - A list of `some_item` blocks as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestDocumentationLineForAttribute_ReferencingASet(t *testing.T) {
+	input := resourcemanager.TerraformSchemaFieldDefinition{
+		ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+			Type: resourcemanager.TerraformSchemaFieldTypeSet,
+			NestedObject: &resourcemanager.TerraformSchemaFieldObjectDefinition{
+				ReferenceName: pointer.To("Other"),
+				Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+			},
+		},
+		Computed: false,
+		ForceNew: false,
+		HclName:  "some_item",
+		Optional: true,
+		Required: false,
+	}
+	actual, err := documentationLineForAttribute(input, "")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	// Sets are technically different internally, but still exposed to users in the same fashion, so we reuse `List` here
+	expected := "* `some_item` - A list of `some_item` blocks as defined below."
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}

--- a/tools/generator-terraform/generator/resource/docs/component_blocks.go
+++ b/tools/generator-terraform/generator/resource/docs/component_blocks.go
@@ -2,165 +2,298 @@ package docs
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
+// TODO: enable documentation for the CommonSchema blocks
+
+//var documentationForCommonSchemaBlocksAttributes = map[resourcemanager.TerraformSchemaFieldType]string{
+//}
+//
+//var documentationForCommonSchemaBlocksArguments = map[resourcemanager.TerraformSchemaFieldType]string{}
+
+type blockDefinition struct {
+	// isList specifies whether this blockDefinition is a List (for example, so we can output "Each XXX block supports"
+	// rather than "A XXX block supports")
+	isList bool
+
+	// nestedWithin specifies which block this field is nested under - a block nested under the
+	// top-level model will be an empty string
+	nestedWithin string
+
+	// objectDefinition is the (Top-Level) Object Definition for this Terraform Schema Field
+	objectDefinition resourcemanager.TerraformSchemaFieldObjectDefinition
+}
+
 func codeForBlocksReference(input models.ResourceInput) (*string, error) {
+	// We need the `hcl_name` for each field to be able to output it correctly, so we have to first
+	// process the top-level model, and then each referenced model to build up the full output.
+	//
+	// The benefit to doing this is it means we can detect nested models, so we can output things like
+	// the "bar" block within the "foo" block.
 
-	blocks := make(map[string]string)
-
-	// TODO update this to iterate over models when hcl names are available
-	for _, field := range input.SchemaModels[input.SchemaModelName].Fields {
-		if field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeReference {
-			nestedBlocks, err := populateBlockAndNestedBlocks(field.HclName, input, input.SchemaModels[*field.ObjectDefinition.ReferenceName])
-			if err != nil {
-				return nil, err
-			}
-			mergeBlocksMapWithNestedBlocks(blocks, nestedBlocks)
-		}
+	// So, let's start with the top-level model and find the blocks nested within it
+	nestedWithin := "" // top-level models aren't nested
+	blocksWithinModel, err := parseBlocksWithinModel(input.SchemaModels, input.SchemaModelName, nestedWithin)
+	if err != nil {
+		return nil, fmt.Errorf("parsing blocks within the top-level model %q: %+v", input.SchemaModelName, err)
 	}
 
+	// now we have a canonical list of block names, let's go through and sort those
+	blockNames := make([]string, 0)
+	for k := range *blocksWithinModel {
+		blockNames = append(blockNames, k)
+	}
+	sort.Strings(blockNames)
+
+	// then iterate over each of the block names, and build up the documentation
+	documentation := make([]string, 0)
+	for _, blockName := range blockNames {
+		block := (*blocksWithinModel)[blockName]
+
+		docs, err := buildDocumentationForBlock(blockName, block, input.SchemaModels, input.Details.DisplayName)
+		if err != nil {
+			return nil, fmt.Errorf("building documentation for the %q block: %+v", blockName, err)
+		}
+		documentation = append(documentation, *docs)
+	}
+
+	// finally format and output that
 	output := ""
-	if len(blocks) > 0 {
-		output = "## Blocks Reference\n"
+	if len(documentation) > 0 {
+		output = fmt.Sprintf(`## Blocks Reference
 
-		sortedBlockNames := sortStringStringMapKeys(blocks)
-		for _, block := range sortedBlockNames {
-			output = fmt.Sprintf(`%s%s
+%s`, strings.Join(documentation, "\n---\n"))
+	}
 
----
-`, output, blocks[block])
+	return &output, nil
+}
+
+func parseBlocksWithinModel(schemaModels map[string]resourcemanager.TerraformSchemaModelDefinition, modelName string, nestedWithin string) (*map[string][]blockDefinition, error) {
+	output := make(map[string][]blockDefinition, 0)
+
+	thisModel, ok := schemaModels[modelName]
+	if !ok {
+		return nil, fmt.Errorf("a schema model named %q was not found", modelName)
+	}
+
+	for fieldName, field := range thisModel.Fields {
+		objectDefinition := topLevelObjectDefinition(field.ObjectDefinition)
+		if _, isBlock := objectDefinitionsWhichShouldBeSurfacedAsBlocks[objectDefinition.Type]; !isBlock {
+			continue
+		}
+
+		existing, ok := output[field.HclName]
+		if !ok {
+			existing = make([]blockDefinition, 0)
+		}
+
+		existing = append(existing, blockDefinition{
+			isList:           field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeList || field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeSet,
+			nestedWithin:     nestedWithin,
+			objectDefinition: objectDefinition,
+		})
+		output[field.HclName] = existing
+
+		// for references, we then need to run down the chain to get its items, and append them
+		if objectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeReference {
+			// NOTE: we're only doing this for references and not all block types because others can be customtypes which don't have a reference
+			if objectDefinition.ReferenceName == nil {
+				return nil, fmt.Errorf("processing field %q: field is a Reference with no ReferenceName", fieldName)
+			}
+			nestedBlocks, err := parseBlocksWithinModel(schemaModels, *objectDefinition.ReferenceName, field.HclName)
+			if err != nil {
+				return nil, fmt.Errorf("processing field %q: parsing blocks within nested model %q: %+v", fieldName, *objectDefinition.ReferenceName, err)
+			}
+			// then go through and append the blocks
+			for k, v := range *nestedBlocks {
+				existing, hasExisting := output[k]
+				if !hasExisting {
+					output[k] = v
+					continue
+				}
+
+				existing = append(existing, v...)
+				output[k] = existing
+			}
 		}
 	}
 
 	return &output, nil
 }
 
-func getFieldsAndNestedBlocks(blockHclName string, input models.ResourceInput, model resourcemanager.TerraformSchemaModelDefinition) (string, string, map[string]string, error) {
-
-	requiredLines := make([]string, 0)
-	optionalLines := make([]string, 0)
-	attributeLines := make([]string, 0)
-	blocks := make(map[string]string)
-
-	sortedFieldNames := sortFieldNamesAlphabetically(model)
-
-	for _, fieldName := range sortedFieldNames {
-		field := model.Fields[fieldName]
-		components := make([]string, 0)
-		components = append(components, fmt.Sprintf("* `%s` -", field.HclName))
-
-		if field.Required {
-			components = append(components, "(Required)")
-		} else if field.Optional {
-			components = append(components, "(Optional)")
-		}
-
-		// identify block
-		isReference := field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeReference
-		if isReference {
-			fieldBeginsWithVowel, err := beginsWithVowel(field.HclName)
-			if err != nil {
-				return "", "", nil, err
-			}
-			if fieldBeginsWithVowel {
-				components = append(components, "An")
-			} else {
-				components = append(components, "A")
+func buildDocumentationForBlock(blockName string, definitions []blockDefinition, schemaModels map[string]resourcemanager.TerraformSchemaModelDefinition, resourceName string) (*string, error) {
+	// determine if we need to output each model uniquely, or if we should de-dupe them in the output
+	areAllUsagesTheSame := true
+	if len(definitions) > 1 {
+		firstDefinition := definitions[0]
+		for _, thisDefinition := range definitions[1:] {
+			if thisDefinition.isList != firstDefinition.isList {
+				areAllUsagesTheSame = false
+				break
 			}
 
-			components = append(components, fmt.Sprintf("`%s` block as defined", field.HclName))
-
-			// blocks are organised alphabetically, so checking order of nested block compared to parent block here
-			if strings.Compare(field.HclName, blockHclName) == 1 {
-				components = append(components, "below.")
-			} else {
-				components = append(components, "above.")
+			if !objectDefinitionsMatch(firstDefinition.objectDefinition, thisDefinition.objectDefinition) {
+				areAllUsagesTheSame = false
+				break
 			}
-		}
-
-		components = append(components, field.Documentation.Markdown)
-
-		isAttribute := false
-		if field.Computed && !field.Optional && !field.Required {
-			isAttribute = true
-		}
-
-		if !isAttribute {
-			// TODO update to include ranges
-			if field.ObjectDefinition.Type == resourcemanager.TerraformSchemaFieldTypeBoolean {
-				components = append(components, "Possible values are `true` and `false`.")
-			} else if field.Validation != nil {
-				if field.Validation.Type == resourcemanager.TerraformSchemaValidationTypePossibleValues {
-					if field.Validation.Type == resourcemanager.TerraformSchemaValidationTypePossibleValues {
-						if values := field.Validation.PossibleValues.Values; values != nil {
-							possibleValues := wordifyPossibleValues(values)
-							components = append(components, possibleValues)
-						}
-					}
-				}
-			}
-
-			// TODO set default if applicable?
-
-			if field.ForceNew {
-				components = append(components, fmt.Sprintf("Changing this forces a new %s to be created.", input.Details.DisplayName))
-			}
-		}
-
-		line := removeExtraSpaces(strings.Join(components, " "))
-
-		if field.Required {
-			requiredLines = append(requiredLines, line)
-		} else if field.Optional {
-			optionalLines = append(optionalLines, line)
-		} else if isAttribute {
-			attributeLines = append(attributeLines, line)
-		}
-
-		if isReference {
-			nestedBlocks, err := populateBlockAndNestedBlocks(field.HclName, input, input.SchemaModels[*field.ObjectDefinition.ReferenceName])
-			if err != nil {
-				return "", "", nil, err
-			}
-			mergeBlocksMapWithNestedBlocks(blocks, nestedBlocks)
 		}
 	}
-	return strings.Join(append(requiredLines, optionalLines...), "\n\n"), strings.Join(attributeLines, "\n\n"), blocks, nil
+
+	if areAllUsagesTheSame {
+		// output the de-duped documentation directly for this block (e.g. "An 'XXX' block supports")
+		definitions[0].nestedWithin = "" // fake this being a top-level block, since it's now being repurposed
+		return documentationForBlock(blockName, definitions[0], schemaModels, resourceName)
+	}
+
+	nestedWithinNames := make([]string, 0)
+	nestedWithinData := make(map[string]blockDefinition)
+	var topLevelBlock *blockDefinition
+	for _, definition := range definitions {
+		if definition.nestedWithin == "" {
+			topLevelBlock = pointer.To(definition)
+			continue
+		}
+
+		nestedWithinData[definition.nestedWithin] = definition
+		nestedWithinNames = append(nestedWithinNames, definition.nestedWithin)
+	}
+
+	// output the top-level block first
+	linesForBlocks := make([]string, 0)
+	if topLevelBlock != nil {
+		docsForBlock, err := documentationForBlock(blockName, *topLevelBlock, schemaModels, resourceName)
+		if err != nil {
+			return nil, fmt.Errorf("building documentation for the top-level block %q: %+v", blockName, err)
+		}
+		linesForBlocks = append(linesForBlocks, *docsForBlock)
+	}
+
+	for _, name := range nestedWithinNames {
+		nestedWithin := nestedWithinData[name]
+		docsForBlock, err := documentationForBlock(blockName, nestedWithin, schemaModels, resourceName)
+		if err != nil {
+			return nil, fmt.Errorf("building documentation for the top-level block %q: %+v", blockName, err)
+		}
+		linesForBlocks = append(linesForBlocks, *docsForBlock)
+	}
+
+	output := strings.Join(linesForBlocks, "---\n\n")
+	return &output, nil
 }
 
-func populateBlockAndNestedBlocks(blockHclName string, input models.ResourceInput, model resourcemanager.TerraformSchemaModelDefinition) (map[string]string, error) {
+func documentationForBlock(blockName string, objectDefinition blockDefinition, schemaModels map[string]resourcemanager.TerraformSchemaModelDefinition, resourceName string) (*string, error) {
+	// if all usages aren't the same, and this is a top-level block, call out that this is a top-level block explictly
+	// e.g. "'example' block (top-level)"
+	title := fmt.Sprintf("`%s` Block", blockName)
+	descriptionPrefix := fmt.Sprintf("The `%s` block", blockName)
+	if objectDefinition.nestedWithin != "" {
+		title = fmt.Sprintf("%s (within the `%s` block)", title, objectDefinition.nestedWithin)
+		descriptionPrefix = fmt.Sprintf("%s within the `%s` block", descriptionPrefix, objectDefinition.nestedWithin)
+	}
 
-	blocks := make(map[string]string)
-	blockArgs, blockAttributes, nestedBlocks, err := getFieldsAndNestedBlocks(blockHclName, input, model)
+	argumentsForBlock, err := getArgumentsForBlock(objectDefinition.objectDefinition, objectDefinition.nestedWithin, schemaModels, resourceName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("building arguments for block %s: %+v", blockName, err)
+	}
+	attributesForBlock, err := getAttributesForBlock(objectDefinition.objectDefinition, objectDefinition.nestedWithin, schemaModels)
+	if err != nil {
+		return nil, fmt.Errorf("building attributes for block %s: %+v", blockName, err)
 	}
 
-	components := make([]string, 0)
-	components = append(components, fmt.Sprintf("\n### `%s` Block", blockHclName))
+	out := fmt.Sprintf("### %[1]s\n", title)
+	if len(*argumentsForBlock) > 0 {
+		out = fmt.Sprintf(`%[1]s
 
-	if blockArgs != "" {
-		components = append(components, fmt.Sprintf("The `%s` block supports the following arguments:", blockHclName))
-		components = append(components, fmt.Sprintf("%s", blockArgs))
+%[2]s supports the following arguments:
+
+%[3]s
+`, out, descriptionPrefix, strings.Join(*argumentsForBlock, "\n"))
 	}
+	if len(*attributesForBlock) > 0 {
+		out = fmt.Sprintf(`%[1]s
 
-	if blockAttributes != "" {
-		components = append(components, fmt.Sprintf("The `%s` block exports the following arguments:", blockHclName))
-		components = append(components, fmt.Sprintf("%s", blockAttributes))
+%[2]s exports the following attributes:
+
+%[3]s
+`, out, descriptionPrefix, strings.Join(*attributesForBlock, "\n"))
 	}
-
-	blocks[blockHclName] = strings.Join(components, "\n\n")
-
-	return mergeBlocksMapWithNestedBlocks(blocks, nestedBlocks), nil
+	return &out, nil
 }
 
-func mergeBlocksMapWithNestedBlocks(blocksMap map[string]string, nestedBlocksMap map[string]string) map[string]string {
-	for k, v := range nestedBlocksMap {
-		blocksMap[k] = v
+func getArgumentsForBlock(objectDefinition resourcemanager.TerraformSchemaFieldObjectDefinition, nestedWithin string, schemaModels map[string]resourcemanager.TerraformSchemaModelDefinition, resourceName string) (*[]string, error) {
+	if objectDefinition.Type != resourcemanager.TerraformSchemaFieldTypeReference {
+		return nil, fmt.Errorf("expected a reference but got %q", string(objectDefinition.Type))
 	}
-	return blocksMap
+	model, ok := schemaModels[*objectDefinition.ReferenceName]
+	if !ok {
+		return nil, fmt.Errorf("the schema model %q was not found", *objectDefinition.ReferenceName)
+	}
+
+	requiredFieldNames := make([]string, 0)
+	optionalFieldNames := make([]string, 0)
+	for fieldName, field := range model.Fields {
+		if field.Required {
+			requiredFieldNames = append(requiredFieldNames, fieldName)
+		}
+		if field.Optional {
+			optionalFieldNames = append(optionalFieldNames, fieldName)
+		}
+	}
+	sort.Strings(requiredFieldNames)
+	sort.Strings(optionalFieldNames)
+
+	lines := make([]string, 0)
+	for _, fieldName := range requiredFieldNames {
+		field := model.Fields[fieldName]
+		docs, err := documentationLineForArgument(field, nestedWithin, resourceName)
+		if err != nil {
+			return nil, fmt.Errorf("building documentation for required argument field %q: %+v", fieldName, err)
+		}
+		lines = append(lines, *docs)
+	}
+	for _, fieldName := range optionalFieldNames {
+		field := model.Fields[fieldName]
+		docs, err := documentationLineForArgument(field, nestedWithin, resourceName)
+		if err != nil {
+			return nil, fmt.Errorf("building documentation for optional argument field %q: %+v", fieldName, err)
+		}
+		lines = append(lines, *docs)
+	}
+
+	return &lines, nil
+}
+func getAttributesForBlock(objectDefinition resourcemanager.TerraformSchemaFieldObjectDefinition, nestedWithin string, schemaModels map[string]resourcemanager.TerraformSchemaModelDefinition) (*[]string, error) {
+	if objectDefinition.Type != resourcemanager.TerraformSchemaFieldTypeReference {
+		return nil, fmt.Errorf("expected a reference but got %q", string(objectDefinition.Type))
+	}
+	model, ok := schemaModels[*objectDefinition.ReferenceName]
+	if !ok {
+		return nil, fmt.Errorf("the schema model %q was not found", *objectDefinition.ReferenceName)
+	}
+
+	fieldNames := make([]string, 0)
+	for fieldName, field := range model.Fields {
+		if field.Computed && !field.Optional && !field.Required {
+			fieldNames = append(fieldNames, fieldName)
+		}
+	}
+	sort.Strings(fieldNames)
+
+	lines := make([]string, 0)
+	for _, fieldName := range fieldNames {
+		field := model.Fields[fieldName]
+		docs, err := documentationLineForAttribute(field, nestedWithin)
+		if err != nil {
+			return nil, fmt.Errorf("building documentation for computed attribute field %q: %+v", fieldName, err)
+		}
+		lines = append(lines, *docs)
+	}
+
+	return &lines, nil
 }

--- a/tools/generator-terraform/generator/resource/docs/component_blocks.go
+++ b/tools/generator-terraform/generator/resource/docs/component_blocks.go
@@ -242,11 +242,11 @@ func documentationForBlock(blockName string, objectDefinition blockDefinition, s
 		descriptionPrefix = fmt.Sprintf("%s within the `%s` block", descriptionPrefix, objectDefinition.nestedWithin)
 	}
 
-	argumentsForBlock, err := getArgumentsForBlock(objectDefinition.objectDefinition, objectDefinition.nestedWithin, schemaModels, resourceName)
+	argumentsForBlock, err := getArgumentsForBlock(objectDefinition.objectDefinition, blockName, schemaModels, resourceName)
 	if err != nil {
 		return nil, fmt.Errorf("building arguments for block %s: %+v", blockName, err)
 	}
-	attributesForBlock, err := getAttributesForBlock(objectDefinition.objectDefinition, objectDefinition.nestedWithin, schemaModels, resourceName)
+	attributesForBlock, err := getAttributesForBlock(objectDefinition.objectDefinition, blockName, schemaModels, resourceName)
 	if err != nil {
 		return nil, fmt.Errorf("building attributes for block %s: %+v", blockName, err)
 	}

--- a/tools/generator-terraform/generator/resource/docs/component_blocks_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_blocks_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
 )
 
-// TODO: above/below
-
 func TestComponentBlocks_ModelsSingle(t *testing.T) {
 	input := models.ResourceInput{
 		Details: resourcemanager.TerraformResourceDetails{
@@ -388,7 +386,7 @@ The 'another_nested_item' block supports the following arguments:
 
 The 'optional_nested_item' block supports the following arguments:
 
-* 'another_nested_item' - (Optional) An 'another_nested_item' block as defined below. 
+* 'another_nested_item' - (Optional) An 'another_nested_item' block as defined above. 
 
 * 'nested_item' - (Optional) Description for nested_item. Possible values are 'string1', 'string2' and 'string3'.
 
@@ -534,13 +532,13 @@ The 'example' block exports the following attributes:
 
 The 'first' block supports the following arguments:
 
-* 'example' - (Required) An 'example' block as defined below. Description for example.
+* 'example' - (Required) An 'example' block as defined above. Description for example.
 
 ### 'second' Block
 
 The 'second' block supports the following arguments:
 
-* 'example' - (Required) An 'example' block as defined below. Description for example.
+* 'example' - (Required) An 'example' block as defined above. Description for example.
 
 `, "'", "`")
 
@@ -692,13 +690,13 @@ The 'example' block within the 'second' block exports the following attributes:
 
 The 'first' block supports the following arguments:
 
-* 'example' - (Required) An 'example' block as defined below. Description for example.
+* 'example' - (Required) An 'example' block as defined above. Description for example.
 
 ### 'second' Block
 
 The 'second' block supports the following arguments:
 
-* 'example' - (Required) An 'example' block as defined below. Description for example.
+* 'example' - (Required) An 'example' block as defined above. Description for example.
 
 `, "'", "`")
 
@@ -773,7 +771,7 @@ The 'required_item' block supports the following arguments:
 
 The 'required_nested_item' block supports the following arguments:
 
-* 'required_item' - (Required) A list of 'required_item' blocks as defined below.
+* 'required_item' - (Required) A list of 'required_item' blocks as defined above.
 
 `, "'", "`")
 
@@ -839,6 +837,14 @@ func TestComponentBlocks_ModelsAndIdentityShouldBeOrderedAlphabetically(t *testi
 			},
 			"Second": {
 				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"First": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("First"),
+						},
+						Optional: true,
+						HclName:  "first",
+					},
 					"SomeField": {
 						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
 							Type: resourcemanager.TerraformSchemaFieldTypeString,
@@ -885,6 +891,8 @@ The 'first' block supports the following arguments:
 The 'second' block supports the following arguments:
 
 * 'some_field' - (Required) Description for 'some_field'.
+
+* 'first' - (Optional) A 'first' block as defined above.
 
 ### 'system_assigned_identity' Block
 

--- a/tools/generator-terraform/generator/resource/docs/component_blocks_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_blocks_test.go
@@ -105,6 +105,148 @@ The 'required_nested_item' block supports the following arguments:
 
 * 'optional_item' - (Optional) Description for optional_item. Possible values are 'string1', 'string2' and 'string3'.
 
+In addition to the arguments defined above, the 'required_nested_item' block exports the following attributes:
+
+* 'computed_item' - Description for computed_item.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_ModelsSingleArgumentsOnly(t *testing.T) {
+	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredNestedItem": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("RequiredNestedSchema"),
+						},
+						Required: true,
+						HclName:  "required_nested_item",
+					},
+				},
+			},
+			"RequiredNestedSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"OptionalItem": {
+						HclName: "optional_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for optional_item.",
+						},
+						Validation: &resourcemanager.TerraformSchemaValidationDefinition{
+							Type: "PossibleValues",
+							PossibleValues: &resourcemanager.TerraformSchemaValidationPossibleValuesDefinition{
+								Values: []interface{}{"string1", "string2", "string3"},
+							},
+						},
+					},
+					"RequiredItem": {
+						HclName: "required_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for required_item.",
+						},
+						Validation: &resourcemanager.TerraformSchemaValidationDefinition{
+							Type: "PossibleValues",
+							PossibleValues: &resourcemanager.TerraformSchemaValidationPossibleValuesDefinition{
+								Values: []interface{}{"string1", "string2", "string3"},
+							},
+						},
+					},
+					"BooleanItem": {
+						HclName: "boolean_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for boolean_item.",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'required_nested_item' Block
+
+The 'required_nested_item' block supports the following arguments:
+
+* 'required_item' - (Required) Description for required_item. Possible values are 'string1', 'string2' and 'string3'.
+
+* 'boolean_item' - (Optional) Description for boolean_item. Possible values are 'true' and 'false'.
+
+* 'optional_item' - (Optional) Description for optional_item. Possible values are 'string1', 'string2' and 'string3'.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_ModelsSingleAttributesOnly(t *testing.T) {
+	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredNestedItem": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("RequiredNestedSchema"),
+						},
+						Required: true,
+						HclName:  "required_nested_item",
+					},
+				},
+			},
+			"RequiredNestedSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"ComputedItem": {
+						HclName: "computed_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Computed: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for computed_item.",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'required_nested_item' Block
+
 The 'required_nested_item' block exports the following attributes:
 
 * 'computed_item' - Description for computed_item.
@@ -392,7 +534,7 @@ The 'optional_nested_item' block supports the following arguments:
 
 * 'z_another_nested_item_2' - (Optional) A 'z_another_nested_item_2' block as defined below. 
 
-The 'optional_nested_item' block exports the following attributes:
+In addition to the arguments defined above, the 'optional_nested_item' block exports the following attributes:
 
 * 'computed_item' - Description for computed_string.
 
@@ -406,7 +548,7 @@ The 'required_nested_item' block supports the following arguments:
 
 * 'optional_item' - (Optional) Description for optional_item. Possible values are 'string1', 'string2' and 'string3'.
 
-The 'required_nested_item' block exports the following attributes:
+In addition to the arguments defined above, the 'required_nested_item' block exports the following attributes:
 
 * 'computed_item' - Description for computed_item.
 
@@ -524,7 +666,7 @@ The 'example' block supports the following arguments:
 
 * 'some_field' - (Optional) Description for some_field. 
 
-The 'example' block exports the following attributes:
+In addition to the arguments defined above, the 'example' block exports the following attributes:
 
 * 'computed_field' - Description for computed_field.
 
@@ -672,7 +814,7 @@ The 'example' block within the 'first' block supports the following arguments:
 
 * 'some_field' - (Optional) Description for some_field. 
 
-The 'example' block within the 'first' block exports the following attributes:
+In addition to the arguments defined above, the 'example' block within the 'first' block exports the following attributes:
 
 * 'computed_field' - Description for computed_field.
 
@@ -682,7 +824,7 @@ The 'example' block within the 'second' block supports the following arguments:
 
 * 'other_field' - (Optional) Description for other_field. 
 
-The 'example' block within the 'second' block exports the following attributes:
+In addition to the arguments defined above, the 'example' block within the 'second' block exports the following attributes:
 
 * 'computed_field' - Description for computed_field.
 
@@ -900,7 +1042,7 @@ The 'system_assigned_identity' block supports the following arguments:
 
 * 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. The only possible value is 'SystemAssigned'.
 
-The 'system_assigned_identity' block exports the following attributes:
+In addition to the arguments defined above, the 'system_assigned_identity' block exports the following attributes:
 
 * 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
 
@@ -968,7 +1110,7 @@ The 'some_identity_field' block supports the following arguments:
 
 * 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. The only possible value is 'SystemAssigned'.
 
-The 'some_identity_field' block exports the following attributes:
+In addition to the arguments defined above, the 'some_identity_field' block exports the following attributes:
 
 * 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
 
@@ -1012,7 +1154,7 @@ The 'required_nested_item' block supports the following arguments:
 
 * 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. The only possible value is 'SystemAssigned'.
 
-The 'required_nested_item' block exports the following attributes:
+In addition to the arguments defined above, the 'required_nested_item' block exports the following attributes:
 
 * 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
 
@@ -1058,7 +1200,7 @@ The 'required_nested_item' block supports the following arguments:
 
 * 'identity_ids' - (Optional) A list of the User Assigned Identity IDs that should be assigned to this Blobby Instance.
 
-The 'required_nested_item' block exports the following attributes:
+In addition to the arguments defined above, the 'required_nested_item' block exports the following attributes:
 
 * 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
 
@@ -1105,7 +1247,7 @@ The 'required_nested_item' block supports the following arguments:
 
 * 'identity_ids' - (Optional) A list of the User Assigned Identity IDs that should be assigned to this Blobby Instance.
 
-The 'required_nested_item' block exports the following attributes:
+In addition to the arguments defined above, the 'required_nested_item' block exports the following attributes:
 
 * 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
 

--- a/tools/generator-terraform/generator/resource/docs/component_blocks_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_blocks_test.go
@@ -7,9 +7,113 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
 )
 
-func TestComponentBlocks(t *testing.T) {
+// TODO: Lists
+// TODO: above/below
+
+func TestComponentBlocks_ModelsSingle(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredNestedItem": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("RequiredNestedSchema"),
+						},
+						Required: true,
+						HclName:  "required_nested_item",
+					},
+				},
+			},
+			"RequiredNestedSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"OptionalItem": {
+						HclName: "optional_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for optional_item.",
+						},
+						Validation: &resourcemanager.TerraformSchemaValidationDefinition{
+							Type: "PossibleValues",
+							PossibleValues: &resourcemanager.TerraformSchemaValidationPossibleValuesDefinition{
+								Values: []interface{}{"string1", "string2", "string3"},
+							},
+						},
+					},
+					"ComputedItem": {
+						HclName: "computed_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Computed: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for computed_item.",
+						},
+					},
+					"RequiredItem": {
+						HclName: "required_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for required_item.",
+						},
+						Validation: &resourcemanager.TerraformSchemaValidationDefinition{
+							Type: "PossibleValues",
+							PossibleValues: &resourcemanager.TerraformSchemaValidationPossibleValuesDefinition{
+								Values: []interface{}{"string1", "string2", "string3"},
+							},
+						},
+					},
+					"BooleanItem": {
+						HclName: "boolean_item",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeBoolean,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for boolean_item.",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'required_nested_item' Block
+
+The 'required_nested_item' block supports the following arguments:
+
+* 'required_item' - (Required) Description for required_item. Possible values are 'string1', 'string2' and 'string3'.
+
+* 'boolean_item' - (Optional) Description for boolean_item. Possible values are 'true' and 'false'.
+
+* 'optional_item' - (Optional) Description for optional_item. Possible values are 'string1', 'string2' and 'string3'.
+
+The 'required_nested_item' block exports the following attributes:
+
+* 'computed_item' - Description for computed_item.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_ModelsMultiple(t *testing.T) {
 	input := models.ResourceInput{
 		ResourceTypeName: "Example",
 		SchemaModelName:  "TopLevelModelResourceSchema",
@@ -281,13 +385,13 @@ The 'another_nested_item' block supports the following arguments:
 
 The 'optional_nested_item' block supports the following arguments:
 
-* 'another_nested_item' - (Optional) An 'another_nested_item' block as defined above. 
+* 'another_nested_item' - (Optional) An 'another_nested_item' block as defined below. 
 
 * 'nested_item' - (Optional) Description for nested_item. Possible values are 'string1', 'string2' and 'string3'.
 
 * 'z_another_nested_item_2' - (Optional) A 'z_another_nested_item_2' block as defined below. 
 
-The 'optional_nested_item' block exports the following arguments:
+The 'optional_nested_item' block exports the following attributes:
 
 * 'computed_item' - Description for computed_string.
 
@@ -303,7 +407,7 @@ The 'required_nested_item' block supports the following arguments:
 
 * 'optional_item' - (Optional) Description for optional_item. Possible values are 'string1', 'string2' and 'string3'.
 
-The 'required_nested_item' block exports the following arguments:
+The 'required_nested_item' block exports the following attributes:
 
 * 'computed_item' - Description for computed_item.
 
@@ -315,10 +419,293 @@ The 'z_another_nested_item_2' block supports the following arguments:
 
 * 'optional_item_2' - (Optional) Description for optional_item. Possible values are 'string4', 'string5' and 'string6'.
 
----
 `, "'", "`")
 
-	if *actual != expected {
-		t.Fatalf("Expected %s but got %s", expected, *actual)
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_ModelsMultipleNestingTheSameModelShouldBeDeduped(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"First": {
+						HclName: "first",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("First"),
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for first.",
+						},
+					},
+					"Second": {
+						HclName: "second",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("Second"),
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for second.",
+						},
+					},
+				},
+			},
+			"Example": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"SomeField": {
+						HclName: "some_field",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for some_field.",
+						},
+					},
+					"ComputedField": {
+						HclName: "computed_field",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Computed: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for computed_field.",
+						},
+					},
+				},
+			},
+			"First": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Example": {
+						HclName: "example",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("Example"),
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for example.",
+						},
+					},
+				},
+			},
+			"Second": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Example": {
+						HclName: "example",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("Example"),
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for example.",
+						},
+					},
+				},
+			},
+		},
 	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'example' Block
+
+The 'example' block supports the following arguments:
+
+* 'some_field' - (Optional) Description for some_field. 
+
+The 'example' block exports the following attributes:
+
+* 'computed_field' - Description for computed_field.
+
+---
+
+### 'first' Block
+
+The 'first' block supports the following arguments:
+
+* 'example' - (Required) An 'example' block as defined below. Description for example.
+
+---
+
+### 'second' Block
+
+The 'second' block supports the following arguments:
+
+* 'example' - (Required) An 'example' block as defined below. Description for example.
+
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_ModelsMultipleNestingDifferentModelsWithTheSameNameShouldBeOutputUniquely(t *testing.T) {
+	input := models.ResourceInput{
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"First": {
+						HclName: "first",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("First"),
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for first.",
+						},
+					},
+					"Second": {
+						HclName: "second",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("Second"),
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for second.",
+						},
+					},
+				},
+			},
+			"Example1": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"SomeField": {
+						HclName: "some_field",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for some_field.",
+						},
+					},
+					"ComputedField": {
+						HclName: "computed_field",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Computed: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for computed_field.",
+						},
+					},
+				},
+			},
+			"Example2": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"OtherField": {
+						HclName: "other_field",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Optional: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for other_field.",
+						},
+					},
+					"ComputedField": {
+						HclName: "computed_field",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Computed: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for computed_field.",
+						},
+					},
+				},
+			},
+			"First": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Example": {
+						HclName: "example",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("Example1"),
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for example.",
+						},
+					},
+				},
+			},
+			"Second": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"Example": {
+						HclName: "example",
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("Example2"),
+						},
+						Required: true,
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for example.",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'example' Block (within the 'first' block)
+
+The 'example' block within the 'first' block supports the following arguments:
+
+* 'some_field' - (Optional) Description for some_field. 
+
+The 'example' block within the 'first' block exports the following attributes:
+
+* 'computed_field' - Description for computed_field.
+
+---
+
+### 'example' Block (within the 'second' block)
+
+The 'example' block within the 'second' block supports the following arguments:
+
+* 'other_field' - (Optional) Description for other_field. 
+
+The 'example' block within the 'second' block exports the following attributes:
+
+* 'computed_field' - Description for computed_field.
+
+---
+
+### 'first' Block
+
+The 'first' block supports the following arguments:
+
+* 'example' - (Required) An 'example' block as defined below. Description for example.
+
+---
+
+### 'second' Block
+
+The 'second' block supports the following arguments:
+
+* 'example' - (Required) An 'example' block as defined below. Description for example.
+
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
 }

--- a/tools/generator-terraform/generator/resource/docs/component_blocks_test.go
+++ b/tools/generator-terraform/generator/resource/docs/component_blocks_test.go
@@ -15,6 +15,9 @@ import (
 
 func TestComponentBlocks_ModelsSingle(t *testing.T) {
 	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
 		ResourceTypeName: "Example",
 		SchemaModelName:  "TopLevelModelResourceSchema",
 		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
@@ -115,6 +118,9 @@ The 'required_nested_item' block exports the following attributes:
 
 func TestComponentBlocks_ModelsMultiple(t *testing.T) {
 	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
 		ResourceTypeName: "Example",
 		SchemaModelName:  "TopLevelModelResourceSchema",
 		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
@@ -379,8 +385,6 @@ The 'another_nested_item' block supports the following arguments:
 
 * 'optional_item' - (Optional) Description for optional_item. Possible values are 'string1', 'string2' and 'string3'.
 
----
-
 ### 'optional_nested_item' Block
 
 The 'optional_nested_item' block supports the following arguments:
@@ -394,8 +398,6 @@ The 'optional_nested_item' block supports the following arguments:
 The 'optional_nested_item' block exports the following attributes:
 
 * 'computed_item' - Description for computed_string.
-
----
 
 ### 'required_nested_item' Block
 
@@ -411,8 +413,6 @@ The 'required_nested_item' block exports the following attributes:
 
 * 'computed_item' - Description for computed_item.
 
----
-
 ### 'z_another_nested_item_2' Block
 
 The 'z_another_nested_item_2' block supports the following arguments:
@@ -426,6 +426,9 @@ The 'z_another_nested_item_2' block supports the following arguments:
 
 func TestComponentBlocks_ModelsMultipleNestingTheSameModelShouldBeDeduped(t *testing.T) {
 	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
 		ResourceTypeName: "Example",
 		SchemaModelName:  "TopLevelModelResourceSchema",
 		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
@@ -528,15 +531,11 @@ The 'example' block exports the following attributes:
 
 * 'computed_field' - Description for computed_field.
 
----
-
 ### 'first' Block
 
 The 'first' block supports the following arguments:
 
 * 'example' - (Required) An 'example' block as defined below. Description for example.
-
----
 
 ### 'second' Block
 
@@ -551,6 +550,9 @@ The 'second' block supports the following arguments:
 
 func TestComponentBlocks_ModelsMultipleNestingDifferentModelsWithTheSameNameShouldBeOutputUniquely(t *testing.T) {
 	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
 		ResourceTypeName: "Example",
 		SchemaModelName:  "TopLevelModelResourceSchema",
 		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
@@ -677,8 +679,6 @@ The 'example' block within the 'first' block exports the following attributes:
 
 * 'computed_field' - Description for computed_field.
 
----
-
 ### 'example' Block (within the 'second' block)
 
 The 'example' block within the 'second' block supports the following arguments:
@@ -689,21 +689,386 @@ The 'example' block within the 'second' block exports the following attributes:
 
 * 'computed_field' - Description for computed_field.
 
----
-
 ### 'first' Block
 
 The 'first' block supports the following arguments:
 
 * 'example' - (Required) An 'example' block as defined below. Description for example.
 
----
-
 ### 'second' Block
 
 The 'second' block supports the following arguments:
 
 * 'example' - (Required) An 'example' block as defined below. Description for example.
+
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_ModelsAndIdentityShouldBeOrderedAlphabetically(t *testing.T) {
+	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"First": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("First"),
+						},
+						Required: true,
+						HclName:  "first",
+					},
+					"SystemAssignedIdentity": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentitySystemAssigned,
+						},
+						Required: true,
+						HclName:  "system_assigned_identity",
+					},
+					"Second": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("Second"),
+						},
+						Required: true,
+						HclName:  "second",
+					},
+					"Third": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("Third"),
+						},
+						Required: true,
+						HclName:  "third",
+					},
+				},
+			},
+			"First": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"SomeField": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Required: true,
+						HclName:  "some_field",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for `some_field`.",
+						},
+					},
+				},
+			},
+			"Second": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"SomeField": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Required: true,
+						HclName:  "some_field",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for `some_field`.",
+						},
+					},
+				},
+			},
+			"Third": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"SomeField": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeString,
+						},
+						Required: true,
+						HclName:  "some_field",
+						Documentation: resourcemanager.TerraformSchemaDocumentationDefinition{
+							Markdown: "Description for `some_field`.",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'first' block
+
+The 'first' block supports the following arguments:
+
+* 'some_field' - (Required) Description for 'some_field'.
+
+### 'second' block
+
+The 'second' block supports the following arguments:
+
+* 'some_field' - (Required) Description for 'some_field'.
+
+### 'system_assigned_identity' Block
+
+The 'system_assigned_identity' block supports the following arguments:
+
+* 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. The only possible value is 'SystemAssigned'.
+
+The 'system_assigned_identity' block exports the following attributes:
+
+* 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+
+* 'tenant_id' - The Tenant ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+
+### 'third' block
+
+The 'third' block supports the following arguments:
+
+* 'some_field' - (Required) Description for 'some_field'.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_NestedIdentityBlockGetsPulledOut(t *testing.T) {
+	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredNestedItem": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type:          resourcemanager.TerraformSchemaFieldTypeReference,
+							ReferenceName: pointer.To("First"),
+						},
+						Required: true,
+						HclName:  "first",
+					},
+				},
+			},
+			"First": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"SomeIdentityField": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentitySystemAssigned,
+						},
+						Required: true,
+						HclName:  "some_identity_field",
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'first' block
+
+The 'first' block supports the following arguments:
+
+* 'some_identity_field' - (Required) A 'some_identity_field' block as defined below.
+
+### 'some_identity_field' Block
+
+The 'some_identity_field' block supports the following arguments:
+
+* 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. The only possible value is 'SystemAssigned'.
+
+The 'some_identity_field' block exports the following attributes:
+
+* 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+
+* 'tenant_id' - The Tenant ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_IdentitySystemAssigned(t *testing.T) {
+	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredNestedItem": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentitySystemAssigned,
+						},
+						Required: true,
+						HclName:  "required_nested_item",
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'required_nested_item' Block
+
+The 'required_nested_item' block supports the following arguments:
+
+* 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. The only possible value is 'SystemAssigned'.
+
+The 'required_nested_item' block exports the following attributes:
+
+* 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+
+* 'tenant_id' - The Tenant ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_IdentitySystemAndUserAssigned(t *testing.T) {
+	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredNestedItem": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned,
+						},
+						Required: true,
+						HclName:  "required_nested_item",
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'required_nested_item' Block
+
+The 'required_nested_item' block supports the following arguments:
+
+* 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. Possible values are 'SystemAssigned', 'SystemAssigned, UserAssigned' and 'UserAssigned'.
+
+* 'identity_ids' - (Optional) A list of the User Assigned Identity IDs that should be assigned to this Blobby Instance.
+
+The 'required_nested_item' block exports the following attributes:
+
+* 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+
+* 'tenant_id' - The Tenant ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_IdentitySystemOrUserAssigned(t *testing.T) {
+	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredNestedItem": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentitySystemOrUserAssigned,
+						},
+						Required: true,
+						HclName:  "required_nested_item",
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'required_nested_item' Block
+
+The 'required_nested_item' block supports the following arguments:
+
+* 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. Possible values are 'SystemAssigned' and 'UserAssigned'.
+
+* 'identity_ids' - (Optional) A list of the User Assigned Identity IDs that should be assigned to this Blobby Instance.
+
+The 'required_nested_item' block exports the following attributes:
+
+* 'principal_id' - The Principal ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+
+* 'tenant_id' - The Tenant ID for the System-Assigned Managed Identity assigned to this Blobby Instance.
+
+`, "'", "`")
+
+	testhelpers.AssertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestComponentBlocks_IdentityUserAssigned(t *testing.T) {
+	input := models.ResourceInput{
+		Details: resourcemanager.TerraformResourceDetails{
+			DisplayName: "Blobby Instance",
+		},
+		ResourceTypeName: "Example",
+		SchemaModelName:  "TopLevelModelResourceSchema",
+		SchemaModels: map[string]resourcemanager.TerraformSchemaModelDefinition{
+			"TopLevelModelResourceSchema": {
+				Fields: map[string]resourcemanager.TerraformSchemaFieldDefinition{
+					"RequiredNestedItem": {
+						ObjectDefinition: resourcemanager.TerraformSchemaFieldObjectDefinition{
+							Type: resourcemanager.TerraformSchemaFieldTypeIdentityUserAssigned,
+						},
+						Required: true,
+						HclName:  "required_nested_item",
+					},
+				},
+			},
+		},
+	}
+	actual, err := codeForBlocksReference(input)
+	if err != nil {
+		t.Fatalf("error: %+v", err)
+	}
+
+	expected := strings.ReplaceAll(`## Blocks Reference
+
+### 'required_nested_item' Block
+
+The 'required_nested_item' block supports the following arguments:
+
+* 'identity_ids' - (Required) A list of the User Assigned Identity IDs that should be assigned to this Blobby Instance.
+
+* 'type' - (Required) Specifies the type of Managed Identity that should be assigned to this Blobby Instance. The only possible value is 'UserAssigned'.
 
 `, "'", "`")
 


### PR DESCRIPTION
This PR does a few things:

* [x] Outputs the `identity` fields as Blocks for both Arguments and Attributes
* [x] Outputs the `identity` blocks inline within the Blocks Reference
* [x] Outputs nested blocks with context of where these are located within the Blocks Reference when there's conflicts (e.g. `the "bar" block within the "foo" block supports:`) to account for blocks having the same name at different locations (also de-duping when these are the same)
* [x] Outputting Lists and Sets appropriately ("One or more XXX blocks" and "Each XXX block supports..")
* [x] Outputting the location of each block (e.g. "the XXX block as defined (above|below)")

Fixes #2270