### PR TITLE
data api: set json name to `parsedFromParentId`

### DIFF
--- a/data/Pandora.Api/V1/Controllers/Terraform-Models.cs
+++ b/data/Pandora.Api/V1/Controllers/Terraform-Models.cs
@@ -256,7 +256,7 @@ public partial class TerraformController
         [JsonPropertyName("segmentName")]
         public string SegmentName { get; set; }
 
-        [JsonPropertyName("parent")]
+        [JsonPropertyName("parsedFromParentId")]
         public bool ParsedFromParentID { get; set; }
     }
 


### PR DESCRIPTION
Will fix https://github.com/hashicorp/terraform-provider-azurerm/pull/22635