### PR TITLE
config: removing `elastic` @ `2020-07-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -200,7 +200,7 @@ service "dynatrace" {
 }
 service "elastic" {
   name      = "Elastic"
-  available = ["2020-07-01", "2023-06-01"]
+  available = ["2023-06-01"]
 }
 service "elasticsan" {
   name      = "ElasticSan"


### PR DESCRIPTION
No longer used as of https://github.com/hashicorp/terraform-provider-azurerm/pull/22451