### PR TITLE
tols/generator-go-sdk: outputting the content type if needed

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods.go
+++ b/tools/generator-go-sdk/generator/templater_methods.go
@@ -496,17 +496,21 @@ func (c methodsPandoraTemplater) requestOptions() (*string, error) {
 		options = "OptionsObject: options,"
 	}
 
-	out := fmt.Sprintf(`client.RequestOptions{
-		ContentType: "application/json",
-		ExpectedStatusCodes: []int{
-			%[1]s,
-		},
-		HttpMethod: http.Method%[2]s,
-		Path: %[3]s,
-		%[4]s
+	contentType := "application/json"
+	if c.operation.ContentType != nil {
+		contentType = *c.operation.ContentType
 	}
-`, strings.Join(expectedStatusCodes, ",\n\t\t\t"), method, path, options)
 
+	out := fmt.Sprintf(`client.RequestOptions{
+		ContentType: %[1]q,
+		ExpectedStatusCodes: []int{
+			%[2]s,
+		},
+		HttpMethod: http.Method%[3]s,
+		Path: %[4]s,
+		%[5]s
+	}
+`, contentType, strings.Join(expectedStatusCodes, ",\n\t\t\t"), method, path, options)
 	return &out, nil
 }
 

--- a/tools/generator-go-sdk/generator/templater_methods_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_test.go
@@ -79,6 +79,78 @@ func (c pandaClient) Get(ctx context.Context , id PandaPop) (result GetOperation
 	assertTemplatedCodeMatches(t, expected, *actual)
 }
 
+func TestTemplateMethodsGetAsTextPowerShell(t *testing.T) {
+	input := ServiceGeneratorData{
+		packageName:       "skinnyPandas",
+		serviceClientName: "pandaClient",
+		source:            AccTestLicenceType,
+		resourceIds: map[string]resourcemanager.ResourceIdDefinition{
+			"PandaPop": {
+				Id: "LingLing",
+			},
+		},
+	}
+
+	actual, err := methodsPandoraTemplater{
+		operation: resourcemanager.ApiOperation{
+			ContentType:         stringPointer("text/powershell"),
+			ExpectedStatusCodes: []int{200},
+			Method:              "GET",
+			ResourceIdName:      stringPointer("PandaPop"),
+			ResponseObject: &resourcemanager.ApiObjectDefinition{
+				Type: resourcemanager.StringApiObjectDefinitionType,
+			},
+		},
+		operationName: "Get",
+	}.immediateOperationTemplate(input)
+
+	if err != nil {
+		t.Fatalf("err %+v", err)
+	}
+
+	expected := `
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData *odata.OData
+	Model *string
+}
+
+// Get ...
+func (c pandaClient) Get(ctx context.Context , id PandaPop) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "text/powershell",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path: id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}
+`
+	assertTemplatedCodeMatches(t, expected, *actual)
+}
+
 func TestTemplateMethodsLROCreate(t *testing.T) {
 	input := ServiceGeneratorData{
 		packageName:       "skinnyPandas",


### PR DESCRIPTION
Fixes https://github.com/hashicorp/pandora/issues/2753