### PR TITLE
tools/generator-go-sdk: fixing an issue where the `environments` import conflicts by aliasing it

### DIFF
--- a/tools/generator-go-sdk/generator/templater_clients.go
+++ b/tools/generator-go-sdk/generator/templater_clients.go
@@ -16,9 +16,8 @@ func (c clientsTemplater) template(data ServiceGeneratorData) (*string, error) {
 	template := fmt.Sprintf(`package %[1]s
 
 import (
-	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
-	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
 )
 
 %[3]s
@@ -27,7 +26,7 @@ type %[2]s struct {
 	Client  *resourcemanager.Client
 }
 
-func New%[2]sWithBaseURI(api environments.Api) (*%[2]s, error) {
+func New%[2]sWithBaseURI(api sdkEnv.Api) (*%[2]s, error) {
 	client, err := resourcemanager.NewResourceManagerClient(api, %[1]q, defaultApiVersion)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating %[2]s: %%+v", err)

--- a/tools/generator-go-sdk/generator/templater_clients_test.go
+++ b/tools/generator-go-sdk/generator/templater_clients_test.go
@@ -19,9 +19,8 @@ func TestTemplateClient(t *testing.T) {
 	expected := `package somepackage
 
 import (
-	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
-	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
 )
 
 // acctests licence placeholder
@@ -30,7 +29,7 @@ type ExampleClient struct {
 	Client  *resourcemanager.Client
 }
 
-func NewExampleClientWithBaseURI(api environments.Api) (*ExampleClient, error) {
+func NewExampleClientWithBaseURI(api sdkEnv.Api) (*ExampleClient, error) {
 	client, err := resourcemanager.NewResourceManagerClient(api, "somepackage", defaultApiVersion)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating ExampleClient: %+v", err)

--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -59,8 +59,8 @@ configureFunc(%[1]s.Client)
 %[2]s
 
 import (
-	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
 	%[3]s
 )
 
@@ -68,7 +68,7 @@ type Client struct {
 	%[4]s
 }
 
-func NewClientWithBaseURI(api environments.Api, configureFunc func(c *resourcemanager.Client)) (*Client, error) {
+func NewClientWithBaseURI(api sdkEnv.Api, configureFunc func(c *resourcemanager.Client)) (*Client, error) {
 	%[5]s
 
 	return &Client{


### PR DESCRIPTION
This fixes an issue where some API Resources are called `Environments`, which conflicts with the import for `sdk/environments`, used to define an Azure Environment

Fixes https://github.com/hashicorp/pandora/issues/2825
Fixes https://github.com/hashicorp/go-azure-sdk/pull/580