### PR TITLE
tools/importer-rest-api-specs: ignoring the LROs in Web

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/internal/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/helpers.go
@@ -31,6 +31,9 @@ func OperationShouldBeIgnored(operationUri string) bool {
 	if strings.Contains(strings.ToLower(operationUri), "/costdetailsoperationresults/") {
 		return true
 	}
+	if strings.Contains(strings.ToLower(operationUri), "/deploymentstatus/") { // web
+		return true
+	}
 	if strings.Contains(strings.ToLower(operationUri), "/managedclusteroperations/") {
 		return true
 	}


### PR DESCRIPTION
Web exposes 2 URI's which are GET LRO's but that don't make sense for us to expose:

> /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName}/deploymentStatus/{deploymentStatusId}

and

> /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName}/slots/{slotName}/deploymentStatus/{deploymentStatusId}

Since both of these are LRO's these results should be available instead via the associated Deployment operations, so these LRO's aren't needed.

This fixes an issue when generating the Go SDK, since GET LRO's aren't supported.