### PR TITLE
revert devtestlabs back to autorest

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -46,6 +46,7 @@ func main() {
 		"ContainerInstance",
 		"CosmosDB",
 		"DataShare",
+		"DevTestLab", // failed due to "devtestlab/2018-09-15/client.go:34:2: environments redeclared in this block"
 		"FrontDoor",
 		"HardwareSecurityModules",
 		"HealthBot",


### PR DESCRIPTION
reverting due to

```
PASS
2023-07-25T17:23:55.7965142Z ok  	github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2023-07-01/privatelinkresources	0.009s
2023-07-25T17:23:57.5233408Z # github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15
2023-07-25T17:23:57.5313869Z ##[error]resource-manager/devtestlab/2018-09-15/client.go:34:2: environments redeclared in this block
2023-07-25T17:23:57.5321859Z ##[error]	resource-manager/devtestlab/2018-09-15/client.go:15:2: other declaration of environments
2023-07-25T17:23:57.5323030Z ##[error]resource-manager/devtestlab/2018-09-15/client.go:34:2: imported and not used: "github.com/hashicorp/go-azure-sdk/sdk/environments"
2023-07-25T17:23:57.5323968Z ##[error]resource-manager/devtestlab/2018-09-15/client.go:64:44: undefined: environments.Api
```