### PR TITLE
commonids: add virtual network and subnet to common_ids.go

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -20,6 +20,8 @@ var commonIdTypes = []commonIdMatcher{
 	// "Core"
 	commonIdNetworkInterface{},
 	commonIdPublicIPAddress{},
+	commonIdSubnet{},
+	commonIdVirtualNetwork{},
 	commonIdVPNConnection{},
 
 	// RP Specific


### PR DESCRIPTION
Forgot to add these to the `common_ids.go` file.