### PR TITLE
tools/importer-rest-api-specs: fixing an issue where Resource IDs which are hidden ARM Scopes are pulled out correctly

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
@@ -375,6 +375,74 @@ func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
 	}
 }
 
+func TestParseResourceIdContainingAHiddenScopeWithExtraSegment(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_extra_segment.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Example"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Example")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 0 {
+		t.Fatalf("expected no Models but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 1 {
+		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
+	}
+
+	// first check the ResourceId looks good
+	expectedResourceId := models.ParsedResourceId{
+		Constants: map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			{
+				Type: resourcemanager.ScopeSegment,
+				Name: "scope",
+			},
+		},
+	}
+	expectedValue := "/{scope}"
+	actualValue, ok := hello.ResourceIds["ScopeId"]
+	if !ok {
+		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
+	}
+	if actualValue.String() != expectedValue {
+		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
+	}
+	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// then check it's exposed in the operation itself
+	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
+	if !ok {
+		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
+	}
+	if operation.ResourceIdName == nil {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
+	}
+	if *operation.ResourceIdName != "ScopeId" {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
+	}
+	if operation.UriSuffix != nil {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be 'nil' but got %q", *operation.UriSuffix)
+	}
+}
+
 func TestParseResourceIdContainingAHiddenScopeWithSuffix(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_suffix.json")
 	if err != nil {
@@ -522,6 +590,74 @@ func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
 				t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
 			}
 		})
+	}
+}
+
+func TestParseResourceIdContainingAHiddenScopeNestedWithExtraSegment(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_extra_segment.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Example"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Example")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 0 {
+		t.Fatalf("expected no Models but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 1 {
+		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
+	}
+
+	// first check the ResourceId looks good
+	expectedResourceId := models.ParsedResourceId{
+		Constants: map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			{
+				Type: resourcemanager.ScopeSegment,
+				Name: "scope",
+			},
+		},
+	}
+	expectedValue := "/{scope}"
+	actualValue, ok := hello.ResourceIds["ScopeId"]
+	if !ok {
+		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
+	}
+	if actualValue.String() != expectedValue {
+		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
+	}
+	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// then check it's exposed in the operation itself
+	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
+	if !ok {
+		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
+	}
+	if operation.ResourceIdName == nil {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
+	}
+	if *operation.ResourceIdName != "ScopeId" {
+		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
+	}
+	if operation.UriSuffix != nil {
+		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be 'nil' but got %q", *operation.UriSuffix)
 	}
 }
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
@@ -306,6 +306,15 @@ func segmentsContainAResourceManagerScope(input []resourcemanager.ResourceIdSegm
 				startingIndex = 10
 			}
 		}
+		// Continue trimming any user specified segments until we get to actual Resource ID
+		// since these can be included in the Scope itself
+		for len(input) > startingIndex {
+			segment := input[startingIndex]
+			if segment.Type != resourcemanager.UserSpecifiedSegment {
+				break
+			}
+			startingIndex++
+		}
 		if len(input) > startingIndex {
 			output = append(output, input[startingIndex:]...)
 		}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested_with_extra_segment.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_nested_with_extra_segment.json
@@ -1,0 +1,96 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{parentResourceType}/{parentResourceName}/{resourceType}/{resourceName}/{someSegment}": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "The name of the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The name of the parent resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The name of the parent resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "someSegment",
+            "in": "path",
+            "description": "Some segment",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_with_extra_segment.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/resource_ids_containing_hidden_scope_with_extra_segment.json
@@ -1,0 +1,82 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerNamespace}/{resourceType}/{resourceName}/{somethingElse}": {
+      "head": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_OperationContainingAHiddenScope",
+        "description": "This example is an operation containing a hidden Scope",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the Resource Group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerNamespace",
+            "in": "path",
+            "description": "The name of the provider namespace",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The name of the resource type",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "somethingElse",
+            "in": "path",
+            "description": "Some segment",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}


### PR DESCRIPTION


This fixes an issue where `/{scope}/{resourceName}` was being output instead of `/{scope}`