### PR TITLE
Config: add Postgresql@2023-03-01-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -388,7 +388,7 @@ service "portal" {
 }
 service "postgresql" {
   name      = "PostgreSql"
-  available = ["2017-12-01", "2018-06-01", "2020-01-01", "2021-06-01", "2022-03-08-preview", "2022-12-01", 2023-03-01-preview]
+  available = ["2017-12-01", "2018-06-01", "2020-01-01", "2021-06-01", "2022-03-08-preview", "2022-12-01", "2023-03-01-preview"]
 }
 service "postgresqlhsc" {
   name      = "PostgreSqlHSC"

--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -388,7 +388,7 @@ service "portal" {
 }
 service "postgresql" {
   name      = "PostgreSql"
-  available = ["2017-12-01", "2018-06-01", "2020-01-01", "2021-06-01", "2022-03-08-preview", "2022-12-01"]
+  available = ["2017-12-01", "2018-06-01", "2020-01-01", "2021-06-01", "2022-03-08-preview", "2022-12-01", 2023-03-01-preview]
 }
 service "postgresqlhsc" {
   name      = "PostgreSqlHSC"


### PR DESCRIPTION
We intend to support geoBackupKeyURI and geoBackupUserAssignedIdentityId for the CMK feature. See more details for this request from https://github.com/hashicorp/terraform-provider-azurerm/issues/20750. Now this feature only exists in this latest version.

API Reference: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2023-03-01-preview/FlexibleServers.json