### PR TITLE
data: moving `DevTestLabs` over to the new base layer

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -40,7 +40,6 @@ func main() {
 		"ContainerInstance",
 		"CosmosDB",
 		"DataShare",
-		"DevTestLab", // https://github.com/hashicorp/pandora/issues/2825
 		"FrontDoor",
 		"HardwareSecurityModules",
 		"HealthBot",


### PR DESCRIPTION
Possible now that https://github.com/hashicorp/pandora/issues/2825 has been fixed