### PR TITLE
tools/generator-go-sdk - fix predicates match condition template

### DIFF
--- a/tools/generator-go-sdk/generator/templater_predicates.go
+++ b/tools/generator-go-sdk/generator/templater_predicates.go
@@ -102,7 +102,7 @@ func (p predicateTemplater) templateForModel(predicateStructName string, name st
 
 			if fieldVal.Optional {
 				matchLines = append(matchLines, fmt.Sprintf(`
-	if p.%[1]s != nil && (input.%[1]s == nil && *p.%[1]s != *input.%[1]s) {
+	if p.%[1]s != nil && (input.%[1]s == nil || *p.%[1]s != *input.%[1]s) {
 	 	return false
 	}
 `, fieldName))


### PR DESCRIPTION
The bug lead to always return the full list for [ListCompleteMatchingPredicate](https://github.com/hashicorp/terraform-provider-azurerm/blob/34e34b59e68b91b6ec3a1ef91eb871419079a85e/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/configurationstores/method_list.go#L70) method.

https://github.com/hashicorp/terraform-provider-azurerm/blob/34e34b59e68b91b6ec3a1ef91eb871419079a85e/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/configurationstores/predicates.go#L53

Should be 
```diff
func (p ConfigurationStoreOperationPredicate) Matches(input ConfigurationStore) bool {

-	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+       if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
		return false
	}

	if p.Location != nil && *p.Location != input.Location {
		return false
	}

-	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
		return false
	}

-	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+ 	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
		return false
	}

	return true
}
```