### PR TITLE
tools/importer-rest-api-specs: adding a workaround for `authorization`'s missing `$filter`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_authorization.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_authorization.go
@@ -1,0 +1,42 @@
+package dataworkarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundAuthorization25080{}
+
+type workaroundAuthorization25080 struct {
+}
+
+func (workaroundAuthorization25080) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	return apiDefinition.ServiceName == "Authorization" && apiDefinition.ApiVersion == "2020-10-01"
+}
+
+func (workaroundAuthorization25080) Name() string {
+	return "Authorization / 25080"
+}
+
+func (workaroundAuthorization25080) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resource, ok := apiDefinition.Resources["RoleManagementPolicies"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `RoleManagementPolicies` but didn't get one")
+	}
+	operation, ok := resource.Operations["ListForScope"]
+	if !ok {
+		return nil, fmt.Errorf("expected an Operation named `ListForScope` but didn't get one")
+	}
+	operation.Options["Filter"] = models.OperationOption{
+		ObjectDefinition: &models.ObjectDefinition{
+			Type: models.ObjectDefinitionString,
+		},
+		QueryStringName: pointer.To("$filter"),
+		Required:        false,
+	}
+	resource.Operations["ListForScope"] = operation
+	apiDefinition.Resources["RoleManagementPolicies"] = resource
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -8,6 +8,7 @@ import (
 )
 
 var workarounds = []workaround{
+	workaroundAuthorization25080{},
 	workaroundBatch21291{},
 	workaroundContainerService21394{},
 	workaroundDataFactory23013{},


### PR DESCRIPTION
Upstream PR on `Azure/azure-rest-api-specs`: https://github.com/Azure/azure-rest-api-specs/pull/25080

Fixes https://github.com/hashicorp/go-azure-sdk/issues/288

Diff:

```diff
 $ git diff data
diff --git a/data/Pandora.Definitions.ResourceManager/Authorization/v2020_10_01/RoleManagementPolicies/Operation-ListForScope.cs b/data/Pandora.Definitions.ResourceManager/Authorization/v2020_10_01/RoleManagementPolicies/Operation-ListForScope.cs
index de2f049153..0141f63acb 100644
--- a/data/Pandora.Definitions.ResourceManager/Authorization/v2020_10_01/RoleManagementPolicies/Operation-ListForScope.cs
+++ b/data/Pandora.Definitions.ResourceManager/Authorization/v2020_10_01/RoleManagementPolicies/Operation-ListForScope.cs
@@ -20,7 +20,14 @@ internal class ListForScopeOperation : Pandora.Definitions.Operations.ListOperat

     public override Type NestedItemType() => typeof(RoleManagementPolicyModel);

-    public override string? UriSuffix() => "/providers/Microsoft.Authorization/roleManagementPolicies";
+    public override Type? OptionsObject() => typeof(ListForScopeOperation.ListForScopeOptions);

+    public override string? UriSuffix() => "/providers/Microsoft.Authorization/roleManagementPolicies";

+    internal class ListForScopeOptions
+    {
+        [QueryStringName("$filter")]
+        [Optional]
+        public string Filter { get; set; }
+    }
 }
```