### PR TITLE
tools/generator-go-sdk: exporting the Raw generated types

### DIFF
--- a/tools/generator-go-sdk/generator/templater_models_discriminators_test.go
+++ b/tools/generator-go-sdk/generator/templater_models_discriminators_test.go
@@ -74,6 +74,15 @@ import (
 type ModeOfTransit interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawModeOfTransitImpl struct {
+	Type string
+	Values map[string]interface{}
+}
+
 func unmarshalModeOfTransitImplementation(input []byte) (ModeOfTransit, error) {
 	if input == nil {
 		return nil, nil
@@ -105,16 +114,11 @@ func unmarshalModeOfTransitImplementation(input []byte) (ModeOfTransit, error) {
 		return out, nil
 	}
 
-	type RawModeOfTransitImpl struct {
-		Type string ''json:"-"''
-		Values map[string]interface{} ''json:"-"''
-	}
 	out := RawModeOfTransitImpl{
 		Type:   value,
 		Values: temp,
 	}
 	return out, nil
-
 }
 `, "''", "`")
 	assertTemplatedCodeMatches(t, expected, *actual)


### PR DESCRIPTION
This PR fixes https://github.com/hashicorp/go-azure-sdk/issues/287 by exposing the Raw types rather than using internal types for these.

Since these fields are intentionally only consumable via the Response and are not usable in Request Payloads exposing this is reasonable, but I've added a warning that these should be a last resort/workaround only.