### PR TITLE
Generation support for Microsoft Graph SDK

### DIFF
--- a/data/Pandora.Api/V1/Helpers/ObjectDefinition.cs
+++ b/data/Pandora.Api/V1/Helpers/ObjectDefinition.cs
@@ -16,7 +16,8 @@ public static class ApiObjectDefinitionMapper
         var definition = new ApiObjectDefinition
         {
             ReferenceName = input.ReferenceName,
-            Type = MapApiObjectType(input.Type)
+            Type = MapApiObjectType(input.Type),
+            ReferenceIsCommonType = input.ReferenceIsCommonType,
         };
         if (input.NestedItem != null)
         {
@@ -96,6 +97,9 @@ public class ApiObjectDefinition
 
     [JsonPropertyName("referenceName")]
     public string? ReferenceName { get; set; }
+
+    [JsonPropertyName("referenceIsCommonType")]
+    public bool? ReferenceIsCommonType { get; set; }
 
     [JsonPropertyName("type")]
     public string? Type { get; set; }

--- a/data/Pandora.Data/Helpers/Type.cs
+++ b/data/Pandora.Data/Helpers/Type.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Pandora.Data.Helpers;
 
@@ -114,6 +115,16 @@ public static class TypeExtensions
             typeof(Definitions.CustomTypes.Zones),
         };
         return customTypes.Contains(input);
+    }
+
+    public static bool? IsCommonType(this Type input)
+    {
+        if (input.Namespace == null)
+        {
+            return null;
+        }
+
+        return input.Namespace.EndsWith(".CommonTypes") || input.Namespace.Contains(".CommonTypes.");
     }
 
     internal static bool HasAttribute<T>(this MemberInfo info) where T : Attribute

--- a/data/Pandora.Data/Models/ObjectDefinition.cs
+++ b/data/Pandora.Data/Models/ObjectDefinition.cs
@@ -6,6 +6,8 @@ public class ObjectDefinition
 
     public string? ReferenceName { get; set; }
 
+    public bool? ReferenceIsCommonType { get; set; }
+
     public ObjectDefinition? NestedItem { get; set; }
 
     // Minimum is the minimum number of items which must be specified when this is a Dictionary/List element, if specified

--- a/data/Pandora.Data/Transformers/ObjectDefinition.cs
+++ b/data/Pandora.Data/Transformers/ObjectDefinition.cs
@@ -77,6 +77,7 @@ public static class ObjectDefinition
         {
             Type = ObjectType.Reference,
             ReferenceName = responseObjectName,
+            ReferenceIsCommonType = input.IsCommonType(),
         };
     }
 

--- a/tools/generator-go-sdk/generator/common_types.go
+++ b/tools/generator-go-sdk/generator/common_types.go
@@ -1,0 +1,128 @@
+package generator
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+	"github.com/hashicorp/pandora/tools/sdk/services"
+)
+
+type CommonTypesGenerator struct{}
+
+func NewCommonTypesGenerator() CommonTypesGenerator {
+	return CommonTypesGenerator{}
+}
+
+type SDKInput struct {
+	CommonPackageName         string
+	CommonPackageRelativePath string
+	CommonTypes               *services.ResourceManagerCommonTypes
+	OutputSubDirectoryName    string
+	OutputDirectoryPath       string
+	VersionName               string
+}
+
+func (s *CommonTypesGenerator) GenerateForSDK(input SDKInput) error {
+	input.VersionName = strings.ToLower(input.VersionName)
+	commonTypesDirectory := filepath.Join(input.OutputDirectoryPath, input.CommonPackageRelativePath)
+
+	if err := cleanAndRecreateWorkingDirectory(commonTypesDirectory); err != nil {
+		return fmt.Errorf("cleaning/recreating working directory %q: %+v", commonTypesDirectory, err)
+	}
+
+	stages := map[string]func(SDKInput, string) error{
+		"commonTypes": s.commonTypes,
+		"predicates":  s.predicates,
+	}
+	for name, stage := range stages {
+		log.Printf("[DEBUG] Running Stage %q..", name)
+		if err := stage(input, commonTypesDirectory); err != nil {
+			return fmt.Errorf("generating %s: %+v", name, err)
+		}
+	}
+
+	runGoFmt(commonTypesDirectory)
+	runGoImports(commonTypesDirectory)
+	return nil
+}
+
+func (s *CommonTypesGenerator) commonTypes(input SDKInput, outputDirectory string) error {
+	data := ServiceGeneratorData{
+		apiVersion:  input.VersionName,
+		constants:   input.CommonTypes.Constants,
+		models:      input.CommonTypes.Models,
+		packageName: "models",
+		source:      resourcemanager.ApiDefinitionsSourceMicrosoftGraphMetadata,
+	}
+
+	for constantName, constant := range input.CommonTypes.Constants {
+		fileName := fmt.Sprintf("constant_%s.go", strings.ToLower(constantName))
+		gen := constantTemplater{
+			name:    constantName,
+			details: constant,
+		}
+		if err := s.writeToPath(outputDirectory, fileName, gen, data); err != nil {
+			return fmt.Errorf("templating constant for %q: %+v", constantName, err)
+		}
+	}
+
+	for modelName, model := range input.CommonTypes.Models {
+		fileName := fmt.Sprintf("model_%s.go", strings.ToLower(modelName))
+		gen := modelsTemplater{
+			name:  modelName,
+			model: model,
+		}
+		if err := s.writeToPath(outputDirectory, fileName, gen, data); err != nil {
+			return fmt.Errorf("templating model for %q: %+v", modelName, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *CommonTypesGenerator) predicates(input SDKInput, outputDirectory string) error {
+	data := ServiceGeneratorData{
+		apiVersion:  input.VersionName,
+		constants:   input.CommonTypes.Constants,
+		models:      input.CommonTypes.Models,
+		packageName: "models",
+		source:      resourcemanager.ApiDefinitionsSourceMicrosoftGraphMetadata,
+	}
+
+	for modelName := range input.CommonTypes.Models {
+		fileName := fmt.Sprintf("predicates_%s.go", strings.ToLower(modelName))
+		gen := predicateTemplater{
+			sortedModelNames: []string{modelName},
+			models:           input.CommonTypes.Models,
+		}
+		if err := s.writeToPath(outputDirectory, fileName, gen, data); err != nil {
+			return fmt.Errorf("templating model predicates for %q: %+v", modelName, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *CommonTypesGenerator) writeToPath(directory, filePath string, templater templaterForResource, data ServiceGeneratorData) error {
+	fileContents, err := templater.template(data)
+	if err != nil {
+		return fmt.Errorf("templating: %+v", err)
+	}
+
+	fullFilePath := filepath.Join(directory, filePath)
+
+	// remove any existing file if it exists
+	_ = os.Remove(fullFilePath)
+	file, err := os.Create(fullFilePath)
+	defer file.Close()
+	if err != nil {
+		return fmt.Errorf("opening %q: %+v", fullFilePath, err)
+	}
+
+	_, _ = file.WriteString(*fileContents)
+	return nil
+}

--- a/tools/generator-go-sdk/generator/data.go
+++ b/tools/generator-go-sdk/generator/data.go
@@ -56,36 +56,41 @@ type ServiceGeneratorData struct {
 	// rather than the existing Autorest base layer?
 	useNewBaseLayer bool
 
-	baseClientMethod  string
-	baseClientPackage string
+	baseClientMethod        string
+	baseClientPackage       string
+	commonPackageName       string
+	commonPackageImportPath string
 }
 
 func (i ServiceGeneratorInput) generatorData(settings Settings) ServiceGeneratorData {
-	servicePackageName := golangPackageName(i.ServiceName)
-	versionPackageName := golangPackageName(i.VersionName)
+	servicePackageName := GolangPackageName(i.ServiceName)
+	versionPackageName := GolangPackageName(i.VersionName)
 	// TODO: it'd be nice to make these snake_case but that's a problem for another day
-	resourcePackageName := golangPackageName(i.ResourceName)
-	versionOutputPath := filepath.Join(i.OutputDirectory, servicePackageName, versionPackageName)
+	resourcePackageName := GolangPackageName(i.ResourceName)
+	versionOutputPath := filepath.Join(i.OutputDirectoryPath, servicePackageName, versionPackageName)
 	resourceOutputPath := filepath.Join(versionOutputPath, resourcePackageName)
 	idsPath := filepath.Join(versionOutputPath, "ids")
+	commonPackageImportPath := fmt.Sprintf("%s/%s", i.OutputSubDirectoryName, i.CommonPackageRelativePath)
 
 	useNewBaseLayer := settings.ShouldUseNewBaseLayer(i.ServiceName, i.VersionName)
 
 	return ServiceGeneratorData{
-		apiVersion:         i.VersionName,
-		baseClientMethod:   i.BaseClientMethod,
-		baseClientPackage:  i.BaseClientPackage,
-		constants:          i.ResourceDetails.Schema.Constants,
-		idsOutputPath:      idsPath,
-		models:             i.ResourceDetails.Schema.Models,
-		operations:         i.ResourceDetails.Operations.Operations,
-		resourceOutputPath: resourceOutputPath,
-		packageName:        resourcePackageName,
-		resourceIds:        i.ResourceDetails.Schema.ResourceIds,
-		serviceClientName:  fmt.Sprintf("%sClient", strings.Title(i.ResourceName)),
-		servicePackageName: strings.ToLower(i.ServiceName),
-		source:             i.Source,
-		useIdAliases:       false,
-		useNewBaseLayer:    useNewBaseLayer,
+		apiVersion:              i.VersionName,
+		baseClientMethod:        i.BaseClientMethod,
+		baseClientPackage:       i.BaseClientPackage,
+		commonPackageName:       i.CommonPackageName,
+		commonPackageImportPath: commonPackageImportPath,
+		constants:               i.ResourceDetails.Schema.Constants,
+		idsOutputPath:           idsPath,
+		models:                  i.ResourceDetails.Schema.Models,
+		operations:              i.ResourceDetails.Operations.Operations,
+		resourceOutputPath:      resourceOutputPath,
+		packageName:             resourcePackageName,
+		resourceIds:             i.ResourceDetails.Schema.ResourceIds,
+		serviceClientName:       fmt.Sprintf("%sClient", strings.Title(i.ResourceName)),
+		servicePackageName:      strings.ToLower(i.ServiceName),
+		source:                  i.Source,
+		useIdAliases:            false,
+		useNewBaseLayer:         useNewBaseLayer,
 	}
 }

--- a/tools/generator-go-sdk/generator/data.go
+++ b/tools/generator-go-sdk/generator/data.go
@@ -48,6 +48,18 @@ type ServiceGeneratorData struct {
 	// the name of the service as a package (e.g. resources or eventhub)
 	servicePackageName string
 
+	// baseClientMethod is the go function for instantiating the particular base client
+	baseClientMethod string
+
+	// baseClientPackage is the go package where the base client can be found
+	baseClientPackage string
+
+	// commonPackageName is the go package containing common types (models, constants, predicates)
+	commonPackageName string
+
+	// commonPackageImportPath is the go import path where common types can be found
+	commonPackageImportPath string
+
 	// development feature flag - this requires work in the Resource ID parser to handle name conflicts
 	// @tombuildsstuff: fix this
 	useIdAliases bool
@@ -55,18 +67,13 @@ type ServiceGeneratorData struct {
 	// development feature flag - should this service use the new transport layer from `hashicorp/go-azure-sdk`
 	// rather than the existing Autorest base layer?
 	useNewBaseLayer bool
-
-	baseClientMethod        string
-	baseClientPackage       string
-	commonPackageName       string
-	commonPackageImportPath string
 }
 
 func (i ServiceGeneratorInput) generatorData(settings Settings) ServiceGeneratorData {
-	servicePackageName := GolangPackageName(i.ServiceName)
-	versionPackageName := GolangPackageName(i.VersionName)
+	servicePackageName := golangPackageName(i.ServiceName)
+	versionPackageName := golangPackageName(i.VersionName)
 	// TODO: it'd be nice to make these snake_case but that's a problem for another day
-	resourcePackageName := GolangPackageName(i.ResourceName)
+	resourcePackageName := golangPackageName(i.ResourceName)
 	versionOutputPath := filepath.Join(i.OutputDirectoryPath, servicePackageName, versionPackageName)
 	resourceOutputPath := filepath.Join(versionOutputPath, resourcePackageName)
 	idsPath := filepath.Join(versionOutputPath, "ids")

--- a/tools/generator-go-sdk/generator/data.go
+++ b/tools/generator-go-sdk/generator/data.go
@@ -55,13 +55,16 @@ type ServiceGeneratorData struct {
 	// development feature flag - should this service use the new transport layer from `hashicorp/go-azure-sdk`
 	// rather than the existing Autorest base layer?
 	useNewBaseLayer bool
+
+	baseClientMethod  string
+	baseClientPackage string
 }
 
 func (i ServiceGeneratorInput) generatorData(settings Settings) ServiceGeneratorData {
-	servicePackageName := strings.ToLower(i.ServiceName)
-	versionPackageName := strings.ToLower(i.VersionName)
+	servicePackageName := golangPackageName(i.ServiceName)
+	versionPackageName := golangPackageName(i.VersionName)
 	// TODO: it'd be nice to make these snake_case but that's a problem for another day
-	resourcePackageName := strings.ToLower(i.ResourceName)
+	resourcePackageName := golangPackageName(i.ResourceName)
 	versionOutputPath := filepath.Join(i.OutputDirectory, servicePackageName, versionPackageName)
 	resourceOutputPath := filepath.Join(versionOutputPath, resourcePackageName)
 	idsPath := filepath.Join(versionOutputPath, "ids")
@@ -70,6 +73,8 @@ func (i ServiceGeneratorInput) generatorData(settings Settings) ServiceGenerator
 
 	return ServiceGeneratorData{
 		apiVersion:         i.VersionName,
+		baseClientMethod:   i.BaseClientMethod,
+		baseClientPackage:  i.BaseClientPackage,
 		constants:          i.ResourceDetails.Schema.Constants,
 		idsOutputPath:      idsPath,
 		models:             i.ResourceDetails.Schema.Models,

--- a/tools/generator-go-sdk/generator/helpers.go
+++ b/tools/generator-go-sdk/generator/helpers.go
@@ -109,7 +109,7 @@ func golangTypeNameForConstantType(input resourcemanager.ConstantType) (*string,
 	return &segmentType, nil
 }
 
-func GolangPackageName(input string) (output string) {
+func golangPackageName(input string) (output string) {
 	output = input
 	output = regexp.MustCompile("[^0-9A-z-]").ReplaceAllString(output, "_")
 	output = strings.ToLower(output)

--- a/tools/generator-go-sdk/generator/helpers.go
+++ b/tools/generator-go-sdk/generator/helpers.go
@@ -109,14 +109,14 @@ func golangTypeNameForConstantType(input resourcemanager.ConstantType) (*string,
 	return &segmentType, nil
 }
 
-func golangPackageName(input string) (output string) {
+func GolangPackageName(input string) (output string) {
 	output = input
 	output = regexp.MustCompile("[^0-9A-z-]").ReplaceAllString(output, "_")
 	output = strings.ToLower(output)
 	return
 }
 
-func golangPackageNameForVersion(input string) (output string) {
+func GolangPackageNameForVersion(input string) (output string) {
 	output = input
 	output = regexp.MustCompile("[^0-9A-z]").ReplaceAllString(output, "_")
 	output = strings.ToLower(output)

--- a/tools/generator-go-sdk/generator/helpers_test.go
+++ b/tools/generator-go-sdk/generator/helpers_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -16,32 +17,30 @@ func assertTemplatedCodeMatches(t *testing.T, expected string, actual string) {
 	actualLines := splitLines(actual)
 	expectedLines := splitLines(expected)
 
-	normalizedActualValue := strings.Join(actualLines, "\n")
-	normalizedExpectedValue := strings.Join(expectedLines, "\n")
+	normalizedActualValue := strings.Join(numberLines(actualLines), "\n")
+	normalizedExpectedValue := strings.Join(numberLines(expectedLines), "\n")
 
-	if len(actualLines) != len(expectedLines) {
-		t.Fatalf(`Expected %d lines but got %d lines.
+	actualLen := len(actualLines)
+	expectedLen := len(expectedLines)
 
-Expected Value:
----
-%s
----
-
-Actual Value:
----
-%s
----
-`, len(expectedLines), len(actualLines), normalizedExpectedValue, normalizedActualValue)
+	if actualLen != expectedLen {
+		t.Errorf("Expected %d lines but got %d lines.", len(expectedLines), len(actualLines))
 	}
 
 	for i := 0; i < len(actualLines); i++ {
 		actualLine := actualLines[i]
-		expectedLine := expectedLines[i]
-		if !strings.EqualFold(strings.TrimSpace(actualLine), strings.TrimSpace(expectedLine)) {
-			t.Fatalf(`Expected and Actual differ on line %d
 
-Expected %q but got %q
+		if expectedLen <= i {
+			t.Errorf("Actual ends at line %d", expectedLen)
+			break
+		} else if expectedLine := expectedLines[i]; !strings.EqualFold(strings.TrimSpace(actualLine), strings.TrimSpace(expectedLine)) {
+			t.Errorf("Expected and Actual differ on line %d\nExpected %q but got %q", i+1, expectedLine, actualLine)
+			break
+		}
+	}
 
+	if t.Failed() {
+		t.Fatalf(`
 Expected Value:
 ---
 %s
@@ -51,8 +50,7 @@ Actual Value:
 ---
 %s
 ---
-`, i, expectedLine, actualLine, normalizedExpectedValue, normalizedActualValue)
-		}
+`, normalizedExpectedValue, normalizedActualValue)
 	}
 }
 
@@ -68,6 +66,14 @@ func splitLines(input string) []string {
 		}
 
 		out = append(out, line)
+	}
+	return out
+}
+
+func numberLines(input []string) []string {
+	out := make([]string, len(input))
+	for n := range input {
+		out[n] = fmt.Sprintf("%d\t%s", n+1, input[n])
 	}
 	return out
 }

--- a/tools/generator-go-sdk/generator/meta_client.go
+++ b/tools/generator-go-sdk/generator/meta_client.go
@@ -12,10 +12,12 @@ func (s *ServiceGenerator) metaClient(data VersionInput, versionDirectory string
 	var templater templaterForVersion
 	if data.UseNewBaseLayer {
 		templater = metaClientTemplater{
-			serviceName: data.ServiceName,
-			apiVersion:  data.VersionName,
-			resources:   data.Resources,
-			source:      data.Source,
+			serviceName:       data.ServiceName,
+			apiVersion:        data.VersionName,
+			baseClientPackage: data.BaseClientPackage,
+			sdkPackage:        data.SdkPackage,
+			resources:         data.Resources,
+			source:            data.Source,
 		}
 	} else {
 		templater = metaClientAutorestTemplater{

--- a/tools/generator-go-sdk/generator/object_definition.go
+++ b/tools/generator-go-sdk/generator/object_definition.go
@@ -4,10 +4,14 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func golangTypeNameForObjectDefinition(input resourcemanager.ApiObjectDefinition) (*string, error) {
-	// NOTE: since all the models are generated into the same Namespace in the Go SDK
-	// we don't need to pass the Package Name in (this is instead used in the TF Generator
-	// where we're instead importing items from the Go SDK).
+func golangTypeNameForObjectDefinition(input resourcemanager.ApiObjectDefinition, commonPackagePath *string) (*string, error) {
+	// NOTE: The models can be generated into the same Namespace in the Go SDK, or in a "common" namespace,
+	// so we'll determine that based on the object definition from the API. Where the same namespace is used,
+	// we don't need to pass the Package Name in (this is instead used in the TF Generator where we're importing
+	// types from the Go SDK).
+	if input.ReferenceIsCommonType != nil && *input.ReferenceIsCommonType {
+		return input.GolangTypeName(commonPackagePath)
+	}
 	return input.GolangTypeName(nil)
 }
 

--- a/tools/generator-go-sdk/generator/service.go
+++ b/tools/generator-go-sdk/generator/service.go
@@ -23,16 +23,19 @@ func NewServiceGenerator(settings Settings) ServiceGenerator {
 }
 
 type ServiceGeneratorInput struct {
-	ServiceName       string
-	ServiceDetails    services.ResourceManagerService
-	VersionName       string
-	VersionDetails    services.ServiceVersion
-	ResourceName      string
-	ResourceDetails   services.Resource
-	BaseClientMethod  string
-	BaseClientPackage string
-	OutputDirectory   string
-	Source            resourcemanager.ApiDefinitionsSource
+	ServiceName               string
+	ServiceDetails            services.ResourceManagerService
+	VersionName               string
+	VersionDetails            services.ServiceVersion
+	ResourceName              string
+	ResourceDetails           services.Resource
+	BaseClientMethod          string
+	BaseClientPackage         string
+	CommonPackageName         string
+	CommonPackageRelativePath string
+	OutputDirectoryPath       string
+	OutputSubDirectoryName    string
+	Source                    resourcemanager.ApiDefinitionsSource
 }
 
 func (s *ServiceGenerator) Generate(input ServiceGeneratorInput) error {
@@ -84,7 +87,7 @@ type VersionInput struct {
 func (s *ServiceGenerator) GenerateForVersion(input VersionInput) error {
 	input.ServiceName = strings.ToLower(input.ServiceName)
 	input.VersionName = strings.ToLower(input.VersionName)
-	versionDirectory := filepath.Join(input.OutputDirectory, golangPackageName(input.ServiceName), golangPackageName(input.VersionName))
+	versionDirectory := filepath.Join(input.OutputDirectory, GolangPackageName(input.ServiceName), GolangPackageName(input.VersionName))
 
 	stages := map[string]func(data VersionInput, versionDirectory string) error{
 		"metaClient": s.metaClient,

--- a/tools/generator-go-sdk/generator/service.go
+++ b/tools/generator-go-sdk/generator/service.go
@@ -87,7 +87,7 @@ type VersionInput struct {
 func (s *ServiceGenerator) GenerateForVersion(input VersionInput) error {
 	input.ServiceName = strings.ToLower(input.ServiceName)
 	input.VersionName = strings.ToLower(input.VersionName)
-	versionDirectory := filepath.Join(input.OutputDirectory, GolangPackageName(input.ServiceName), GolangPackageName(input.VersionName))
+	versionDirectory := filepath.Join(input.OutputDirectory, golangPackageName(input.ServiceName), golangPackageName(input.VersionName))
 
 	stages := map[string]func(data VersionInput, versionDirectory string) error{
 		"metaClient": s.metaClient,

--- a/tools/generator-go-sdk/generator/service.go
+++ b/tools/generator-go-sdk/generator/service.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
-
 	"github.com/hashicorp/pandora/tools/sdk/services"
 )
 
@@ -24,14 +23,16 @@ func NewServiceGenerator(settings Settings) ServiceGenerator {
 }
 
 type ServiceGeneratorInput struct {
-	ServiceName     string
-	ServiceDetails  services.ResourceManagerService
-	VersionName     string
-	VersionDetails  services.ServiceVersion
-	ResourceName    string
-	ResourceDetails services.Resource
-	OutputDirectory string
-	Source          resourcemanager.ApiDefinitionsSource
+	ServiceName       string
+	ServiceDetails    services.ResourceManagerService
+	VersionName       string
+	VersionDetails    services.ServiceVersion
+	ResourceName      string
+	ResourceDetails   services.Resource
+	BaseClientMethod  string
+	BaseClientPackage string
+	OutputDirectory   string
+	Source            resourcemanager.ApiDefinitionsSource
 }
 
 func (s *ServiceGenerator) Generate(input ServiceGeneratorInput) error {
@@ -70,18 +71,20 @@ func (s *ServiceGenerator) Generate(input ServiceGeneratorInput) error {
 }
 
 type VersionInput struct {
-	OutputDirectory string
-	Resources       map[string]services.Resource
-	ServiceName     string
-	Source          resourcemanager.ApiDefinitionsSource
-	UseNewBaseLayer bool
-	VersionName     string
+	OutputDirectory   string
+	Resources         map[string]services.Resource
+	ServiceName       string
+	Source            resourcemanager.ApiDefinitionsSource
+	UseNewBaseLayer   bool
+	BaseClientPackage string
+	SdkPackage        string
+	VersionName       string
 }
 
 func (s *ServiceGenerator) GenerateForVersion(input VersionInput) error {
 	input.ServiceName = strings.ToLower(input.ServiceName)
 	input.VersionName = strings.ToLower(input.VersionName)
-	versionDirectory := filepath.Join(input.OutputDirectory, input.ServiceName, input.VersionName)
+	versionDirectory := filepath.Join(input.OutputDirectory, golangPackageName(input.ServiceName), golangPackageName(input.VersionName))
 
 	stages := map[string]func(data VersionInput, versionDirectory string) error{
 		"metaClient": s.metaClient,

--- a/tools/generator-go-sdk/generator/stage_models.go
+++ b/tools/generator-go-sdk/generator/stage_models.go
@@ -14,7 +14,7 @@ func (s *ServiceGenerator) models(data ServiceGeneratorData) error {
 		// model_{name}.go
 		// arguably we could enhance this to make `MyThing` be `my_thing` but this is fine for now
 		fileName := fmt.Sprintf("model_%s.go", strings.ToLower(modelName))
-		gen := modelsTemplater{
+		gen := modelTemplater{
 			name:  modelName,
 			model: model,
 		}

--- a/tools/generator-go-sdk/generator/stage_predicates.go
+++ b/tools/generator-go-sdk/generator/stage_predicates.go
@@ -39,7 +39,7 @@ func (s *ServiceGenerator) predicates(data ServiceGeneratorData) error {
 		return nil
 	}
 
-	templater := predicateTemplater{
+	templater := predicatesTemplater{
 		sortedModelNames: sortedModelNames,
 		models:           data.models,
 	}

--- a/tools/generator-go-sdk/generator/stage_predicates.go
+++ b/tools/generator-go-sdk/generator/stage_predicates.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *ServiceGenerator) predicates(data ServiceGeneratorData) error {
-	modelNames := make(map[string]struct{}, 0)
+	modelNames := make(map[string]struct{})
 	for _, operation := range data.operations {
 		if operation.FieldContainingPaginationDetails == nil {
 			continue
@@ -20,7 +20,13 @@ func (s *ServiceGenerator) predicates(data ServiceGeneratorData) error {
 			continue
 		}
 
-		modelNames[*operation.ResponseObject.ReferenceName] = struct{}{}
+		modelName := *operation.ResponseObject.ReferenceName
+
+		if _, ok := data.models[modelName]; !ok {
+			continue
+		}
+
+		modelNames[modelName] = struct{}{}
 	}
 
 	sortedModelNames := make([]string, 0)

--- a/tools/generator-go-sdk/generator/templater_clients.go
+++ b/tools/generator-go-sdk/generator/templater_clients.go
@@ -16,18 +16,19 @@ func (c clientsTemplater) template(data ServiceGeneratorData) (*string, error) {
 	template := fmt.Sprintf(`package %[1]s
 
 import (
-	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/%[4]s"
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 )
 
 %[3]s
 
 type %[2]s struct {
-	Client  *resourcemanager.Client
+	Client  *%[4]s.Client
 }
 
-func New%[2]sWithBaseURI(sdkApi sdkEnv.Api) (*%[2]s, error) {
-	client, err := resourcemanager.NewResourceManagerClient(sdkApi, %[1]q, defaultApiVersion)
+func New%[2]sWithBaseURI(api sdkEnv.Api) (*%[2]s, error) {
+	client, err := %[4]s.%[5]s(api, %[1]q, defaultApiVersion)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating %[2]s: %%+v", err)
 	}
@@ -35,6 +36,6 @@ func New%[2]sWithBaseURI(sdkApi sdkEnv.Api) (*%[2]s, error) {
 	return &%[2]s{
 		Client: client,
 	}, nil
-}`, data.packageName, data.serviceClientName, *copyrightLines)
+}`, data.packageName, data.serviceClientName, *copyrightLines, data.baseClientPackage, data.baseClientMethod)
 	return &template, nil
 }

--- a/tools/generator-go-sdk/generator/templater_clients.go
+++ b/tools/generator-go-sdk/generator/templater_clients.go
@@ -18,7 +18,6 @@ func (c clientsTemplater) template(data ServiceGeneratorData) (*string, error) {
 import (
 	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/%[4]s"
-	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 )
 
 %[3]s

--- a/tools/generator-go-sdk/generator/templater_clients_test.go
+++ b/tools/generator-go-sdk/generator/templater_clients_test.go
@@ -6,6 +6,8 @@ import (
 
 func TestTemplateClient(t *testing.T) {
 	input := ServiceGeneratorData{
+		baseClientPackage: "baseClient",
+		baseClientMethod:  "NewBaseClient",
 		packageName:       "somepackage",
 		serviceClientName: "ExampleClient",
 		source:            AccTestLicenceType,
@@ -19,18 +21,18 @@ func TestTemplateClient(t *testing.T) {
 	expected := `package somepackage
 
 import (
-	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/baseClient"
 )
 
 // acctests licence placeholder
 
 type ExampleClient struct {
-	Client  *resourcemanager.Client
+	Client  *baseClient.Client
 }
 
-func NewExampleClientWithBaseURI(sdkApi sdkEnv.Api) (*ExampleClient, error) {
-	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "somepackage", defaultApiVersion)
+func NewExampleClientWithBaseURI(api sdkEnv.Api) (*ExampleClient, error) {
+	client, err := baseClient.NewBaseClient(api, "somepackage", defaultApiVersion)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating ExampleClient: %+v", err)
 	}

--- a/tools/generator-go-sdk/generator/templater_constant.go
+++ b/tools/generator-go-sdk/generator/templater_constant.go
@@ -157,7 +157,7 @@ func PossibleValuesFor%[1]s() []%[2]s {
 }
 
 func (t constantTemplater) parseFunction() (*string, error) {
-	// we only output the parse function if it's a String constant (in which case it'll be needed by the Normalizaation function)
+	// we only output the parse function if it's a String constant (in which case it'll be needed by the Normalization function)
 	// or if the Constant is used in a Resource ID segment (since that calls this to parse the Resource ID segment)
 	// we could output this always, but this reduces the TLOC we output, which is preferable.
 	requiresParseFunction := t.details.Type == resourcemanager.StringConstant || t.constantUsedInAResourceID

--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -37,7 +37,7 @@ func (m metaClientTemplater) template() (*string, error) {
 	for _, resourceName := range resourceNames {
 		variableName := fmt.Sprintf("%s%sClient", strings.ToLower(string(resourceName[0])), resourceName[1:])
 
-		imports = append(imports, fmt.Sprintf(`"github.com/hashicorp/go-azure-sdk/%s/%s/%s/%s"`, m.sdkPackage, GolangPackageName(m.serviceName), GolangPackageName(m.apiVersion), GolangPackageName(resourceName)))
+		imports = append(imports, fmt.Sprintf(`"github.com/hashicorp/go-azure-sdk/%s/%s/%s/%s"`, m.sdkPackage, golangPackageName(m.serviceName), golangPackageName(m.apiVersion), golangPackageName(resourceName)))
 		fields = append(fields, fmt.Sprintf("%[1]s *%[2]s.%[1]sClient", resourceName, strings.ToLower(resourceName)))
 		clientInitializationTemplate := fmt.Sprintf(`%[1]s, err := %[2]s.New%[3]sClientWithBaseURI(sdkApi)
 if err != nil {

--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -37,7 +37,7 @@ func (m metaClientTemplater) template() (*string, error) {
 	for _, resourceName := range resourceNames {
 		variableName := fmt.Sprintf("%s%sClient", strings.ToLower(string(resourceName[0])), resourceName[1:])
 
-		imports = append(imports, fmt.Sprintf(`"github.com/hashicorp/go-azure-sdk/%s/%s/%s/%s"`, m.sdkPackage, golangPackageName(m.serviceName), golangPackageName(m.apiVersion), golangPackageName(resourceName)))
+		imports = append(imports, fmt.Sprintf(`"github.com/hashicorp/go-azure-sdk/%s/%s/%s/%s"`, m.sdkPackage, GolangPackageName(m.serviceName), GolangPackageName(m.apiVersion), GolangPackageName(resourceName)))
 		fields = append(fields, fmt.Sprintf("%[1]s *%[2]s.%[1]sClient", resourceName, strings.ToLower(resourceName)))
 		clientInitializationTemplate := fmt.Sprintf(`%[1]s, err := %[2]s.New%[3]sClientWithBaseURI(sdkApi)
 if err != nil {
@@ -54,7 +54,7 @@ configureFunc(%[1]s.Client)
 	sort.Strings(fields)
 	sort.Strings(imports)
 
-	packageName := golangPackageNameForVersion(m.apiVersion)
+	packageName := GolangPackageNameForVersion(m.apiVersion)
 
 	out := fmt.Sprintf(`package %[1]s
 

--- a/tools/generator-go-sdk/generator/templater_methods.go
+++ b/tools/generator-go-sdk/generator/templater_methods.go
@@ -40,12 +40,13 @@ import (
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+    "github.com/hashicorp/go-azure-sdk/%[4]s"
 )
 
 %[2]s
 
 %[3]s
-`, data.packageName, *copyrightLines, *methods)
+`, data.packageName, *copyrightLines, *methods, data.commonPackageImportPath)
 	return &template, nil
 }
 
@@ -288,7 +289,7 @@ func (c methodsPandoraTemplater) listOperationTemplate(data ServiceGeneratorData
 	if err != nil {
 		return nil, fmt.Errorf("building options struct: %+v", err)
 	}
-	typeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject)
+	typeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject, &data.commonPackageName)
 	if err != nil {
 		return nil, fmt.Errorf("determining golang type name for response object: %+v", err)
 	}
@@ -453,7 +454,7 @@ func (c methodsPandoraTemplater) argumentsTemplateForMethod(data ServiceGenerato
 		arguments = append(arguments, fmt.Sprintf("id %s", idName))
 	}
 	if c.operation.RequestObject != nil {
-		typeName, err := golangTypeNameForObjectDefinition(*c.operation.RequestObject)
+		typeName, err := golangTypeNameForObjectDefinition(*c.operation.RequestObject, &data.commonPackageName)
 		if err != nil {
 			return nil, fmt.Errorf("determining type name for request object: %+v", err)
 		}
@@ -531,7 +532,7 @@ func (c methodsPandoraTemplater) marshalerTemplate() (*string, error) {
 func (c methodsPandoraTemplater) unmarshalerTemplate(data ServiceGeneratorData) (*string, error) {
 	var output string
 	if c.operation.ResponseObject != nil {
-		golangTypeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject)
+		golangTypeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject, &data.commonPackageName)
 		if err != nil {
 			return nil, fmt.Errorf("determing golang type name for response object: %+v", err)
 		}
@@ -593,7 +594,7 @@ func (c methodsPandoraTemplater) responseStructTemplate(data ServiceGeneratorDat
 	model := ""
 	typeName := ""
 	if c.operation.ResponseObject != nil {
-		golangTypeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject)
+		golangTypeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject, &data.commonPackageName)
 		if err != nil {
 			return nil, fmt.Errorf("determing golang type name for response object: %+v", err)
 		}
@@ -655,7 +656,7 @@ func (c methodsPandoraTemplater) optionsStruct(data ServiceGeneratorData) (*stri
 	headerAssignments := make([]string, 0)
 
 	for optionName, option := range c.operation.Options {
-		optionType, err := golangTypeNameForObjectDefinition(option.ObjectDefinition)
+		optionType, err := golangTypeNameForObjectDefinition(option.ObjectDefinition, &data.commonPackageName)
 		if err != nil {
 			return nil, fmt.Errorf("determining golang type name for option %q's ObjectDefinition: %+v", optionName, err)
 		}

--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -49,15 +49,15 @@ import (
 	"github.com/hashicorp/go-azure-sdk/%[4]s"
 )
 
-%s
+%[2]s
 
-%s
+%[3]s
 `, data.packageName, *copyrightLines, *methods, data.commonPackageImportPath)
 	return &template, nil
 }
 
 func (c methodsAutoRestTemplater) methods(data ServiceGeneratorData) (*string, error) {
-	// NOTE: most of this logic is sanity checking, but should be within the API and it's validators too
+	// NOTE: most of this logic is sanity checking, but should be within the API and it's validators too.
 	// that could be a separate validation tool, but this would be most useful as unit tests
 
 	switch strings.ToUpper(c.operation.Method) {

--- a/tools/generator-go-sdk/generator/templater_methods_autorest.go
+++ b/tools/generator-go-sdk/generator/templater_methods_autorest.go
@@ -46,12 +46,13 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/polling"
+	"github.com/hashicorp/go-azure-sdk/%[4]s"
 )
 
 %s
 
 %s
-`, data.packageName, *copyrightLines, *methods)
+`, data.packageName, *copyrightLines, *methods, data.commonPackageImportPath)
 	return &template, nil
 }
 
@@ -224,7 +225,7 @@ func (c methodsAutoRestTemplater) listOperationTemplate(data ServiceGeneratorDat
 	if err != nil {
 		return nil, fmt.Errorf("building responder template: %+v", err)
 	}
-	typeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject)
+	typeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject, &data.commonPackageName)
 	if err != nil {
 		return nil, fmt.Errorf("determining golang type name for response object: %+v", err)
 	}
@@ -449,7 +450,7 @@ func (c methodsAutoRestTemplater) argumentsTemplateForMethod(data ServiceGenerat
 		arguments = append(arguments, fmt.Sprintf("id %s", idName))
 	}
 	if c.operation.RequestObject != nil {
-		typeName, err := golangTypeNameForObjectDefinition(*c.operation.RequestObject)
+		typeName, err := golangTypeNameForObjectDefinition(*c.operation.RequestObject, &data.commonPackageName)
 		if err != nil {
 			return nil, fmt.Errorf("determining type name for request object: %+v", err)
 		}
@@ -601,7 +602,7 @@ func (c methodsAutoRestTemplater) responderTemplate(responseStructName string, d
 	steps = append(steps, "autorest.ByClosing()")
 
 	if c.operation.FieldContainingPaginationDetails != nil && discriminatedType == "" {
-		typeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject)
+		typeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject, &data.commonPackageName)
 		if err != nil {
 			return nil, fmt.Errorf("determining golang type name for response object: %+v", err)
 		}
@@ -653,7 +654,7 @@ func (c %[1]s) responderFor%[2]s(resp *http.Response) (result %[6]s, err error) 
 	}
 
 	if discriminatedType != "" && c.operation.FieldContainingPaginationDetails != nil {
-		typeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject)
+		typeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject, &data.commonPackageName)
 		if err != nil {
 			return nil, fmt.Errorf("determining golang type name for response object: %+v", err)
 		}
@@ -768,7 +769,7 @@ func (c methodsAutoRestTemplater) responseStructTemplate(responseStructName stri
 	model := ""
 	typeName := ""
 	if c.operation.ResponseObject != nil {
-		golangTypeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject)
+		golangTypeName, err := golangTypeNameForObjectDefinition(*c.operation.ResponseObject, nil) // TODO package path
 		if err != nil {
 			return nil, fmt.Errorf("determing golang type name for response object: %+v", err)
 		}
@@ -869,7 +870,7 @@ func (c methodsAutoRestTemplater) optionsStruct(data ServiceGeneratorData) (*str
 	headerAssignments := make([]string, 0)
 
 	for optionName, option := range c.operation.Options {
-		optionType, err := golangTypeNameForObjectDefinition(option.ObjectDefinition)
+		optionType, err := golangTypeNameForObjectDefinition(option.ObjectDefinition, &data.commonPackageName)
 		if err != nil {
 			return nil, fmt.Errorf("determining golang type name for option %q's ObjectDefinition: %+v", optionName, err)
 		}

--- a/tools/generator-go-sdk/generator/templater_methods_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_test.go
@@ -442,9 +442,10 @@ func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, id Panda
 
 func TestTemplateMethodsTopLevelDiscriminatorReferencingParentType(t *testing.T) {
 	input := ServiceGeneratorData{
-		packageName:       "chubbypandas",
-		serviceClientName: "pandaClient",
-		source:            AccTestLicenceType,
+		commonPackageImportPath: "pandas/common",
+		packageName:             "chubbypandas",
+		serviceClientName:       "pandaClient",
+		source:                  AccTestLicenceType,
 		models: map[string]resourcemanager.ModelDetails{
 			"FizzyDrink": {
 				TypeHintIn: stringPointer("Type"),
@@ -492,6 +493,7 @@ import (
 "github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 "github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 "github.com/hashicorp/go-azure-sdk/sdk/odata"
+"github.com/hashicorp/go-azure-sdk/pandas/common"
 )
 // acctests licence placeholder
 type GetOperationResponse struct {
@@ -543,9 +545,10 @@ func (c pandaClient) Get(ctx context.Context ) (result GetOperationResponse, err
 
 func TestTemplateMethodsTopLevelDiscriminatorReferencingImplementation(t *testing.T) {
 	input := ServiceGeneratorData{
-		packageName:       "chubbypandas",
-		serviceClientName: "pandaClient",
-		source:            AccTestLicenceType,
+		commonPackageImportPath: "pandas/common",
+		packageName:             "chubbypandas",
+		serviceClientName:       "pandaClient",
+		source:                  AccTestLicenceType,
 		models: map[string]resourcemanager.ModelDetails{
 			"PandaPop": {
 				ParentTypeName: stringPointer("FizzyDrink"),
@@ -594,6 +597,7 @@ import (
 "github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 "github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 "github.com/hashicorp/go-azure-sdk/sdk/odata"
+"github.com/hashicorp/go-azure-sdk/pandas/common"
 )
 // acctests licence placeholder
 type GetOperationResponse struct {

--- a/tools/generator-go-sdk/generator/templater_model.go
+++ b/tools/generator-go-sdk/generator/templater_model.go
@@ -12,14 +12,14 @@ import (
 
 // TODO: add unit tests covering this
 
-var _ templaterForResource = modelsTemplater{}
+var _ templaterForResource = modelTemplater{}
 
-type modelsTemplater struct {
+type modelTemplater struct {
 	name  string
 	model resourcemanager.ModelDetails
 }
 
-func (c modelsTemplater) template(data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) template(data ServiceGeneratorData) (*string, error) {
 	copyrightLines, err := copyrightLinesForSource(data.source)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving copyright lines: %+v", err)
@@ -57,7 +57,7 @@ import (
 	return &template, nil
 }
 
-func (c modelsTemplater) structCode(data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) structCode(data ServiceGeneratorData) (*string, error) {
 	// if this is an Abstract/Type Hint, we output an Interface with a manual unmarshal func that gets called wherever it's used
 	if c.model.TypeHintIn != nil && c.model.ParentTypeName == nil {
 		out := fmt.Sprintf(`
@@ -168,7 +168,7 @@ type %[1]s struct {
 	return &out, nil
 }
 
-func (c modelsTemplater) methods(data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) methods(data ServiceGeneratorData) (*string, error) {
 	code := make([]string, 0)
 
 	dateFunctions, err := c.codeForDateFunctions(data)
@@ -195,7 +195,7 @@ func (c modelsTemplater) methods(data ServiceGeneratorData) (*string, error) {
 	return &output, nil
 }
 
-func (c modelsTemplater) structLineForField(fieldName, fieldType string, fieldDetails resourcemanager.FieldDetails, data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) structLineForField(fieldName, fieldType string, fieldDetails resourcemanager.FieldDetails, data ServiceGeneratorData) (*string, error) {
 	jsonDetails := fieldDetails.JsonName
 
 	isOptional := false
@@ -224,7 +224,7 @@ func (c modelsTemplater) structLineForField(fieldName, fieldType string, fieldDe
 	return &line, nil
 }
 
-func (c modelsTemplater) dateFormatString(input resourcemanager.DateFormat) string {
+func (c modelTemplater) dateFormatString(input resourcemanager.DateFormat) string {
 	switch input {
 	case resourcemanager.RFC3339:
 		return time.RFC3339
@@ -237,7 +237,7 @@ func (c modelsTemplater) dateFormatString(input resourcemanager.DateFormat) stri
 	}
 }
 
-func (c modelsTemplater) codeForDateFunctions(data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) codeForDateFunctions(data ServiceGeneratorData) (*string, error) {
 	fieldsRequiringDateFunctions := make([]string, 0)
 	// parent models are output as interfaces with no fields - so we can skip these
 	// since the inherited models output the fields from their parents, the methods are output there
@@ -290,7 +290,7 @@ func (c modelsTemplater) codeForDateFunctions(data ServiceGeneratorData) (*strin
 	return &output, nil
 }
 
-func (c modelsTemplater) dateFunctionForField(fieldName string, fieldDetails resourcemanager.FieldDetails) (*string, error) {
+func (c modelTemplater) dateFunctionForField(fieldName string, fieldDetails resourcemanager.FieldDetails) (*string, error) {
 	if fieldDetails.DateFormat == nil {
 		return nil, fmt.Errorf("Date Field %q has no DateFormat", fieldName)
 	}
@@ -327,7 +327,7 @@ func (c modelsTemplater) dateFunctionForField(fieldName string, fieldDetails res
 	return &out, nil
 }
 
-func (c modelsTemplater) codeForMarshalFunctions(data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) codeForMarshalFunctions(data ServiceGeneratorData) (*string, error) {
 	output := ""
 
 	if c.model.TypeHintValue != nil {
@@ -387,7 +387,7 @@ func (s %[1]s) MarshalJSON() ([]byte, error) {
 	return &output, nil
 }
 
-func (c modelsTemplater) codeForUnmarshalFunctions(data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) codeForUnmarshalFunctions(data ServiceGeneratorData) (*string, error) {
 	unmarshalFunction, err := c.codeForUnmarshalStructFunction(data)
 	if err != nil {
 		return nil, fmt.Errorf("generating code for unmarshal struct function: %+v", err)
@@ -405,7 +405,7 @@ func (c modelsTemplater) codeForUnmarshalFunctions(data ServiceGeneratorData) (*
 	return &output, nil
 }
 
-func (c modelsTemplater) codeForUnmarshalParentFunction(data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) codeForUnmarshalParentFunction(data ServiceGeneratorData) (*string, error) {
 	// if this is a Discriminated Type (e.g. Parent) then we need to generate a unmarshal{Name}Implementations
 	// function which can be used in any usages
 	lines := make([]string, 0)
@@ -484,7 +484,7 @@ func unmarshal%[1]sImplementation(input []byte) (%[1]s, error) {
 	return &output, nil
 }
 
-func (c modelsTemplater) codeForUnmarshalStructFunction(data ServiceGeneratorData) (*string, error) {
+func (c modelTemplater) codeForUnmarshalStructFunction(data ServiceGeneratorData) (*string, error) {
 	// this is a parent, therefore there'll be no struct fields to check here
 	if c.model.IsDiscriminatedParentType() {
 		out := ""
@@ -684,7 +684,7 @@ func (s *%[1]s) UnmarshalJSON(bytes []byte) error {`, c.name))
 // recurseParentModels walks the models hierarchy to find the parentName and field details of the model for disciminated types
 // This is a temporary measure until we update the swagger importer to connect the model fields inheritance for multiple parents.
 // Tracked at: https://github.com/hashicorp/pandora/issues/1235
-func (c modelsTemplater) recurseParentModels(data ServiceGeneratorData, model string, typeHint string) (*resourcemanager.FieldDetails, *string, error) {
+func (c modelTemplater) recurseParentModels(data ServiceGeneratorData, model string, typeHint string) (*resourcemanager.FieldDetails, *string, error) {
 	parentModel, ok := data.models[model]
 	if !ok {
 		return nil, nil, fmt.Errorf("the parent model %q for model %q was not found", model, c.name)

--- a/tools/generator-go-sdk/generator/templater_model_constant_test.go
+++ b/tools/generator-go-sdk/generator/templater_model_constant_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestModelTemplaterWithOptionalFloatConstant(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -81,7 +81,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithOptionalIntegerConstant(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -155,7 +155,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithOptionalStringConstant(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -229,7 +229,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredFloatConstant(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -302,7 +302,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredIntegerConstant(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -375,7 +375,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredStringConstant(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -449,7 +449,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithOptionalListOfFloatConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -528,7 +528,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithOptionalListOfIntegerConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -607,7 +607,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithOptionalListOfStringConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -687,7 +687,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredListOfFloatConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -766,7 +766,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredListOfIntegerConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -845,7 +845,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredListOfStringConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -925,7 +925,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithOptionalMapOfFloatConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -1004,7 +1004,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithOptionalMapOfIntegerConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -1083,7 +1083,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithOptionalMapOfStringConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -1163,7 +1163,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredMapOfFloatConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -1242,7 +1242,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredMapOfIntegerConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -1321,7 +1321,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithRequiredMapOfStringConstants(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{

--- a/tools/generator-go-sdk/generator/templater_model_discriminators_test.go
+++ b/tools/generator-go-sdk/generator/templater_model_discriminators_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTemplaterModelsParent(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "ModeOfTransit",
 		model: resourcemanager.ModelDetails{
 			TypeHintIn: stringPointer("Type"),
@@ -125,7 +125,7 @@ func unmarshalModeOfTransitImplementation(input []byte) (ModeOfTransit, error) {
 }
 
 func TestTemplaterModelsImplementation(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Train",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -244,7 +244,7 @@ func (s Train) MarshalJSON() ([]byte, error) {
 }
 
 func TestTemplaterModelsFieldImplementation(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "TrainFactory",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -336,7 +336,7 @@ type TrainFactory struct {
 }
 
 func TestTemplaterModelsImplementationInheritedFromParentType(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "FirstImplementation",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{

--- a/tools/generator-go-sdk/generator/templater_model_test.go
+++ b/tools/generator-go-sdk/generator/templater_model_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestModelTemplaterSimple(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -80,7 +80,7 @@ type Basic struct {
 }
 
 func TestModelTemplaterWithDate(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{
@@ -169,7 +169,7 @@ func (o *Basic) SetDateOfBirthAsTime(input time.Time) {
 }
 
 func TestModelTemplaterWithOptionalObject(t *testing.T) {
-	actual, err := modelsTemplater{
+	actual, err := modelTemplater{
 		name: "Basic",
 		model: resourcemanager.ModelDetails{
 			Fields: map[string]resourcemanager.FieldDetails{

--- a/tools/generator-go-sdk/generator/templater_models.go
+++ b/tools/generator-go-sdk/generator/templater_models.go
@@ -86,7 +86,7 @@ type Raw%[1]sImpl struct {
 	for _, fieldName := range fields {
 		fieldDetails := c.model.Fields[fieldName]
 		fieldTypeName := "FIXME"
-		fieldTypeVal, err := golangTypeNameForObjectDefinition(fieldDetails.ObjectDefinition)
+		fieldTypeVal, err := golangTypeNameForObjectDefinition(fieldDetails.ObjectDefinition, nil)
 		if err != nil {
 			return nil, fmt.Errorf("determining type information for %q: %+v", fieldName, err)
 		}
@@ -137,7 +137,7 @@ type Raw%[1]sImpl struct {
 			for _, fieldName := range parentFields {
 				fieldDetails := parent.Fields[fieldName]
 				fieldTypeName := "FIXME"
-				fieldTypeVal, err := golangTypeNameForObjectDefinition(fieldDetails.ObjectDefinition)
+				fieldTypeVal, err := golangTypeNameForObjectDefinition(fieldDetails.ObjectDefinition, nil)
 				if err != nil {
 					return nil, fmt.Errorf("determining type information for %q: %+v", fieldName, err)
 				}

--- a/tools/generator-go-sdk/generator/templater_predicates.go
+++ b/tools/generator-go-sdk/generator/templater_predicates.go
@@ -10,12 +10,12 @@ import (
 
 // TODO: add unit tests covering this
 
-type predicateTemplater struct {
+type predicatesTemplater struct {
 	sortedModelNames []string
 	models           map[string]resourcemanager.ModelDetails
 }
 
-func (p predicateTemplater) template(data ServiceGeneratorData) (*string, error) {
+func (p predicatesTemplater) template(data ServiceGeneratorData) (*string, error) {
 	output := make([]string, 0)
 	for _, modelName := range p.sortedModelNames {
 		model := data.models[modelName]
@@ -44,7 +44,7 @@ func (p predicateTemplater) template(data ServiceGeneratorData) (*string, error)
 	return &template, nil
 }
 
-func (p predicateTemplater) templateForModel(predicateStructName string, name string, model resourcemanager.ModelDetails) (*string, error) {
+func (p predicatesTemplater) templateForModel(predicateStructName string, name string, model resourcemanager.ModelDetails) (*string, error) {
 	fieldNames := make([]string, 0)
 
 	// unsupported at this time - see https://github.com/hashicorp/pandora/issues/164

--- a/tools/generator-go-sdk/generator/templater_predicates.go
+++ b/tools/generator-go-sdk/generator/templater_predicates.go
@@ -94,7 +94,7 @@ func (p predicateTemplater) templateForModel(predicateStructName string, name st
 		for _, fieldName := range fieldNames {
 			fieldVal := model.Fields[fieldName]
 
-			typeInfo, err := golangTypeNameForObjectDefinition(fieldVal.ObjectDefinition)
+			typeInfo, err := golangTypeNameForObjectDefinition(fieldVal.ObjectDefinition, nil) // TODO package path needed?
 			if err != nil {
 				return nil, fmt.Errorf("determining type information for field %q in model %q with info %q: %+v", fieldName, name, string(fieldVal.ObjectDefinition.Type), err)
 			}

--- a/tools/generator-go-sdk/generator/templater_readme.go
+++ b/tools/generator-go-sdk/generator/templater_readme.go
@@ -129,8 +129,8 @@ payload := %[1]s.%[2]s{
 }
 `, packageName, *operation.RequestObject.ReferenceName))
 		} else {
-			// for simplicities sake
-			typeName, err := golangTypeNameForObjectDefinition(*operation.RequestObject)
+			// for simplicity's sake
+			typeName, err := golangTypeNameForObjectDefinition(*operation.RequestObject, &data.commonPackageName)
 			if err != nil {
 				return nil, fmt.Errorf("determining golang type name for request object: %+v", err)
 			}
@@ -185,8 +185,8 @@ payload := %[1]s.%[2]s{
 }
 `, packageName, *operation.RequestObject.ReferenceName))
 		} else {
-			// for simplicities sake
-			typeName, err := golangTypeNameForObjectDefinition(*operation.RequestObject)
+			// for simplicity's sake
+			typeName, err := golangTypeNameForObjectDefinition(*operation.RequestObject, &data.commonPackageName)
 			if err != nil {
 				return nil, fmt.Errorf("determining golang type name for request object: %+v", err)
 			}
@@ -242,8 +242,8 @@ payload := %[1]s.%[2]s{
 }
 `, packageName, *operation.RequestObject.ReferenceName))
 		} else {
-			// for simplicities sake
-			typeName, err := golangTypeNameForObjectDefinition(*operation.RequestObject)
+			// for simplicity's sake
+			typeName, err := golangTypeNameForObjectDefinition(*operation.RequestObject, &data.commonPackageName)
 			if err != nil {
 				return nil, fmt.Errorf("determining golang type name for request object: %+v", err)
 			}

--- a/tools/generator-go-sdk/generator/templater_version.go
+++ b/tools/generator-go-sdk/generator/templater_version.go
@@ -17,13 +17,13 @@ func (c versionTemplater) template(data ServiceGeneratorData) (*string, error) {
 
 import "fmt"
 
-%[3]s
+%[4]s
 
-const defaultApiVersion = "%[2]s"
+const defaultApiVersion = "%[3]s"
 
 func userAgent() string {
-	return fmt.Sprintf("hashicorp/go-azure-sdk/%[1]s/%%s", defaultApiVersion)
+	return fmt.Sprintf("hashicorp/go-azure-sdk/%[1]s/%[2]s/%%s", defaultApiVersion)
 }
-`, data.packageName, data.apiVersion, *copyrightLines)
+`, data.baseClientPackage, data.packageName, data.apiVersion, *copyrightLines)
 	return &template, nil
 }

--- a/tools/generator-go-sdk/generator/templater_version.go
+++ b/tools/generator-go-sdk/generator/templater_version.go
@@ -13,7 +13,7 @@ func (c versionTemplater) template(data ServiceGeneratorData) (*string, error) {
 		return nil, fmt.Errorf("retrieving copyright lines: %+v", err)
 	}
 
-	template := fmt.Sprintf(`package %[1]s
+	template := fmt.Sprintf(`package %[2]s
 
 import "fmt"
 

--- a/tools/generator-go-sdk/generator/templater_version_test.go
+++ b/tools/generator-go-sdk/generator/templater_version_test.go
@@ -6,9 +6,10 @@ import (
 
 func TestTemplateVersion(t *testing.T) {
 	input := ServiceGeneratorData{
-		packageName: "somepackage",
-		apiVersion:  "2022-02-01",
-		source:      AccTestLicenceType,
+		baseClientPackage: "pandas-api",
+		packageName:       "somepackage",
+		apiVersion:        "2022-02-01",
+		source:            AccTestLicenceType,
 	}
 
 	actual, err := versionTemplater{}.template(input)
@@ -25,7 +26,7 @@ import "fmt"
 const defaultApiVersion = "2022-02-01"
 
 func userAgent() string {
-	return fmt.Sprintf("hashicorp/go-azure-sdk/somepackage/%s", defaultApiVersion)
+	return fmt.Sprintf("hashicorp/go-azure-sdk/pandas-api/somepackage/%s", defaultApiVersion)
 }`
 	assertTemplatedCodeMatches(t, expected, *actual)
 }

--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -24,13 +24,26 @@ type GeneratorInput struct {
 }
 
 type SDK struct {
-	baseClientMethod                   string
-	baseClientPackage                  string
-	clients                            map[string]func(string) resourcemanager.Client
+	// baseClientMethod is the go function for instantiating the particular base client
+	baseClientMethod string
+
+	// baseClientPackage is the go package where the base client can be found
+	baseClientPackage string
+
+	// clients is a map of Data API clients to use when retrieving definitions for the SDK
+	clients map[string]func(string) resourcemanager.Client
+
+	// commonModelsPackageNameFromVersion is a function that returns the go package name containing common types (models, constants, predicates), for the SDK version
 	commonModelsPackageNameFromVersion func(string) (*string, error)
+
+	// commonModelsPackagePathFromVersion is a function that returns the go import path where common types can be found, for the SDK version
 	commonModelsPackagePathFromVersion func(string) (*string, error)
-	outputSubDirectory                 string
-	versionMapper                      func(string) (*string, error)
+
+	// outputSubDirectory is the base directory where the SDK will reside in the go-azure-sdk repository
+	outputSubDirectory string
+
+	// versionMapper is a function that returns a local API version for a given version as returned by the Data API
+	versionMapper func(string) (*string, error)
 }
 
 var availableSDKs = map[string]SDK{

--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -18,8 +18,52 @@ import (
 type GeneratorInput struct {
 	apiServerEndpoint string
 	outputDirectory   string
+	sdkName           string
 	services          []string
 	settings          generator.Settings
+}
+
+type SDK struct {
+	baseClientMethod   string
+	baseClientPackage  string
+	clients            []func(string) resourcemanager.Client
+	outputSubDirectory string
+	versionMapper      func(string) (*string, error)
+}
+
+var availableSDKs = map[string]SDK{
+	"resource-manager": {
+		baseClientMethod:  "NewResourceManagerClient",
+		baseClientPackage: "resourcemanager",
+		clients: []func(string) resourcemanager.Client{
+			resourcemanager.NewResourceManagerClient,
+		},
+		outputSubDirectory: "resource-manager",
+		versionMapper:      func(in string) (*string, error) { return &in, nil },
+	},
+
+	"microsoft-graph": {
+		baseClientMethod:  "NewMsGraphClient",
+		baseClientPackage: "msgraph",
+		clients: []func(string) resourcemanager.Client{
+			resourcemanager.NewMicrosoftGraphStableV1Client,
+			resourcemanager.NewMicrosoftGraphBetaClient,
+		},
+		outputSubDirectory: "microsoft-graph",
+		versionMapper: func(in string) (*string, error) {
+			version := ""
+			switch in {
+			case "StableV1":
+				version = "v1.0"
+			case "Beta":
+				version = "beta"
+			}
+			if version == "" {
+				return nil, fmt.Errorf("unsupported API version: %q", in)
+			}
+			return &version, nil
+		},
+	},
 }
 
 func main() {
@@ -27,56 +71,12 @@ func main() {
 		settings: generator.Settings{},
 	}
 
-	input.settings.UseOldBaseLayerFor(
-		// @tombuildsstuff: New Services should now use the `hashicorp/go-azure-sdk` base layer by default
-		// instead of the base layer from `Azure/go-autorest` - as such this list is for compatibility purposes
-		// with services already used in `terraform-provider-azurerm`. These services will be gradually removed
-		// from this list to ensure they're migrated across to using `hashicorp/go-azure-sdk`s base layer.
-
-		// NOTE: also see the list in ./tools/generator-terraform/generator/definitions/template_service_client.go
-		// for services/resources which are auto-generated
-		"ContainerApps",
-		"ContainerInstance",
-		"CosmosDB",
-		"DataShare",
-		"FrontDoor",
-		"Insights",
-		"Kusto",
-		"Maintenance",
-		"ManagedServices",
-		"RecoveryServicesBackup", // error: generating Service "RecoveryServicesBackup" / Version "2023-04-01" / Resource "Operation": generating methods: templating methods (using hashicorp/go-azure-sdk): templating: building methods: building response struct template: existing model "ValidateOperationResponse" conflicts with the operation response model for "Validate"
-		"Security",
-		"SecurityInsights",
-		"ServiceFabric",
-		"ServiceFabricManagedCluster",
-		"ServiceLinker",
-		"SqlVirtualMachine",
-		"Storage",
-		"StreamAnalytics",
-		"Subscription",
-		"TimeSeriesInsights",
-
-		// Automation @ 2022-08-08 uses the new base layer, so let's invert the older versions for now
-		"Automation@2015-10-31",
-		"Automation@2019-06-01",
-		"Automation@2020-01-13-preview",
-		"Automation@2021-06-22",
-
-		// @tombuildsstuff: there's generated resources associated with these three - please check before removing these
-		"ContainerService",
-		"LoadTestService",
-		"ManagedIdentity",
-
-		// @tombuildsstuff: KeyVault requires that the exact casing retrieved from the API is re-sent back to the API
-		// as such will require custom work in the Provider (potentially a custom unmarshaller from the HTTP Body) to support this
-		"KeyVault",
-	)
-
 	var serviceNames string
 
 	f := flag.NewFlagSet("generator-go-sdk", flag.ExitOnError)
 	f.StringVar(&input.apiServerEndpoint, "data-api", "http://localhost:5000", "-data-api=http://localhost:5000")
 	f.StringVar(&input.outputDirectory, "output-dir", "", "-output-dir=../generated-sdk-dev")
+	f.StringVar(&input.sdkName, "sdk", "resource-manager", "-sdk=resource-manager")
 	f.StringVar(&serviceNames, "services", "", "A list of comma separated Service named from the Data API to import")
 	if err := f.Parse(os.Args[1:]); err != nil {
 		log.Fatalf("parsing arguments: %+v", err)
@@ -91,115 +91,176 @@ func main() {
 		input.outputDirectory = filepath.Join(homeDir, "/Desktop/generated-sdk-dev")
 	}
 
+	if input.sdkName == "resource-manager" {
+		input.settings.UseOldBaseLayerFor(
+			// @tombuildsstuff: New Services should now use the `hashicorp/go-azure-sdk` base layer by default
+			// instead of the base layer from `Azure/go-autorest` - as such this list is for compatibility purposes
+			// with services already used in `terraform-provider-azurerm`. These services will be gradually removed
+			// from this list to ensure they're migrated across to using `hashicorp/go-azure-sdk`s base layer.
+
+			// NOTE: also see the list in ./tools/generator-terraform/generator/definitions/template_service_client.go
+			// for services/resources which are auto-generated
+			"ContainerApps",
+			"ContainerInstance",
+			"CosmosDB",
+			"DataShare",
+			"FrontDoor",
+			"Insights",
+			"Kusto",
+			"Maintenance",
+			"ManagedServices",
+			"RecoveryServicesBackup", // error: generating Service "RecoveryServicesBackup" / Version "2023-04-01" / Resource "Operation": generating methods: templating methods (using hashicorp/go-azure-sdk): templating: building methods: building response struct template: existing model "ValidateOperationResponse" conflicts with the operation response model for "Validate"
+			"Security",
+			"SecurityInsights",
+			"ServiceFabric",
+			"ServiceFabricManagedCluster",
+			"ServiceLinker",
+			"SqlVirtualMachine",
+			"Storage",
+			"StreamAnalytics",
+			"Subscription",
+			"TimeSeriesInsights",
+
+			// Automation @ 2022-08-08 uses the new base layer, so let's invert the older versions for now
+			"Automation@2015-10-31",
+			"Automation@2019-06-01",
+			"Automation@2020-01-13-preview",
+			"Automation@2021-06-22",
+
+			// @tombuildsstuff: there's generated resources associated with these three - please check before removing these
+			"ContainerService",
+			"LoadTestService",
+			"ManagedIdentity",
+
+			// @tombuildsstuff: KeyVault requires that the exact casing retrieved from the API is re-sent back to the API
+			// as such will require custom work in the Provider (potentially a custom unmarshaller from the HTTP Body) to support this
+			"KeyVault",
+		)
+	}
+
 	if err := run(input); err != nil {
 		log.Printf("error: %+v", err)
 		os.Exit(1)
-		return
 	}
 
 	os.Exit(0)
 }
 
 func run(input GeneratorInput) error {
-	client := resourcemanager.NewResourceManagerClient(input.apiServerEndpoint)
-
-	// resource manager items should be output into the folder ./resource-manager
-	input.outputDirectory = path.Join(input.outputDirectory, "resource-manager")
-
-	var loadedServices services.ResourceManagerServices
-	if len(input.services) > 0 {
-		log.Printf("[DEBUG] Loading the Services from the Data API %q..", strings.Join(input.services, " / "))
-		services, err := services.GetResourceManagerServicesByName(client, input.services)
-		if err != nil {
-			return fmt.Errorf("retrieving resource manager services: %+v", err)
-		}
-		loadedServices = *services
-	} else {
-		log.Printf("[DEBUG] Loading All Services..")
-		services, err := services.GetResourceManagerServices(client)
-		if err != nil {
-			return fmt.Errorf("retrieving resource manager services: %+v", err)
-		}
-		loadedServices = *services
+	sdk, ok := availableSDKs[input.sdkName]
+	if !ok {
+		return fmt.Errorf("unsupported SDK %q", input.sdkName)
 	}
 
-	errCh := make(chan error, 1)
-	waitDone := make(chan struct{}, 1)
-	var wg sync.WaitGroup
-	addErr := func(err error) {
-		// only put one err to channel
-		select {
-		case errCh <- err:
-		default:
-		}
-	}
+	input.outputDirectory = path.Join(input.outputDirectory, sdk.outputSubDirectory)
 
-	generatorService := generator.NewServiceGenerator(input.settings)
-	for serviceName, service := range loadedServices.Services {
-		log.Printf("[DEBUG] Service %q..", serviceName)
-		if !service.Details.Generate {
-			log.Printf("[DEBUG] .. is opted out of generation, skipping..")
-			continue
+	for _, apiClient := range sdk.clients {
+		client := apiClient(input.apiServerEndpoint)
+
+		var loadedServices services.ResourceManagerServices
+		if len(input.services) > 0 {
+			log.Printf("[DEBUG] Loading the Services from the Data API %q..", strings.Join(input.services, " / "))
+			servicesResult, err := services.GetResourceManagerServicesByName(client, input.services)
+			if err != nil {
+				return fmt.Errorf("retrieving resource manager services: %+v", err)
+			}
+			loadedServices = *servicesResult
+		} else {
+			log.Printf("[DEBUG] Loading All Services..")
+			servicesResult, err := services.GetResourceManagerServices(client)
+			if err != nil {
+				return fmt.Errorf("retrieving resource manager services: %+v", err)
+			}
+			loadedServices = *servicesResult
 		}
 
-		wg.Add(1)
-		go func(serviceName string, service services.ResourceManagerService, input GeneratorInput) {
-			defer wg.Done()
-			log.Printf("[DEBUG] Service %q", serviceName)
-			for versionNumber, versionDetails := range service.Versions {
-				log.Printf("[DEBUG]   Version %q", versionNumber)
-				for resourceName, resourceDetails := range versionDetails.Resources {
-					log.Printf("[DEBUG]      Resource %q..", resourceName)
-					generatorData := generator.ServiceGeneratorInput{
-						ServiceName:     serviceName,
-						ServiceDetails:  service,
-						VersionName:     versionNumber,
-						VersionDetails:  versionDetails,
-						ResourceName:    resourceName,
-						ResourceDetails: resourceDetails,
-						OutputDirectory: input.outputDirectory,
-						Source:          versionDetails.Details.Source,
-					}
-					log.Printf("[DEBUG] Generating Service %q / Version %q / Resource %q..", serviceName, versionNumber, resourceName)
-					if err := generatorService.Generate(generatorData); err != nil {
-						addErr(fmt.Errorf("generating Service %q / Version %q / Resource %q: %+v", serviceName, versionNumber, resourceName, err))
+		errCh := make(chan error, 1)
+		waitDone := make(chan struct{}, 1)
+		var wg sync.WaitGroup
+		addErr := func(err error) {
+			// only put one err to channel
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
+
+		generatorService := generator.NewServiceGenerator(input.settings)
+		for serviceName, service := range loadedServices.Services {
+			log.Printf("[DEBUG] Service %q..", serviceName)
+			if !service.Details.Generate {
+				log.Printf("[DEBUG] .. is opted out of generation, skipping..")
+				continue
+			}
+
+			wg.Add(1)
+			go func(serviceName string, service services.ResourceManagerService, input GeneratorInput) {
+				defer wg.Done()
+				log.Printf("[DEBUG] Service %q", serviceName)
+				for versionNumber, versionDetails := range service.Versions {
+					log.Printf("[DEBUG]   Version %q", versionNumber)
+					versionName, err := sdk.versionMapper(versionNumber)
+					if err != nil {
+						addErr(fmt.Errorf("generating Service %q / Version %q: %+v", serviceName, versionNumber, err))
 						return
 					}
-					log.Printf("[DEBUG] Generated Service %q / Version %q / Resource %q..", serviceName, versionNumber, resourceName)
-				}
+					for resourceName, resourceDetails := range versionDetails.Resources {
+						log.Printf("[DEBUG]      Resource %q..", resourceName)
+						generatorData := generator.ServiceGeneratorInput{
+							ServiceName:       serviceName,
+							ServiceDetails:    service,
+							VersionName:       *versionName,
+							VersionDetails:    versionDetails,
+							ResourceName:      resourceName,
+							ResourceDetails:   resourceDetails,
+							BaseClientMethod:  sdk.baseClientMethod,
+							BaseClientPackage: sdk.baseClientPackage,
+							OutputDirectory:   input.outputDirectory,
+							Source:            versionDetails.Details.Source,
+						}
+						log.Printf("[DEBUG] Generating Service %q / Version %q / Resource %q..", serviceName, versionNumber, resourceName)
+						if err := generatorService.Generate(generatorData); err != nil {
+							addErr(fmt.Errorf("generating Service %q / Version %q / Resource %q: %+v", serviceName, versionNumber, resourceName, err))
+							return
+						}
+						log.Printf("[DEBUG] Generated Service %q / Version %q / Resource %q..", serviceName, versionNumber, resourceName)
+					}
 
-				// then output the Meta Client
-				generatorData := generator.VersionInput{
-					OutputDirectory: input.outputDirectory,
-					ServiceName:     serviceName,
-					VersionName:     versionNumber,
-					Resources:       versionDetails.Resources,
-					Source:          versionDetails.Details.Source,
+					// then output the Meta Client
+					generatorData := generator.VersionInput{
+						OutputDirectory:   input.outputDirectory,
+						ServiceName:       serviceName,
+						VersionName:       *versionName,
+						BaseClientPackage: sdk.baseClientPackage,
+						SdkPackage:        sdk.outputSubDirectory,
+						Resources:         versionDetails.Resources,
+						Source:            versionDetails.Details.Source,
+					}
+					generatorData.UseNewBaseLayer = false
+					if input.settings.ShouldUseNewBaseLayer(serviceName, versionNumber) {
+						generatorData.UseNewBaseLayer = true
+					}
+					log.Printf("[DEBUG] Generating Service %q / Version %q..", serviceName, versionNumber)
+					if err := generatorService.GenerateForVersion(generatorData); err != nil {
+						addErr(fmt.Errorf("generating Service %q / Version %q: %+v", serviceName, versionNumber, err))
+						return
+					}
+					log.Printf("[DEBUG] Generated Service %q / Version %q..", serviceName, versionNumber)
 				}
-				generatorData.UseNewBaseLayer = false
-				if input.settings.ShouldUseNewBaseLayer(serviceName, versionNumber) {
-					generatorData.UseNewBaseLayer = true
-				}
-				log.Printf("[DEBUG] Generating Service %q / Version %q..", serviceName, versionNumber)
-				if err := generatorService.GenerateForVersion(generatorData); err != nil {
-					addErr(fmt.Errorf("generating Service %q / Version %q: %+v", serviceName, versionNumber, err))
-					return
-				}
-				log.Printf("[DEBUG] Generated Service %q / Version %q..", serviceName, versionNumber)
-			}
-		}(serviceName, service, input)
-	}
+			}(serviceName, service, input)
+		}
 
-	go func() {
-		wg.Wait()
-		waitDone <- struct{}{}
-	}()
+		go func() {
+			wg.Wait()
+			waitDone <- struct{}{}
+		}()
 
-	select {
-	case <-waitDone:
-		break
-	case err := <-errCh:
-		return err
+		select {
+		case <-waitDone:
+			break
+		case err := <-errCh:
+			return err
+		}
 	}
 
 	return nil

--- a/tools/sdk/resourcemanager/client.go
+++ b/tools/sdk/resourcemanager/client.go
@@ -52,6 +52,12 @@ func (c Client) ApiSchema() ApiSchemaClient {
 	}
 }
 
+func (c Client) CommonTypes() CommonTypesClient {
+	return CommonTypesClient{
+		Client: c,
+	}
+}
+
 func (c Client) ServiceDetails() ServiceDetailsClient {
 	return ServiceDetailsClient{
 		Client: c,

--- a/tools/sdk/resourcemanager/common_types.go
+++ b/tools/sdk/resourcemanager/common_types.go
@@ -1,0 +1,37 @@
+package resourcemanager
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type CommonTypesClient struct {
+	Client
+}
+
+func (c CommonTypesClient) Get() (*CommonTypesDetails, error) {
+	endpoint := fmt.Sprintf("%s%s/commonTypes", c.endpoint, c.apiEndpoint)
+	resp, err := c.client.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: handle this being a 404 etc
+
+	var response CommonTypesDetails
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+type CommonTypesDetails struct {
+	// Constants is a map of key (Constant Name) to value (ConstantDetails) describing
+	// each common Constant supported by this API
+	Constants map[string]ConstantDetails `json:"constants"`
+
+	// Models is a map of key (Model Name) to value (ModelDetails) describing
+	// each common Model supported by this API
+	Models map[string]ModelDetails `json:"models"`
+}

--- a/tools/sdk/resourcemanager/models.go
+++ b/tools/sdk/resourcemanager/models.go
@@ -5,9 +5,10 @@ import (
 )
 
 type ApiObjectDefinition struct {
-	NestedItem    *ApiObjectDefinition    `json:"nestedItem,omitempty"`
-	ReferenceName *string                 `json:"referenceName,omitempty"`
-	Type          ApiObjectDefinitionType `json:"type"`
+	NestedItem            *ApiObjectDefinition    `json:"nestedItem,omitempty"`
+	ReferenceName         *string                 `json:"referenceName,omitempty"`
+	ReferenceIsCommonType *bool                   `json:"referenceIsCommonType,omitempty"`
+	Type                  ApiObjectDefinitionType `json:"type"`
 }
 
 func (d ApiObjectDefinition) GolangTypeName(packageName *string) (*string, error) {

--- a/tools/sdk/resourcemanager/service_version.go
+++ b/tools/sdk/resourcemanager/service_version.go
@@ -57,4 +57,9 @@ const (
 	// that this set of API Definitions is based on data within the Azure
 	// Rest API Specs repository.
 	ApiDefinitionsSourceResourceManagerRestApiSpecs ApiDefinitionsSource = "ResourceManagerRestApiSpecs"
+
+	// ApiDefinitionsSourceMicrosoftGraphMetadata is used to signify that
+	// this set of API Definitions is based on data within the
+	// Microsoft-Graph/MSGraph-Metadata repository.
+	ApiDefinitionsSourceMicrosoftGraphMetadata ApiDefinitionsSource = "MicrosoftGraphMetadata"
 )

--- a/tools/sdk/services/data.go
+++ b/tools/sdk/services/data.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-// GetResourceManagerServices returns all of the Services supported by the Resource Manager endpoint
+// GetResourceManagerServices returns all the Services supported by the Resource Manager endpoint
 func GetResourceManagerServices(client resourcemanager.Client) (*ResourceManagerServices, error) {
 	return GetResourceManagerServicesByName(client, nil)
 }
@@ -18,9 +18,9 @@ func GetResourceManagerServicesByName(client resourcemanager.Client, servicesToL
 		return nil, err
 	}
 
-	serviceNames := make(map[string]struct{})
+	serviceNames := make(map[string]bool)
 	for _, serviceName := range servicesToLoad {
-		serviceNames[serviceName] = struct{}{}
+		serviceNames[serviceName] = true
 	}
 
 	resourceManagerServices := make(map[string]ResourceManagerService, 0)
@@ -119,5 +119,18 @@ func GetResourceManagerServicesByName(client resourcemanager.Client, servicesToL
 
 	return &ResourceManagerServices{
 		Services: resourceManagerServices,
+	}, nil
+}
+
+// GetResourceManagerCommonTypes returns the specified Services from the Data API
+func GetResourceManagerCommonTypes(client resourcemanager.Client) (*ResourceManagerCommonTypes, error) {
+	commonTypes, err := client.CommonTypes().Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceManagerCommonTypes{
+		Constants: commonTypes.Constants,
+		Models:    commonTypes.Models,
 	}, nil
 }

--- a/tools/sdk/services/resourcemanager.go
+++ b/tools/sdk/services/resourcemanager.go
@@ -22,3 +22,8 @@ type Resource struct {
 	Operations resourcemanager.ApiOperationDetails
 	Schema     resourcemanager.ApiSchemaDetails
 }
+
+type ResourceManagerCommonTypes struct {
+	Constants map[string]resourcemanager.ConstantDetails
+	Models    map[string]resourcemanager.ModelDetails
+}


### PR DESCRIPTION
*Depends on Importer bug fixes and improvements in https://github.com/hashicorp/pandora/pull/2917*

<hr>

This PR adds support for generating a Microsoft Graph SDK supporting the v1.0 and beta API versions.

* SDK is located at `github.com/hashicorp/go-azure-sdk/microsoft-graph`
* Uses the `github.com/hashicorp/go-azure-sdk/sdk/client/msgraph` base client
* Common types, including models, constants, and predicates, are output to the `microsoft-graph/common/{version}/models` package
* Services are structured like this:
    <img width="472" alt="Screenshot 2023-09-08 at 02 05 23" src="https://github.com/hashicorp/pandora/assets/251987/860285af-a239-49ef-97fd-f394edbc8505">

### Example Client

<img width="830" alt="Screenshot 2023-09-08 at 02 22 42" src="https://github.com/hashicorp/pandora/assets/251987/383343ba-b98d-420f-8e7e-809b7494d47d">

### Example Get Operation

<img width="1234" alt="Screenshot 2023-09-08 at 02 06 44" src="https://github.com/hashicorp/pandora/assets/251987/e93d4eb8-bf18-43df-a399-1136f88220bf">
