### PR TITLE
tools/generator-go-sdk: updating `apimanagement` to use the new base layer

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -35,7 +35,6 @@ func main() {
 
 		// NOTE: also see the list in ./tools/generator-terraform/generator/definitions/template_service_client.go
 		// for services/resources which are auto-generated
-		"ApiManagement",
 		"Compute",
 		"ContainerApps",
 		"ContainerInstance",


### PR DESCRIPTION
Whilst I was leaving this until the initial PR to port this over to the new SDK was open, turns out we need to fix a recasing issue, so we might as well do this from the start.