### PR TITLE
config: remove `sql` due to duplicated and differing definition of SensitivityLabelSource constant

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -472,10 +472,6 @@ service "solutions" {
   name      = "ManagedApplications"
   available = ["2019-07-01", "2021-07-01"]
 }
-service "sql" {
-  name      = "Sql"
-  available = ["2017-03-01-preview", "2018-06-01-preview", "2021-02-01-preview", "2022-11-01-preview"]
-}
 service "sqlvirtualmachine" {
   name      = "SqlVirtualMachine"
   available = ["2022-02-01"]


### PR DESCRIPTION
https://github.com/Azure/azure-rest-api-specs/blob/7349b70d60d608ea1c99b837b6372f48db1e27ac/specification/sql/resource-manager/Microsoft.Sql/preview/2021-02-01-preview/ManagedDatabaseSensitivityLabels.json#L62

https://github.com/Azure/azure-rest-api-specs/blob/7349b70d60d608ea1c99b837b6372f48db1e27ac/specification/sql/resource-manager/Microsoft.Sql/preview/2021-02-01-preview/ManagedDatabaseSensitivityLabels.json#LL391C14-L391C14

Swagger PR:
https://github.com/Azure/azure-rest-api-specs/pull/24187