### PR TITLE
tools/importer-rest-api-specs: fixing an eventual consistency bug when parsing the data

### DIFF
--- a/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent_test.go
+++ b/tools/importer-rest-api-specs/components/schema/processors/model_flatten_properties_into_parent_test.go
@@ -395,19 +395,23 @@ func TestProcessModel_FlattenPropertiesIntoParent_Invalid(t *testing.T) {
 		},
 	}
 
-	for i, v := range testData {
-		t.Logf("[DEBUG] Iteration %d - testing %s", i, v.modelNameInput)
+	for i := range testData {
+		// @tombuildsstuff; this test is eventually consistent, so let's run it a few times to be sure
+		for n := 0; n < 10; n++ {
+			v := testData[i]
+			t.Logf("[DEBUG] Iteration %d re-iteration %d - testing %s", i, n, v.modelNameInput)
 
-		actualModels, actualMappings, err := modelFlattenPropertiesIntoParent{}.ProcessModel(v.modelNameInput, v.modelsInput[v.modelNameInput], v.modelsInput, v.mappingsInput)
-		if err != nil {
-			if v.expectedModels == nil {
-				continue
+			actualModels, actualMappings, err := modelFlattenPropertiesIntoParent{}.ProcessModel(v.modelNameInput, v.modelsInput[v.modelNameInput], v.modelsInput, v.mappingsInput)
+			if err != nil {
+				if v.expectedModels == nil {
+					continue
+				}
+
+				t.Fatalf("error: %+v", err)
 			}
 
-			t.Fatalf("error: %+v", err)
+			modelDefinitionsMatch(t, actualModels, v.expectedModels)
+			mappingDefinitionsMatch(t, actualMappings, v.expectedMappings)
 		}
-
-		modelDefinitionsMatch(t, actualModels, v.expectedModels)
-		mappingDefinitionsMatch(t, actualMappings, v.expectedMappings)
 	}
 }

--- a/tools/importer-rest-api-specs/components/schema/processors/models_test.go
+++ b/tools/importer-rest-api-specs/components/schema/processors/models_test.go
@@ -93,7 +93,7 @@ func modelDefinitionsMatch(t *testing.T, actual *map[string]resourcemanager.Terr
 func fieldDefinitionsMatch(t *testing.T, modelName string, first map[string]resourcemanager.TerraformSchemaFieldDefinition, second map[string]resourcemanager.TerraformSchemaFieldDefinition) bool {
 	// we can't use reflect.DeepEqual since there's pointers involved, so we'll do this the old-fashioned way
 	if len(first) != len(second) {
-		t.Fatalf("model %q - first had %d fields but second had %d fields", modelName, len(first), len(second))
+		t.Fatalf("model %q - first had %d fields but second had %d fields.\nFirst: %+v\nSecond: %+v", modelName, len(first), len(second), first, second)
 		return false
 	}
 


### PR DESCRIPTION
This occurs when the map of keys hasn't been populated yet, thus depending on the ordering this may or may not get flattened, causing issues