### PR TITLE
`loadtest`: updating to use API Version `2022-12-01`

### DIFF
--- a/config/resources/loadtestservice.hcl
+++ b/config/resources/loadtestservice.hcl
@@ -1,7 +1,7 @@
 service "LoadTestService" {
   terraform_package = "loadtestservice"
 
-  api "2021-12-01-preview" {
+  api "2022-12-01" {
     package "LoadTests" {
       definition "load_test" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LoadTestService/loadTests/{loadTestName}"


### PR DESCRIPTION
This commit updates to the latest stable Api version (2022-12-01) however the `encryption` block is currently intentionally being removed due to a conflict - this will be added in the future, but is tracked in #2608

Fixes #2549