### PR TITLE
tools/version-bumper: skipping updating services which are EOL/Deprecated/appear to be deprecated when importing the full set

### DIFF
--- a/tools/version-bumper/config.go
+++ b/tools/version-bumper/config.go
@@ -54,12 +54,12 @@ func reconcileWithAvailableServices(input services.Config, availableServices []A
 	result := make(map[string]services.Service, 0)
 	// first add the existing services we know about
 	for _, service := range input.Services {
-		result[strings.ToLower(service.Directory)] = service
+		result[normalizeServiceName(service.Directory)] = service
 	}
 
 	// first add the existing services we know about
 	for _, availableService := range availableServices {
-		key := strings.ToLower(availableService.Directory)
+		key := normalizeServiceName(availableService.Directory)
 		existing, hasExisting := result[key]
 		if !hasExisting {
 			// temporary feature-flag to ensure we only update the versions for previously-imported services
@@ -77,7 +77,7 @@ func reconcileWithAvailableServices(input services.Config, availableServices []A
 
 			result[key] = services.Service{
 				Directory: availableService.Directory,
-				Name:      strings.Title(availableService.Directory),
+				Name:      key,
 				Available: []string{
 					latestVersion,
 				},

--- a/tools/version-bumper/services_resource_manager.go
+++ b/tools/version-bumper/services_resource_manager.go
@@ -65,8 +65,28 @@ func (s ResourceManagerService) AvailableServices() (*[]AvailableService, error)
 		return nil, err
 	}
 
+	servicesToSkip := map[string]struct{}{
+		// These services are Removed and should be excluded
+		"blockchain":        {},
+		"devspaces":         {},
+		"servicefabricmesh": {},
+		"vmwarecloudsimple": {},
+
+		// These services are Deprecated and should be excluded
+		"servicemap": {},
+
+		// NOTE: we believe these services are deprecated?
+		"adhybridhealthservice": {},
+		"customerlockbox":       {},
+		"dynamicstelemetry":     {},
+		"iotspaces":             {},
+	}
 	output := make([]AvailableService, 0)
 	for _, service := range services {
+		if _, shouldSkip := servicesToSkip[strings.ToLower(service.Name)]; shouldSkip {
+			continue
+		}
+
 		output = append(output, service)
 	}
 


### PR DESCRIPTION
These also don't import correctly currently due to Swagger issues, however since they're EOL/Deprecated we can skip them