### PR TITLE
config: downgrade trusted access binding to `2023-03-02-preview`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -105,7 +105,7 @@ service "containerregistry" {
 }
 service "containerservice" {
   name      = "ContainerService"
-  available = ["2019-08-01", "2022-09-02-preview", "2023-04-02-preview"]
+  available = ["2019-08-01", "2022-09-02-preview", "2023-03-02-preview", "2023-04-02-preview"]
 }
 service "cosmos-db" {
   name      = "CosmosDB"

--- a/config/resources/containerservice.hcl
+++ b/config/resources/containerservice.hcl
@@ -16,7 +16,7 @@ HERE
     }
   }
 
-  api "2023-04-02-preview" {
+  api "2023-03-02-preview" {
     package "TrustedAccess" {
       definition "kubernetes_cluster_trusted_access_role_binding" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{managedClusterName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}"


### PR DESCRIPTION
Running the resource tests with 2023-04-02-preview results in an error:
```
=== CONT  TestAccKubernetesClusterTrustedAccessRoleBinding_complete
    testcase.go:113: Step 1/2 error: Error running apply: exit status 1
        Error: checking for the presence of an existing Trusted Access Role Binding (Subscription: "*******"
        Resource Group Name: "/subscriptions/*******/resourceGroups/acctestrg-230718013756695319/providers/Microsoft.ContainerService/managedClusters/acctestaksnzelq"
        Managed Cluster Name: "/subscriptions/*******/resourceGroups/acctestrg-230718013756695319/providers/Microsoft.ContainerService/managedClusters/acctestaksnzelq"
        Trusted Access Role Binding Name: "acctestkctarb-nzelq"): trustedaccess.TrustedAccessClient#RoleBindingsGet: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidApiVersionParameter" Message="The api-version '2023-04-02-preview' is invalid. The supported versions are '2023-07-01-preview,2023-03-01-preview,2022-12-01,2022-11-01-preview,2022-09-01,2022-06-01,2022-05-01,2022-03-01-preview,2022-01-01,2021-04-01,2021-01-01,2020-10-01,2020-09-01,2020-08-01,2020-07-01,2020-06-01,2020-05-01,2020-01-01,2019-11-01,2019-10-01,2019-09-01,2019-08-01,2019-07-01,2019-06-01,2019-05-10,2019-05-01,2019-03-01,2018-11-01,2018-09-01,2018-08-01,2018-07-01,2018-06-01,2018-05-01,2018-02-01,2018-01-01,2017-12-01,2017-08-01,2017-06-01,2017-05-10,2017-05-01,2017-03-01,2016-09-01,2016-07-01,2016-06-01,2016-02-01,2015-11-01,2015-01-01,2014-04-01-preview,2014-04-01,2014-01-01,2013-03-01,2014-02-26,2014-04'."
```