### PR TITLE
tools/generator-go-sdk: fixing an issue where the argument name conflicts with the generated SDK

### DIFF
--- a/tools/generator-go-sdk/generator/templater_clients.go
+++ b/tools/generator-go-sdk/generator/templater_clients.go
@@ -26,8 +26,8 @@ type %[2]s struct {
 	Client  *resourcemanager.Client
 }
 
-func New%[2]sWithBaseURI(api sdkEnv.Api) (*%[2]s, error) {
-	client, err := resourcemanager.NewResourceManagerClient(api, %[1]q, defaultApiVersion)
+func New%[2]sWithBaseURI(sdkApi sdkEnv.Api) (*%[2]s, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, %[1]q, defaultApiVersion)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating %[2]s: %%+v", err)
 	}

--- a/tools/generator-go-sdk/generator/templater_clients_test.go
+++ b/tools/generator-go-sdk/generator/templater_clients_test.go
@@ -29,8 +29,8 @@ type ExampleClient struct {
 	Client  *resourcemanager.Client
 }
 
-func NewExampleClientWithBaseURI(api sdkEnv.Api) (*ExampleClient, error) {
-	client, err := resourcemanager.NewResourceManagerClient(api, "somepackage", defaultApiVersion)
+func NewExampleClientWithBaseURI(sdkApi sdkEnv.Api) (*ExampleClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "somepackage", defaultApiVersion)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating ExampleClient: %+v", err)
 	}

--- a/tools/generator-go-sdk/generator/templater_meta_client.go
+++ b/tools/generator-go-sdk/generator/templater_meta_client.go
@@ -37,7 +37,7 @@ func (m metaClientTemplater) template() (*string, error) {
 
 		imports = append(imports, fmt.Sprintf(`"github.com/hashicorp/go-azure-sdk/resource-manager/%s/%s/%s"`, strings.ToLower(m.serviceName), m.apiVersion, strings.ToLower(resourceName)))
 		fields = append(fields, fmt.Sprintf("%[1]s *%[2]s.%[1]sClient", resourceName, strings.ToLower(resourceName)))
-		clientInitializationTemplate := fmt.Sprintf(`%[1]s, err := %[2]s.New%[3]sClientWithBaseURI(api)
+		clientInitializationTemplate := fmt.Sprintf(`%[1]s, err := %[2]s.New%[3]sClientWithBaseURI(sdkApi)
 if err != nil {
 	return nil, fmt.Errorf("building %[3]s client: %%+v", err)
 }
@@ -68,7 +68,7 @@ type Client struct {
 	%[4]s
 }
 
-func NewClientWithBaseURI(api sdkEnv.Api, configureFunc func(c *resourcemanager.Client)) (*Client, error) {
+func NewClientWithBaseURI(sdkApi sdkEnv.Api, configureFunc func(c *resourcemanager.Client)) (*Client, error) {
 	%[5]s
 
 	return &Client{


### PR DESCRIPTION
See: https://github.com/hashicorp/go-azure-sdk/actions/runs/5716954573