### PR TITLE
tools/importer-rest-api-specs: bumping the unit test timeout to 60m

### DIFF
--- a/tools/importer-rest-api-specs/GNUmakefile
+++ b/tools/importer-rest-api-specs/GNUmakefile
@@ -23,7 +23,7 @@ import-with-api: build
 	dotnet format whitespace --verbosity quiet ../../data/Pandora.sln
 
 test: build
-	go test -v ./...
+	go test -v ./... -timeout=60m
 
 tools:
 	@echo "==> installing required tooling..."


### PR DESCRIPTION
This defaults to 10m, and there's enough data imported that we're now hitting this limit

Supersedes #2649
Fixes the test failure seen once #2648 is opened/run