### PR TITLE
tools/importer-rest-api-specs: adding Common IDs for App Service / App Service Plan / App Service Environment

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdAppService{}
+
+type commonIdAppService struct{}
+
+func (c commonIdAppService) id() models.ParsedResourceId {
+	name := "AppService"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			models.StaticResourceIDSegment("sites", "sites"),
+			models.UserSpecifiedResourceIDSegment("siteName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_environment.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_environment.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdAppServiceEnvironment{}
+
+type commonIdAppServiceEnvironment struct{}
+
+func (c commonIdAppServiceEnvironment) id() models.ParsedResourceId {
+	name := "AppServiceEnvironment"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			models.StaticResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
+			models.UserSpecifiedResourceIDSegment("hostingEnvironmentName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_plan.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_plan.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdAppServicePlan{}
+
+type commonIdAppServicePlan struct{}
+
+func (c commonIdAppServicePlan) id() models.ParsedResourceId {
+	name := "AppServicePlan"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			models.StaticResourceIDSegment("serverFarms", "serverFarms"),
+			models.UserSpecifiedResourceIDSegment("serverFarmName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -59,6 +59,11 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdStorageAccount{},
 	commonIdStorageContainer{},
 
+	// Web / App Service
+	commonIdAppService{},
+	commonIdAppServiceEnvironment{},
+	commonIdAppServicePlan{},
+
 	// Parent IDs
 	commonIdKubernetesCluster{},
 }


### PR DESCRIPTION
Needs the associated Common IDs into `hashicorp/go-azure-helpers` vendored into `hashicorp/go-azure-sdk` and `hashicorp/terraform-provider-azurerm` first

Dependent on https://github.com/hashicorp/go-azure-helpers/pull/172