### PR TITLE
data-api: support for common types (models and constants)

### DIFF
--- a/data/Pandora.Api/Startup.cs
+++ b/data/Pandora.Api/Startup.cs
@@ -23,6 +23,7 @@ public class Startup
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<IServiceReferencesRepository>(new ServiceReferencesRepository(SupportedServices.Get()));
+        services.AddSingleton<ICommonTypesRepository>(new CommonTypesRepository(SupportedCommonTypes.Get()));
         services.AddControllers();
     }
 

--- a/data/Pandora.Api/V1/Controllers/CommonTypes.cs
+++ b/data/Pandora.Api/V1/Controllers/CommonTypes.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Pandora.Api.V1.Helpers;
+using Pandora.Data.Models;
+using Pandora.Data.Repositories;
+
+namespace Pandora.Api.V1.Controllers;
+
+public class CommonTypesController : ControllerBase
+{
+    private readonly ICommonTypesRepository _repo;
+
+    public CommonTypesController(ICommonTypesRepository repo)
+    {
+        _repo = repo;
+    }
+
+    [Route("/v1/microsoft-graph/{apiVersion}/commonTypes")]
+    public IActionResult MicrosoftGraph(string apiVersion)
+    {
+        var definitionType = apiVersion.ParseServiceDefinitionTypeFromApiVersion();
+        if (definitionType == null)
+        {
+            return BadRequest($"the API Version {apiVersion} is not supported");
+        }
+
+        return CommonTypes(definitionType.Value);
+    }
+
+    private IActionResult CommonTypes(ServiceDefinitionType serviceDefinitionType)
+    {
+        var commonTypes = _repo.Get(serviceDefinitionType);
+        return new JsonResult(MapResponse(commonTypes));
+    }
+
+    private class CommonTypesResponse
+    {
+        [JsonPropertyName("constants")]
+        public Dictionary<string, ConstantApiDefinition> Constants { get; set; }
+
+        [JsonPropertyName("models")]
+        public Dictionary<string, ModelApiDefinition> Models { get; set; }
+
+        [JsonPropertyName("resourceIds")]
+        public Dictionary<string, ResourceIdDefinition> ResourceIds { get; set; }
+    }
+
+    private static CommonTypesResponse MapResponse(IEnumerable<CommonTypesDefinition> resource)
+    {
+        var constants = resource.SelectMany(c => c.Constants);
+        var models = resource.SelectMany(c => c.Models);
+
+        return new CommonTypesResponse
+        {
+            Constants = constants.ToDictionary(c => c.Name, ConstantApiDefinition.Map),
+            Models = models.ToDictionary(m => m.Name, MapModel),
+        };
+    }
+
+    private class ModelApiDefinition
+    {
+        [JsonPropertyName("fields")]
+        public Dictionary<string, PropertyApiDefinition> Fields { get; set; }
+
+        [JsonPropertyName("parentTypeName")]
+        public string? ParentTypeName { get; set; }
+
+        [JsonPropertyName("typeHintIn")]
+        public string? TypeHintIn { get; set; }
+
+        [JsonPropertyName("typeHintValue")]
+        public string? TypeHintValue { get; set; }
+    }
+
+    private static ModelApiDefinition MapModel(ModelDefinition model)
+    {
+        return new ModelApiDefinition
+        {
+            Fields = model.Properties.ToDictionary(p => p.Name, MapProperty),
+            ParentTypeName = model.ParentTypeName,
+            TypeHintIn = model.TypeHintIn,
+            TypeHintValue = model.TypeHintValue,
+        };
+    }
+
+    private class PropertyApiDefinition
+    {
+        [JsonPropertyName("dateFormat")]
+        public string? DateFormat { get; set; }
+
+        [JsonPropertyName("default")]
+        public object? Default { get; set; }
+
+        [JsonPropertyName("forceNew")]
+        public bool ForceNew { get; set; }
+
+        [JsonPropertyName("isTypeHint")]
+        public bool IsTypeHint { get; set; }
+
+        [JsonPropertyName("jsonName")]
+        public string JsonName { get; set; }
+
+        [JsonPropertyName("objectDefinition")]
+        public ApiObjectDefinition ObjectDefinition { get; set; }
+
+        [JsonPropertyName("optional")]
+        public bool Optional { get; set; }
+
+        [JsonPropertyName("required")]
+        public bool Required { get; set; }
+
+        [JsonPropertyName("validation")]
+        public ValidationApiDefinition? Validation { get; set; }
+    }
+
+    private static PropertyApiDefinition MapProperty(PropertyDefinition definition)
+    {
+        return new PropertyApiDefinition
+        {
+            DateFormat = definition.DateFormat,
+            Default = definition.Default,
+            ForceNew = definition.ForceNew,
+            JsonName = definition.JsonName,
+            IsTypeHint = definition.IsTypeHint,
+            ObjectDefinition = ApiObjectDefinitionMapper.Map(definition.ObjectDefinition),
+            Optional = definition.Optional,
+            Required = definition.Required,
+            Validation = ValidationApiDefinition.Map(definition.Validation),
+        };
+    }
+}

--- a/data/Pandora.Api/V1/Controllers/CommonTypes.cs
+++ b/data/Pandora.Api/V1/Controllers/CommonTypes.cs
@@ -29,6 +29,12 @@ public class CommonTypesController : ControllerBase
         return CommonTypes(definitionType.Value);
     }
 
+    [Route("/v1/resource-manager/commonTypes")]
+    public IActionResult ResourceManager(string apiVersion)
+    {
+        return CommonTypes(ServiceDefinitionType.ResourceManager);
+    }
+
     private IActionResult CommonTypes(ServiceDefinitionType serviceDefinitionType)
     {
         var commonTypes = _repo.Get(serviceDefinitionType);
@@ -42,9 +48,6 @@ public class CommonTypesController : ControllerBase
 
         [JsonPropertyName("models")]
         public Dictionary<string, ModelApiDefinition> Models { get; set; }
-
-        [JsonPropertyName("resourceIds")]
-        public Dictionary<string, ResourceIdDefinition> ResourceIds { get; set; }
     }
 
     private static CommonTypesResponse MapResponse(IEnumerable<CommonTypesDefinition> resource)

--- a/data/Pandora.Api/V1/Controllers/ServiceDetails.cs
+++ b/data/Pandora.Api/V1/Controllers/ServiceDetails.cs
@@ -52,7 +52,7 @@ public class ServiceDetailsController : ControllerBase
         {
             ResourceProvider = version.ResourceProvider!,
             TerraformPackageName = version.TerraformPackageName,
-            TerraformUri = $"/v1/resource-manager/services/{serviceName}/terraform",
+            TerraformUri = $"{routePrefix}/services/{serviceName}/terraform",
             Versions = version.Versions.ToDictionary(v => v.Version, v => MapVersion(v, serviceName, routePrefix))
         };
     }

--- a/data/Pandora.Api/V1/Controllers/ServiceVersion.cs
+++ b/data/Pandora.Api/V1/Controllers/ServiceVersion.cs
@@ -29,7 +29,7 @@ public class ServiceVersionController : ControllerBase
             return BadRequest($"the API Version {apiVersion} is not supported");
         }
 
-        return ForService(serviceName, serviceApiVersion, definitionType.Value, "/v1/microsoft-graph/{apiVersion}");
+        return ForService(serviceName, serviceApiVersion, definitionType.Value, $"/v1/microsoft-graph/{apiVersion}");
     }
 
     [Route("/v1/resource-manager/services/{serviceName}/{serviceApiVersion}")]

--- a/data/Pandora.Api/V1/Controllers/ServiceVersion.cs
+++ b/data/Pandora.Api/V1/Controllers/ServiceVersion.cs
@@ -69,11 +69,12 @@ public class ServiceVersionController : ControllerBase
     {
         switch (input)
         {
-            // TODO: support a Graph source
             case Data.Models.ApiDefinitionsSource.HandWritten:
                 return ApiDefinitionsSource.HandWritten.ToString();
             case Data.Models.ApiDefinitionsSource.ResourceManagerRestApiSpecs:
                 return ApiDefinitionsSource.ResourceManagerRestApiSpecs.ToString();
+            case Data.Models.ApiDefinitionsSource.MicrosoftGraphMetadata:
+                return ApiDefinitionsSource.MicrosoftGraphMetadata.ToString();
         }
 
         throw new NotSupportedException($"unsupported/unmapped Source {input.ToString()}");
@@ -115,8 +116,9 @@ public class ServiceVersionController : ControllerBase
         ResourceManagerRestApiSpecs,
 
         [Description("HandWritten")]
-        HandWritten
+        HandWritten,
 
-        // TODO: support for Graph
+        [Description("MicrosoftGraphMetadata")]
+        MicrosoftGraphMetadata,
     }
 }

--- a/data/Pandora.Data/CommonTypeDefinitions.cs
+++ b/data/Pandora.Data/CommonTypeDefinitions.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pandora.Data.Models;
+using Pandora.Definitions.Interfaces;
+using CommonTypesDefinition = Pandora.Definitions.Interfaces.CommonTypesDefinition;
+
+namespace Pandora.Data;
+
+public static class SupportedCommonTypes
+{
+    public static Dictionary<ServiceDefinitionType, IEnumerable<CommonTypesDefinition>> Get()
+    {
+        var data = DefinitionTypes.Get();
+        var output = new Dictionary<ServiceDefinitionType, IEnumerable<CommonTypesDefinition>>();
+        foreach (var item in data)
+        {
+            var commonTypes = item.Value.Select(Definitions.Discovery.CommonTypesDefinition.ForServiceDefinition);
+            output.Add(item.Key, commonTypes);
+        }
+
+        return output;
+    }
+}

--- a/data/Pandora.Data/DefinitionTypes.cs
+++ b/data/Pandora.Data/DefinitionTypes.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using Pandora.Data.Models;
+using Pandora.Definitions.DataPlane;
+using Pandora.Definitions.HandDefined;
+using Pandora.Definitions.Interfaces;
+using Pandora.Definitions.MicrosoftGraph.Beta;
+using Pandora.Definitions.MicrosoftGraph.StableV1;
+using Pandora.Definitions.ResourceManager;
+using ServiceDefinition = Pandora.Definitions.Interfaces.ServiceDefinition;
+
+namespace Pandora.Data;
+
+public static class DefinitionTypes
+{
+    public static Dictionary<ServiceDefinitionType, List<ServicesDefinition>> Get()
+    {
+        return new Dictionary<ServiceDefinitionType, List<ServicesDefinition>>
+        {
+            {
+                ServiceDefinitionType.DataPlane,
+                new List<ServicesDefinition>
+                {
+                    new DataPlaneServices(),
+                }
+            },
+            {
+                ServiceDefinitionType.MicrosoftGraphBeta,
+                new List<ServicesDefinition>
+                {
+                    new MicrosoftGraphBetaServices(),
+                }
+            },
+            {
+                ServiceDefinitionType.MicrosoftGraphStableV1,
+                new List<ServicesDefinition>
+                {
+                    new MicrosoftGraphStableV1Services(),
+                }
+            },
+            {
+                ServiceDefinitionType.ResourceManager,
+                new List<ServicesDefinition>
+                {
+                    new HandDefinedServices(),
+                    new ResourceManagerServices(),
+                }
+            },
+        };
+    }
+}

--- a/data/Pandora.Data/Models/ApiDefinitionsSource.cs
+++ b/data/Pandora.Data/Models/ApiDefinitionsSource.cs
@@ -10,5 +10,8 @@ public enum ApiDefinitionsSource
     ResourceManagerRestApiSpecs,
 
     [Description("HandWritten")]
-    HandWritten
+    HandWritten,
+
+    [Description("MicrosoftGraphMetadata")]
+    MicrosoftGraphMetadata,
 }

--- a/data/Pandora.Data/Models/CommonTypesDefinition.cs
+++ b/data/Pandora.Data/Models/CommonTypesDefinition.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Pandora.Data.Models;
+
+public class CommonTypesDefinition
+{
+    public ServiceDefinitionType ServiceDefinitionType { get; set; }
+    public IEnumerable<ConstantDefinition> Constants { get; set; }
+    public IEnumerable<ModelDefinition> Models { get; set; }
+}

--- a/data/Pandora.Data/Repositories/CommonTypesRepository.cs
+++ b/data/Pandora.Data/Repositories/CommonTypesRepository.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pandora.Data.Models;
+using CommonTypesDefinition = Pandora.Data.Models.CommonTypesDefinition;
+
+namespace Pandora.Data.Repositories;
+
+public class CommonTypesRepository : ICommonTypesRepository
+{
+    private readonly Dictionary<ServiceDefinitionType, List<CommonTypesDefinition>> _commonTypes;
+
+    public CommonTypesRepository(Dictionary<ServiceDefinitionType, IEnumerable<Definitions.Interfaces.CommonTypesDefinition>> commonTypes)
+    {
+        _commonTypes = new Dictionary<ServiceDefinitionType, List<CommonTypesDefinition>>();
+        foreach (var commonType in commonTypes)
+        {
+            var mapped = commonType.Value.Select(s => Transformers.CommonTypes.Map(s, commonType.Key)).ToList();
+            _commonTypes.Add(commonType.Key, mapped);
+        }
+    }
+
+    public IEnumerable<CommonTypesDefinition> Get(ServiceDefinitionType serviceDefinitionType)
+    {
+        var commonTypes = _commonTypes.Where(c => c.Key == serviceDefinitionType);
+        if (!commonTypes.Any())
+        {
+            return null;
+        }
+
+        return commonTypes.SelectMany(v => v.Value).ToList();
+    }
+}

--- a/data/Pandora.Data/Repositories/ICommonTypesRepository.cs
+++ b/data/Pandora.Data/Repositories/ICommonTypesRepository.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using Pandora.Data.Models;
+
+namespace Pandora.Data.Repositories;
+
+public interface ICommonTypesRepository
+{
+    IEnumerable<CommonTypesDefinition> Get(ServiceDefinitionType serviceDefinitionType);
+}

--- a/data/Pandora.Data/ServiceDefinitions.cs
+++ b/data/Pandora.Data/ServiceDefinitions.cs
@@ -1,12 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Pandora.Data.Models;
-using Pandora.Definitions.DataPlane;
-using Pandora.Definitions.HandDefined;
-using Pandora.Definitions.Interfaces;
-using Pandora.Definitions.MicrosoftGraph.Beta;
-using Pandora.Definitions.MicrosoftGraph.Stable;
-using Pandora.Definitions.ResourceManager;
 using ServiceDefinition = Pandora.Definitions.Interfaces.ServiceDefinition;
 
 namespace Pandora.Data;
@@ -15,38 +9,7 @@ public static class SupportedServices
 {
     public static Dictionary<ServiceDefinitionType, IEnumerable<ServiceDefinition>> Get()
     {
-        var data = new Dictionary<ServiceDefinitionType, List<ServicesDefinition>>
-        {
-            {
-                ServiceDefinitionType.DataPlane,
-                new List<ServicesDefinition>
-                {
-                    new DataPlaneServices(),
-                }
-            },
-            {
-                ServiceDefinitionType.MicrosoftGraphBeta,
-                new List<ServicesDefinition>
-                {
-                    new MicrosoftGraphBetaServices(),
-                }
-            },
-            {
-                ServiceDefinitionType.MicrosoftGraphStableV1,
-                new List<ServicesDefinition>
-                {
-                    new MicrosoftGraphStableV1Services(),
-                }
-            },
-            {
-                ServiceDefinitionType.ResourceManager,
-                new List<ServicesDefinition>
-                {
-                    new HandDefinedServices(),
-                    new ResourceManagerServices(),
-                }
-            },
-        };
+        var data = DefinitionTypes.Get();
         var output = new Dictionary<ServiceDefinitionType, IEnumerable<ServiceDefinition>>();
         foreach (var item in data)
         {

--- a/data/Pandora.Data/ServiceDefinitionsTests.cs
+++ b/data/Pandora.Data/ServiceDefinitionsTests.cs
@@ -8,7 +8,7 @@ using Pandora.Definitions.DataPlane;
 using Pandora.Definitions.HandDefined;
 using Pandora.Definitions.Interfaces;
 using Pandora.Definitions.MicrosoftGraph.Beta;
-using Pandora.Definitions.MicrosoftGraph.Stable;
+using Pandora.Definitions.MicrosoftGraph.StableV1;
 using Pandora.Definitions.ResourceManager;
 using ServiceDefinition = Pandora.Data.Models.ServiceDefinition;
 

--- a/data/Pandora.Data/Transformers/CommonTypes.cs
+++ b/data/Pandora.Data/Transformers/CommonTypes.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using Pandora.Data.Models;
+using Pandora.Definitions.Interfaces;
+using CommonTypesDefinition = Pandora.Data.Models.CommonTypesDefinition;
+
+namespace Pandora.Data.Transformers;
+
+public static class CommonTypes
+{
+    public static CommonTypesDefinition Map(Definitions.Interfaces.CommonTypesDefinition input, ServiceDefinitionType serviceDefinitionType)
+    {
+        try
+        {
+            var output = new CommonTypesDefinition
+            {
+                ServiceDefinitionType=serviceDefinitionType,
+            };
+            if (input == null)
+            {
+                return output;
+            }
+
+            output.Constants = input.Constants.Select(Constant.FromEnum).ToList();
+            output.Models = input.Models.Select(Model.Map).Where(m => m != null).Distinct(new ModelComparer()).OrderBy(m => m.Name).ToList();
+
+            return output;
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Mapping CommonTypes {input.GetType().FullName}", ex);
+        }
+    }
+}

--- a/data/Pandora.Data/Transformers/Version.cs
+++ b/data/Pandora.Data/Transformers/Version.cs
@@ -50,6 +50,9 @@ public static class Version
 
             case Source.ResourceManagerRestApiSpecs:
                 return ApiDefinitionsSource.ResourceManagerRestApiSpecs;
+
+            case Source.MicrosoftGraphMetadata:
+                return ApiDefinitionsSource.MicrosoftGraphMetadata;
         }
 
         throw new NotSupportedException($"unsupported/unmapped Source ${input.ToString()}");

--- a/data/Pandora.Definitions.MicrosoftGraph.StableV1/MicrosoftGraphStableV1Services.cs
+++ b/data/Pandora.Definitions.MicrosoftGraph.StableV1/MicrosoftGraphStableV1Services.cs
@@ -1,6 +1,6 @@
 ﻿using Pandora.Definitions.Interfaces;
 
-namespace Pandora.Definitions.MicrosoftGraph.Stable;
+namespace Pandora.Definitions.MicrosoftGraph.StableV1;
 
 public class MicrosoftGraphStableV1Services : ServicesDefinition
 {

--- a/data/Pandora.Definitions/Discovery/CommonTypes.cs
+++ b/data/Pandora.Definitions/Discovery/CommonTypes.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pandora.Definitions.Interfaces;
+
+namespace Pandora.Definitions.Discovery;
+
+public class CommonTypesDefinition : Pandora.Definitions.Interfaces.CommonTypesDefinition
+{
+    public IEnumerable<Type> Constants { get; set; }
+    public IEnumerable<Type> Models { get; set; }
+
+    public static CommonTypesDefinition ForServiceDefinition(ServicesDefinition input)
+    {
+        var commonTypesNamespace = $"{input.GetType().Assembly.GetName().Name}.CommonTypes";
+        var theType = input.GetType();
+        var commonTypes = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => a.FullName == input.GetType().Assembly.FullName)
+            .SelectMany(a => a.DefinedTypes)
+            .Where(t => t.Namespace == commonTypesNamespace)
+            .Select(t => t.UnderlyingSystemType).ToList();
+
+        var definition = new CommonTypesDefinition();
+        definition.Constants = commonTypes.Where(c => c.IsEnum).ToList();
+        definition.Models = commonTypes.Where(c => !c.IsEnum).ToList();
+
+        return definition;
+    }
+}

--- a/data/Pandora.Definitions/Interfaces/CommonTypesDefinition.cs
+++ b/data/Pandora.Definitions/Interfaces/CommonTypesDefinition.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Pandora.Definitions.Interfaces;
+
+public interface CommonTypesDefinition
+{
+    public IEnumerable<Type> Constants { get; set; }
+    public IEnumerable<Type> Models { get; set; }
+}

--- a/data/Pandora.Definitions/Interfaces/Source.cs
+++ b/data/Pandora.Definitions/Interfaces/Source.cs
@@ -17,4 +17,10 @@ public enum Source
     /// is sourced from data within the github.com/Azure/azure-rest-api-specs repository
     /// </summary>
     ResourceManagerRestApiSpecs,
+
+    /// <summary>
+    /// MicrosoftGraphMetadata specifies that this set of API Definitions
+    /// is sourced from data within the github.com/microsoftgraph/msgraph-metadata repository
+    /// </summary>
+    MicrosoftGraphMetadata,
 }


### PR DESCRIPTION
Adds an endpoint `/v1/microsoft-graph/{version}/commonTypes` which returns a composite response containing the 'common types' which should be in the `Pandora.Definitions.MicrosoftGraph.{Version}.CommonTypes` namespace.

* Returns only models/constants in this common namespace
* Does not include models/constants defined within a service/version/resource/other namespace
* Does not support any other types

This is intended to provide a mechanism to expose Microsoft Graph named models, which are highly interrelated and form an extensive graph network, making it infeasible to duplicate them between services/resources.

Also adds the API definitions source `MicrosoftGraphMetadata`.

**Example:**

```json
{
  "constants": {
    "AccessPackageAssignmentState": {
      "caseInsensitive": false,
      "type": "string",
      "values": {
        "delivering": "Delivering",
        "partiallyDelivered": "PartiallyDelivered",
        "delivered": "Delivered",
        "expired": "Expired",
        "deliveryFailed": "DeliveryFailed"
      }
    },
    "AccessPackageCatalogState": {
      "caseInsensitive": false,
      "type": "string",
      "values": {
        "unpublished": "Unpublished",
        "published": "Published"
      }
    }
  },
  "models": {
    "AccessPackageAnswer": {
      "fields": {
        "AnsweredQuestion": {
          "dateFormat": null,
          "default": null,
          "forceNew": false,
          "isTypeHint": false,
          "jsonName": "answeredQuestion",
          "objectDefinition": {
            "nestedItem": null,
            "referenceName": "AccessPackageQuestion",
            "type": "Reference"
          },
          "optional": true,
          "required": false,
          "validation": null
        },
        "DisplayValue": {
          "dateFormat": null,
          "default": null,
          "forceNew": false,
          "isTypeHint": false,
          "jsonName": "displayValue",
          "objectDefinition": {
            "nestedItem": null,
            "referenceName": null,
            "type": "String"
          },
          "optional": true,
          "required": false,
          "validation": null
        },
        "ODataType": {
          "dateFormat": null,
          "default": null,
          "forceNew": false,
          "isTypeHint": false,
          "jsonName": "@odata.type",
          "objectDefinition": {
            "nestedItem": null,
            "referenceName": null,
            "type": "String"
          },
          "optional": true,
          "required": false,
          "validation": null
        }
      },
      "parentTypeName": null,
      "typeHintIn": null,
      "typeHintValue": null
    }
  }
}
```

TODO:

- [ ] Naming things better
- [ ] Tests