### PR TITLE
config: reverting `sql` @ `2022-11-01-preview`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -472,10 +472,6 @@ service "solutions" {
   name      = "ManagedApplications"
   available = ["2019-07-01", "2021-07-01"]
 }
-service "sql" {
-  name      = "Sql"
-  available = ["2022-11-01-preview"]
-}
 service "sqlvirtualmachine" {
   name      = "SqlVirtualMachine"
   available = ["2022-02-01"]

--- a/tools/importer-rest-api-specs/components/parser/internal/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/helpers.go
@@ -34,6 +34,9 @@ func OperationShouldBeIgnored(operationUri string) bool {
 	if strings.Contains(strings.ToLower(operationUri), "/managedclusteroperationresults/") {
 		return true
 	}
+	if strings.Contains(strings.ToLower(operationUri), "/manageddatabasemoveoperationresults/") {
+		return true
+	}
 	if strings.Contains(strings.ToLower(operationUri), "/operationresults/") {
 		return true
 	}


### PR DESCRIPTION
There's an issue in the source data where the API operations support different Enum values, thus should be using a different Enum (or as I've done [in this PR](https://github.com/Azure/azure-rest-api-specs/pull/24187) - split this out to a separate endpoint, since it's a separate operation) - as such [this is currently causing flapping in the data](https://github.com/hashicorp/pandora/pull/2557/files#diff-c6309cb7c86d8a927d172057baa8ccc0a5381600b6228e4960994d642895a055L17-R22) - so we're going to need to remove this API version for now.

Once [the upstream PR's been merged](https://github.com/Azure/azure-rest-api-specs/pull/24187), we should be able to re-introduce this API Version.