### PR TITLE
importer-rest-api-specs: define common id for kubernetes cluster which is a parent resource

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
@@ -10,7 +10,7 @@ var _ commonIdMatcher = commonIdKubernetesCluster{}
 type commonIdKubernetesCluster struct{}
 
 func (c commonIdKubernetesCluster) id() models.ParsedResourceId {
-	name := "KeyVault"
+	name := "KubernetesCluster"
 	return models.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdKubernetesCluster{}
+
+type commonIdKubernetesCluster struct{}
+
+func (c commonIdKubernetesCluster) id() models.ParsedResourceId {
+	name := "KeyVault"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ContainerService"),
+			models.StaticResourceIDSegment("managedClusters", "managedClusters"),
+			models.UserSpecifiedResourceIDSegment("managedClusterName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -52,6 +52,9 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdKeyVaultKey{},
 	commonIdKeyVaultKeyVersion{},
 	commonIdKeyVaultPrivateEndpointConnection{},
+
+	// Parent IDs
+	commonIdKubernetesCluster{},
 }
 
 func switchOutCommonResourceIDsAsNeeded(input []models.ParsedResourceId) []models.ParsedResourceId {


### PR DESCRIPTION
Prerequisite for #2664