### PR TITLE
Importer: Custom filed user assigned identity (map) tolerate exposed principal id at top level

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_map.go
@@ -95,9 +95,9 @@ func (userAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition 
 			continue
 		}
 
-		// some services expose tenant ID in the definition for a user assigned identity - we should recognise it as a user assigned identity but ignore the field
-		// https://github.com/Azure/azure-rest-api-specs/blob/5a9afce8360020c46b38841e04179447a28118b2/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/FlexibleServers.json#L812-L834
-		if strings.EqualFold(fieldName, "TenantId") {
+		// some services expose tenant ID or/and principal ID in the definition for a user assigned identity - we should recognise it as a user assigned identity but ignore the field
+		// https://github.com/Azure/azure-rest-api-specs/blob/14d24d17491d8c2bde24532cb8cc2d663c0ffd9f/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2023-05-01/amlfilesystem.json#L565
+		if strings.EqualFold(fieldName, "TenantId") || strings.EqualFold(fieldName, "PrincipalId") {
 			continue
 		}
 

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_map.go
@@ -96,7 +96,8 @@ func (userAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition 
 		}
 
 		// some services expose tenant ID or/and principal ID in the definition for a user assigned identity - we should recognise it as a user assigned identity but ignore the field
-		// https://github.com/Azure/azure-rest-api-specs/blob/14d24d17491d8c2bde24532cb8cc2d663c0ffd9f/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2023-05-01/amlfilesystem.json#L565
+		// This model exposed "tenantId": https://github.com/Azure/azure-rest-api-specs/blob/5a9afce8360020c46b38841e04179447a28118b2/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2022-12-01/FlexibleServers.json#L812-L834
+		// This model exposed both "tenantId" and "principalId": https://github.com/Azure/azure-rest-api-specs/blob/14d24d17491d8c2bde24532cb8cc2d663c0ffd9f/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2023-05-01/amlfilesystem.json#L565
 		if strings.EqualFold(fieldName, "TenantId") || strings.EqualFold(fieldName, "PrincipalId") {
 			continue
 		}

--- a/tools/importer-rest-api-specs/components/parser/models_identity_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_identity_test.go
@@ -2531,6 +2531,99 @@ func TestModelsWithAUserAssignedMapIdentityWithTenantId(t *testing.T) {
 	}
 }
 
+func TestModelsWithAUserAssignedMapIdentityWithPrincipalId(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "model_user_assigned_map_with_principal_id.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "Example" {
+		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	exampleModel, ok := hello.Models["Example"]
+	if !ok {
+		t.Fatalf("expected there to be a model called Example")
+	}
+	if len(exampleModel.Fields) != 2 {
+		t.Fatalf("expected the model Example to have 2 field but got %d", len(exampleModel.Fields))
+	}
+	if _, ok := exampleModel.Fields["Name"]; !ok {
+		t.Fatalf("expected there to be a field called Name")
+	}
+	identityField, ok := exampleModel.Fields["Identity"]
+	if !ok {
+		t.Fatalf("expected there to be a field called Identity")
+	}
+	if identityField.CustomFieldType == nil {
+		t.Fatalf("expected the field Identity to have a CustomFieldType")
+	}
+	if *identityField.CustomFieldType != models.CustomFieldTypeUserAssignedIdentityMap {
+		t.Fatalf("expected the field Identity to have a CustomFieldType of UserAssignedIdentityMap")
+	}
+	if identityField.ObjectDefinition != nil {
+		t.Fatalf("expected the field Identity to have no ObjectDefinition")
+	}
+}
+
 func TestModelsWithAUserAssignedMapIdentityWithAdditionalFields(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "model_user_assigned_map_with_additional_field.json")
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/parser/testdata/model_user_assigned_map_with_principal_id.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/model_user_assigned_map_with_principal_id.json
@@ -1,0 +1,91 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Example"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Example": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identity": {
+          "$ref": "#/definitions/UserAssignedIdentityMap"
+        }
+      },
+      "type": "object",
+      "title": "Example"
+    },
+    "UserAssignedIdentityMap": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "None",
+            "UserAssigned"
+          ],
+          "x-ms-enum": {
+            "name": "IdentityType2",
+            "modelAsString": true
+          }
+        },
+        "userAssignedIdentities": {
+          "$ref": "#/definitions/UserAssignedIdentityMapReal"
+        },
+        "principalId" : {
+          "type": "string",
+          "description": "The principal ID for the user-assigned identity of the resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "UserAssignedIdentityMapReal": {
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string"
+          },
+          "principalId": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
The storage cache AML file system resource defined UAI with the `principalId` and `tenantId` defined at the top identity model level: https://github.com/Azure/azure-rest-api-specs/blob/14d24d17491d8c2bde24532cb8cc2d663c0ffd9f/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2023-05-01/amlfilesystem.json#L565.

Without this change, the identity field of the `AMLFileSystem` model will not be defined as the commonschema.

Related to: https://github.com/hashicorp/terraform-provider-azurerm/pull/22680