### PR TITLE
Remove 2020-01-01 from pandora

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -344,7 +344,7 @@ service "msi" {
 }
 service "mysql" {
   name      = "MySql"
-  available = ["2020-01-01", "2021-05-01", "2021-12-01-preview", "2022-01-01"]
+  available = ["2021-05-01", "2021-12-01-preview", "2022-01-01"]
 }
 service "netapp" {
   name      = "NetApp"


### PR DESCRIPTION
We need [legacy 2021-05-01](https://github.com/Azure/azure-rest-api-specs/tree/7c50841aadb4bfc241de3f09146e1f97ce3583b2/specification/mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2021-05-01) but we already support a version `2021-05-01`. Is there a way we can point to the legacy version as well?