### PR TITLE
Legacy MySQL 2020-01-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -344,7 +344,7 @@ service "msi" {
 }
 service "mysql" {
   name      = "MySql"
-  available = ["2021-05-01", "2021-12-01-preview", "2022-01-01"]
+  available = ["2020-01-01", "2021-05-01", "2021-12-01-preview", "2022-01-01"]
 }
 service "netapp" {
   name      = "NetApp"


### PR DESCRIPTION
This PR adds legacy 2020-01-01 mysql to pandora. Not sure if this is the right way to do this but it's what we need to migrate mysql over to go-azure-sdk

API Specs for reference https://github.com/Azure/azure-rest-api-specs/tree/7c50841aadb4bfc241de3f09146e1f97ce3583b2/specification/mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2020-01-01