### PR TITLE
tools/importer-rest-api-specs: ModelDefinition comparisons are now more detailed and Reference checks are now case-insensitive

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/internal/structs.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/structs.go
@@ -3,7 +3,9 @@ package internal
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -69,9 +71,92 @@ func (r *ParseResult) AppendModels(other map[string]models.ModelDetails) error {
 			return fmt.Errorf("comparing TypeHintValue: %+v", err)
 		}
 
-		if !reflect.DeepEqual(existing.Fields, v.Fields) {
-			return fmt.Errorf("different model objects. First fields: %+v. Second fields: %+v", existing.Fields, v.Fields)
+		if err := compareFields(existing.Fields, v.Fields); err != nil {
+			return fmt.Errorf("different model objects for Model %q: %+v.\n\nFirst fields: %+v.\n\nSecond fields: %+v", k, err, existing.Fields, v.Fields)
 		}
+	}
+
+	return nil
+}
+
+func compareFields(first map[string]models.FieldDetails, second map[string]models.FieldDetails) error {
+	if len(first) != len(second) {
+		return fmt.Errorf("first had %d fields but second had %d fields", len(first), len(second))
+	}
+
+	for k := range first {
+		firstVal := first[k]
+		secondVal, ok := second[k]
+		if !ok {
+			return fmt.Errorf("second didn't contain the key %q", k)
+		}
+
+		if firstVal.JsonName != secondVal.JsonName {
+			return fmt.Errorf("first.JsonName was %q but second.JsonName was %q", firstVal.JsonName, secondVal.JsonName)
+		}
+		if firstVal.Required != secondVal.Required {
+			return fmt.Errorf("first.Required was %t but second.Required was %t", firstVal.Required, secondVal.Required)
+		}
+		if firstVal.Sensitive != secondVal.Sensitive {
+			return fmt.Errorf("first.Sensitive was %t but second.Sensitive was %t", firstVal.Sensitive, secondVal.Sensitive)
+		}
+		if err := objectDefinitionsMatch(firstVal.ObjectDefinition, secondVal.ObjectDefinition); err != nil {
+			return fmt.Errorf("object definitions differ: %+v.\n\nFirst %q\n\nSecond %q", err, firstVal.ObjectDefinition, secondVal.ObjectDefinition)
+		}
+		if err := customFieldTypesMatch(firstVal.CustomFieldType, secondVal.CustomFieldType); err != nil {
+			return fmt.Errorf("custom field types differ: %+v\n\nFirst %q\n\nSecond %q", err, firstVal.ObjectDefinition, secondVal.ObjectDefinition)
+		}
+		// NOTE: we're intentionally not checking Description at this time
+	}
+
+	return nil
+}
+
+func objectDefinitionsMatch(first *models.ObjectDefinition, second *models.ObjectDefinition) error {
+	if first == nil && second == nil {
+		return nil
+	}
+	if first != nil && second == nil {
+		return fmt.Errorf("first was %q but second was nil", first.String())
+	}
+	if first == nil && second != nil {
+		return fmt.Errorf("first was nil but second was %q", second.String())
+	}
+	if err := objectDefinitionsMatch(first.NestedItem, second.NestedItem); err != nil {
+		return fmt.Errorf("nested items differ: %+v", err)
+	}
+	if first.Type != second.Type {
+		return fmt.Errorf("first.Type was %q but second.Type was %q", string(first.Type), string(second.Type))
+	}
+	if err := compareNilableString(first.ReferenceName, second.ReferenceName); err != nil {
+		return fmt.Errorf("value for ReferenceName differs: %+v\n\nFirst was %q but second was %q", err, pointer.From(first.ReferenceName), pointer.From(second.ReferenceName))
+	}
+	if err := compareNilableInteger(first.Maximum, second.Maximum); err != nil {
+		return fmt.Errorf("value for Maximum differs: %+v\n\nFirst was %d but second was %d", err, pointer.From(first.Maximum), pointer.From(second.Maximum))
+	}
+	if err := compareNilableInteger(first.Minimum, second.Minimum); err != nil {
+		return fmt.Errorf("value for Minimum differs: %+v\n\nFirst was %d but second was %d", err, pointer.From(first.Minimum), pointer.From(second.Minimum))
+	}
+	if err := compareNilableBoolean(first.UniqueItems, second.UniqueItems); err != nil {
+		return fmt.Errorf("value for Unique Items differs: %+v\n\nFirst was %t but second was %t", err, pointer.From(first.UniqueItems), pointer.From(second.UniqueItems))
+	}
+
+	return nil
+}
+
+func customFieldTypesMatch(first *models.CustomFieldType, second *models.CustomFieldType) error {
+	if first == nil && second == nil {
+		return nil
+	}
+	if first != nil && second == nil {
+		return fmt.Errorf("first was %q but second was nil", string(*first))
+	}
+	if first == nil && second != nil {
+		return fmt.Errorf("first was nil but second was %q", string(*second))
+	}
+
+	if *first != *second {
+		return fmt.Errorf("values differ - first was %q but second was %q", string(*first), string(*second))
 	}
 
 	return nil
@@ -83,13 +168,61 @@ func compareNilableString(first *string, second *string) error {
 			return fmt.Errorf("first value was %q but second value was nil", *first)
 		}
 
-		if *first != *second {
+		// @tombuildsstuff: the Azure API Definitions are wholy inconsistent here, so we'll case-insensitively
+		// compare the references as they're normalized at the final stage
+		//  * first value was "daprMetadata" but second value was "DaprMetadata"
+		//  * first value was "status" but second value was "Status"
+		//  * first value was "status" but second value was "Status"
+		//  * first value was "DataProviderMetadata" but second value was "dataProviderMetadata"
+		if !strings.EqualFold(*first, *second) {
 			return fmt.Errorf("first value was %q but second value was %q", *first, *second)
 		}
+
+		return nil
 	}
 
 	if second != nil {
 		return fmt.Errorf("first value was nil but second value was %q", *second)
+	}
+
+	return nil
+}
+
+func compareNilableInteger(first *int, second *int) error {
+	if first != nil {
+		if second == nil {
+			return fmt.Errorf("first value was %d but second value was nil", *first)
+		}
+
+		if *first != *second {
+			return fmt.Errorf("first value was %d but second value was %d", *first, *second)
+		}
+
+		return nil
+	}
+
+	if second != nil {
+		return fmt.Errorf("first value was nil but second value was %d", *second)
+	}
+
+	return nil
+}
+
+func compareNilableBoolean(first *bool, second *bool) error {
+	if first != nil {
+		if second == nil {
+			return fmt.Errorf("first value was %t but second value was nil", *first)
+		}
+
+		if *first != *second {
+			return fmt.Errorf("first value was %t but second value was %t", *first, *second)
+		}
+
+		return nil
+	}
+
+	if second != nil {
+		return fmt.Errorf("first value was nil but second value was %t", *second)
 	}
 
 	return nil

--- a/tools/importer-rest-api-specs/models/models.go
+++ b/tools/importer-rest-api-specs/models/models.go
@@ -1,6 +1,10 @@
 package models
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -53,6 +57,23 @@ type ObjectDefinition struct {
 
 	// UniqueItems specifies whether every item in this List/Dictionary must be unique
 	UniqueItems *bool
+}
+
+func (od ObjectDefinition) String() string {
+	nestedItem := "<nil>"
+	if od.NestedItem != nil {
+		nestedItem = od.NestedItem.String()
+	}
+
+	components := []string{
+		fmt.Sprintf("Type: %q", string(od.Type)),
+		fmt.Sprintf("Reference: %q", pointer.From(od.ReferenceName)),
+		fmt.Sprintf("Minimum: %d", pointer.From(od.Minimum)),
+		fmt.Sprintf("Maximum: %d", pointer.From(od.Maximum)),
+		fmt.Sprintf("Unique Items: %t", pointer.From(od.UniqueItems)),
+		fmt.Sprintf("Nested Item: %q", nestedItem),
+	}
+	return strings.Join(components, " / ")
 }
 
 type ObjectDefinitionType string


### PR DESCRIPTION
Fixes an issue when parsing ContainerApps@2022-11-01-preview and Web@2022-09-01

Unblocks https://github.com/hashicorp/pandora/pull/2734

I've tried adding an acctest to cover this scenario, but I'm struggling to do so due to the normalization - so I've omitted this for now.