### PR TITLE
`tools/importer-rest-api-specs`: detecting generic ARM Resource scopes

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
@@ -297,75 +297,86 @@ func TestParseResourceIdContainingAScope(t *testing.T) {
 }
 
 func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope.json")
-	if err != nil {
-		t.Fatalf("parsing: %+v", err)
+	files := []string{
+		"resource_ids_containing_hidden_scope.json",
+		"resource_ids_containing_hidden_scope_constant.json",
+		"resource_ids_containing_hidden_scope_hardcoded_provider.json",
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			fileName := file
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
+			result, err := ParseSwaggerFileForTesting(t, fileName)
+			if err != nil {
+				t.Fatalf("parsing: %+v", err)
+			}
+			if result == nil {
+				t.Fatal("result was nil")
+			}
+			if len(result.Resources) != 1 {
+				t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+			}
 
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
+			hello, ok := result.Resources["Example"]
+			if !ok {
+				t.Fatalf("no resources were output with the tag Example")
+			}
 
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type: resourcemanager.ScopeSegment,
-				Name: "scope",
-			},
-		},
-	}
-	expectedValue := "/{scope}"
-	actualValue, ok := hello.ResourceIds["ScopeId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
+			if len(hello.Constants) != 0 {
+				t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+			}
+			if len(hello.Models) != 0 {
+				t.Fatalf("expected no Models but got %d", len(hello.Models))
+			}
+			if len(hello.Operations) != 1 {
+				t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+			}
+			if len(hello.ResourceIds) != 1 {
+				t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
+			}
 
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ScopeId" {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
+			// first check the ResourceId looks good
+			expectedResourceId := models.ParsedResourceId{
+				Constants: map[string]resourcemanager.ConstantDetails{},
+				Segments: []resourcemanager.ResourceIdSegment{
+					{
+						Type: resourcemanager.ScopeSegment,
+						Name: "scope",
+					},
+				},
+			}
+			expectedValue := "/{scope}"
+			actualValue, ok := hello.ResourceIds["ScopeId"]
+			if !ok {
+				t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
+			}
+			if actualValue.String() != expectedValue {
+				t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
+			}
+			if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			// then check it's exposed in the operation itself
+			operation, ok := hello.Operations["OperationContainingAHiddenScope"]
+			if !ok {
+				t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
+			}
+			if operation.ResourceIdName == nil {
+				t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
+			}
+			if *operation.ResourceIdName != "ScopeId" {
+				t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
+			}
+			if operation.UriSuffix != nil {
+				t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
+			}
+		})
 	}
 }
 
-func TestParseResourceIdContainingAHiddenScopeConstant(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_constant.json")
+func TestParseResourceIdContainingAHiddenScopeWithSuffix(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_suffix.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -427,13 +438,95 @@ func TestParseResourceIdContainingAHiddenScopeConstant(t *testing.T) {
 	if *operation.ResourceIdName != "ScopeId" {
 		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
 	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
+	if operation.UriSuffix == nil {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be '/someEndpoint' but was nil")
+	}
+	if *operation.UriSuffix != "/someEndpoint" {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be '/someEndpoint' but got %q", *operation.UriSuffix)
 	}
 }
 
-func TestParseResourceIdContainingAHiddenScopeAndAHardcodedProviderName(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_hardcoded_provider.json")
+func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
+	files := []string{
+		"resource_ids_containing_hidden_scope_nested.json",
+		"resource_ids_containing_hidden_scope_nested_constants.json",
+		"resource_ids_containing_hidden_scope_nested_hardcoded_provider.json",
+	}
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			fileName := file
+
+			result, err := ParseSwaggerFileForTesting(t, fileName)
+			if err != nil {
+				t.Fatalf("parsing: %+v", err)
+			}
+			if result == nil {
+				t.Fatal("result was nil")
+			}
+			if len(result.Resources) != 1 {
+				t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+			}
+
+			hello, ok := result.Resources["Example"]
+			if !ok {
+				t.Fatalf("no resources were output with the tag Example")
+			}
+
+			if len(hello.Constants) != 0 {
+				t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+			}
+			if len(hello.Models) != 0 {
+				t.Fatalf("expected no Models but got %d", len(hello.Models))
+			}
+			if len(hello.Operations) != 1 {
+				t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+			}
+			if len(hello.ResourceIds) != 1 {
+				t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
+			}
+
+			// first check the ResourceId looks good
+			expectedResourceId := models.ParsedResourceId{
+				Constants: map[string]resourcemanager.ConstantDetails{},
+				Segments: []resourcemanager.ResourceIdSegment{
+					{
+						Type: resourcemanager.ScopeSegment,
+						Name: "scope",
+					},
+				},
+			}
+			expectedValue := "/{scope}"
+			actualValue, ok := hello.ResourceIds["ScopeId"]
+			if !ok {
+				t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
+			}
+			if actualValue.String() != expectedValue {
+				t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
+			}
+			if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			// then check it's exposed in the operation itself
+			operation, ok := hello.Operations["OperationContainingAHiddenScope"]
+			if !ok {
+				t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
+			}
+			if operation.ResourceIdName == nil {
+				t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
+			}
+			if *operation.ResourceIdName != "ScopeId" {
+				t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
+			}
+			if operation.UriSuffix != nil {
+				t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
+			}
+		})
+	}
+}
+
+func TestParseResourceIdContainingAHiddenScopeNestedWithSuffix(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_suffix.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -495,8 +588,11 @@ func TestParseResourceIdContainingAHiddenScopeAndAHardcodedProviderName(t *testi
 	if *operation.ResourceIdName != "ScopeId" {
 		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
 	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
+	if operation.UriSuffix == nil {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be '/someEndpoint' but was nil")
+	}
+	if *operation.UriSuffix != "/someEndpoint" {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be '/someEndpoint' but got %q", *operation.UriSuffix)
 	}
 }
 

--- a/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
@@ -296,6 +296,210 @@ func TestParseResourceIdContainingAScope(t *testing.T) {
 	}
 }
 
+func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Example"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Example")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 0 {
+		t.Fatalf("expected no Models but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 1 {
+		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
+	}
+
+	// first check the ResourceId looks good
+	expectedResourceId := models.ParsedResourceId{
+		Constants: map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			{
+				Type: resourcemanager.ScopeSegment,
+				Name: "scope",
+			},
+		},
+	}
+	expectedValue := "/{scope}"
+	actualValue, ok := hello.ResourceIds["ScopeId"]
+	if !ok {
+		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
+	}
+	if actualValue.String() != expectedValue {
+		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
+	}
+	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// then check it's exposed in the operation itself
+	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
+	if !ok {
+		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
+	}
+	if operation.ResourceIdName == nil {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
+	}
+	if *operation.ResourceIdName != "ScopeId" {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
+	}
+	if operation.UriSuffix != nil {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
+	}
+}
+
+func TestParseResourceIdContainingAHiddenScopeConstant(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_constant.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Example"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Example")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 0 {
+		t.Fatalf("expected no Models but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 1 {
+		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
+	}
+
+	// first check the ResourceId looks good
+	expectedResourceId := models.ParsedResourceId{
+		Constants: map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			{
+				Type: resourcemanager.ScopeSegment,
+				Name: "scope",
+			},
+		},
+	}
+	expectedValue := "/{scope}"
+	actualValue, ok := hello.ResourceIds["ScopeId"]
+	if !ok {
+		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
+	}
+	if actualValue.String() != expectedValue {
+		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
+	}
+	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// then check it's exposed in the operation itself
+	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
+	if !ok {
+		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
+	}
+	if operation.ResourceIdName == nil {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
+	}
+	if *operation.ResourceIdName != "ScopeId" {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
+	}
+	if operation.UriSuffix != nil {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
+	}
+}
+
+func TestParseResourceIdContainingAHiddenScopeAndAHardcodedProviderName(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_hardcoded_provider.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Example"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Example")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 0 {
+		t.Fatalf("expected no Models but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 1 {
+		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
+	}
+
+	// first check the ResourceId looks good
+	expectedResourceId := models.ParsedResourceId{
+		Constants: map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			{
+				Type: resourcemanager.ScopeSegment,
+				Name: "scope",
+			},
+		},
+	}
+	expectedValue := "/{scope}"
+	actualValue, ok := hello.ResourceIds["ScopeId"]
+	if !ok {
+		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
+	}
+	if actualValue.String() != expectedValue {
+		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
+	}
+	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// then check it's exposed in the operation itself
+	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
+	if !ok {
+		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
+	}
+	if operation.ResourceIdName == nil {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
+	}
+	if *operation.ResourceIdName != "ScopeId" {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
+	}
+	if operation.UriSuffix != nil {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
+	}
+}
+
 func TestParseResourceIdWithJustUriSuffix(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "resource_ids_with_just_suffix.json")
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
@@ -294,8 +294,20 @@ func segmentsContainAResourceManagerScope(input []resourcemanager.ResourceIdSegm
 				Name: "scope",
 			},
 		}
-		if len(input) > 8 {
-			output = append(output, input[8:]...)
+
+		// However it can _also_ be a Nested ID, e.g. for a Child Resource nested under a Parent Resource, for example:
+		// > /subscriptions/{}/resourceGroups/{}/providers/{}/{}/{}/{}/{}
+		// so we also need to check that
+		startingIndex := 8
+		if len(input) >= 10 {
+			nestedResourcePresent := input[8].Type == resourcemanager.UserSpecifiedSegment || input[8].Type == resourcemanager.ConstantSegment
+			nestedResourceNamePresent := input[9].Type == resourcemanager.UserSpecifiedSegment
+			if nestedResourcePresent && nestedResourceNamePresent {
+				startingIndex = 10
+			}
+		}
+		if len(input) > startingIndex {
+			output = append(output, input[startingIndex:]...)
 		}
 		return &output, true
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
@@ -189,6 +189,17 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 		segments = append(segments, models.StaticResourceIDSegment(normalizedName, normalizedSegment))
 	}
 
+	// now that we've parsed all of the URI Segments, let's determine if this contains a Resource ID scope
+
+	// Some Swaggers define Operation URI's which are generic scopes but which use the full Resource ID format
+	// rather than a /{scope} parameter, e.g.
+	// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}
+	//
+	// so we want to double-check if this is a matching scope
+	if replacement, ok := segmentsContainAResourceManagerScope(segments); ok {
+		segments = *replacement
+	}
+
 	out := processedResourceId{
 		segments:  nil,
 		uriSuffix: nil,
@@ -254,6 +265,42 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 	}
 
 	return &out, nil
+}
+
+func segmentsContainAResourceManagerScope(input []resourcemanager.ResourceIdSegment) (*[]resourcemanager.ResourceIdSegment, bool) {
+	if len(input) < 8 {
+		return nil, false
+	}
+
+	// a Resource Manager Scope is where a Scope is defined as:
+	// > /subscriptions/{}/resourceGroups/{}/providers/Some.ResourceProvider/{}/{}
+	// or
+	// > /subscriptions/{}/resourceGroups/{}/providers/{}/{}/{}
+	// as such, let's check this
+	subscriptionsPresent := input[0].Type == resourcemanager.StaticSegment && input[0].FixedValue != nil && strings.EqualFold(*input[0].FixedValue, "subscriptions")
+	subscriptionIdPresent := input[1].Type == resourcemanager.SubscriptionIdSegment
+	resourceGroupsPresent := input[2].Type == resourcemanager.StaticSegment && input[2].FixedValue != nil && strings.EqualFold(*input[2].FixedValue, "resourceGroups")
+	resourceGroupNamePresent := input[3].Type == resourcemanager.ResourceGroupSegment
+	providersPresent := input[4].Type == resourcemanager.StaticSegment && input[4].FixedValue != nil && strings.EqualFold(*input[4].FixedValue, "providers")
+	providerPresent := input[5].Type == resourcemanager.ResourceProviderSegment || input[5].Type == resourcemanager.UserSpecifiedSegment
+	resourceTypePresent := input[6].Type == resourcemanager.UserSpecifiedSegment || input[6].Type == resourcemanager.ConstantSegment
+	resourceNamePresent := input[7].Type == resourcemanager.UserSpecifiedSegment
+
+	prefixedWithGenericArmId := subscriptionsPresent && subscriptionIdPresent && resourceGroupsPresent && resourceGroupNamePresent && providersPresent && providerPresent && resourceTypePresent && resourceNamePresent
+	if prefixedWithGenericArmId {
+		output := []resourcemanager.ResourceIdSegment{
+			{
+				Type: resourcemanager.ScopeSegment,
+				Name: "scope",
+			},
+		}
+		if len(input) > 8 {
+			output = append(output, input[8:]...)
+		}
+		return &output, true
+	}
+
+	return nil, false
 }
 
 func determineUniqueNamesForSegments(input []resourcemanager.ResourceIdSegment) (*[]resourcemanager.ResourceIdSegment, error) {

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope.json
@@ -1,0 +1,75 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{resourceType}/{resourceName}": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "The name of the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_constant.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_constant.json
@@ -1,0 +1,83 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{resourceType}/{resourceName}": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "The name of the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "first",
+              "second"
+            ],
+            "x-ms-enum": {
+              "name": "ResourceTypeName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_hardcoded_provider.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_hardcoded_provider.json
@@ -1,0 +1,68 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.FooBar/{resourceType}/{resourceName}": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested.json
@@ -1,0 +1,89 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{parentResourceType}/{parentResourceName}/{resourceType}/{resourceName}": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "The name of the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The name of the parent resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The name of the parent resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested_constants.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested_constants.json
@@ -1,0 +1,105 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{parentResourceType}/{parentResourceName}/{resourceType}/{resourceName}": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "The name of the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The name of the parent resource type",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "first",
+              "second"
+            ],
+            "x-ms-enum": {
+              "name": "ParentResourceTypeName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The name of the parent resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "first",
+              "second"
+            ],
+            "x-ms-enum": {
+              "name": "ResourceTypeName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested_hardcoded_provider.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested_hardcoded_provider.json
@@ -1,0 +1,82 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.FooBar/{parentResourceType}/{parentResourceName}/{resourceType}/{resourceName}": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The name of the parent resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The name of the parent resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested_with_suffix.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested_with_suffix.json
@@ -1,0 +1,89 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{parentResourceType}/{parentResourceName}/{resourceType}/{resourceName}/someEndpoint": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "The name of the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The name of the parent resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The name of the parent resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_with_suffix.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_with_suffix.json
@@ -1,0 +1,75 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{resourceType}/{resourceName}/someEndpoint": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "The name of the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}


### PR DESCRIPTION
This fixes an issue when importing EventGrid, but detects Generic ARM Resource Scopes which are defined as ARM Resources with User Specified Segments (e.g. `/subscriptions/{}/resourceGroups/{}/providers/{}/{}/{}`) instead of Scopes (`/{scope}`). This is also the case for "nested" items (for example `/subscriptions/{}/resourceGroups/{}/providers/{}/{}/{}/{}/{}`)

These should be normalised into the Common ID `ScopeId` - but aren't captured with the Common IDs detection logic
since these can be one of many slightly different formats, so this is easiest to special-case.

Fixes #2341
Fixes #502
Unblocks #2309