### PR TITLE
tools/importer-rest-api-specs: adding a workaround for `digitaltwins`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_digitaltwins_25120.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_digitaltwins_25120.go
@@ -1,0 +1,53 @@
+package dataworkarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundDigitalTwins25120{}
+
+// Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/21520
+type workaroundDigitalTwins25120 struct{}
+
+func (workaroundDigitalTwins25120) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	// API Defines a Constant with the string values `"true"` and `"false`:
+	// RecordPropertyAndItemRemovals           *RecordPropertyAndItemRemovals `json:"recordPropertyAndItemRemovals,omitempty"`
+	// but the API returns a boolean:
+	// "recordPropertyAndItemRemovals": false,
+	return apiDefinition.ServiceName == "DigitalTwins" && apiDefinition.ApiVersion == "2023-01-31"
+}
+
+func (workaroundDigitalTwins25120) Name() string {
+	return "DigitalTwins / 25120"
+}
+
+func (workaroundDigitalTwins25120) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resource, ok := apiDefinition.Resources["TimeSeriesDatabaseConnections"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `TimeSeriesDatabaseConnections`")
+	}
+
+	model, ok := resource.Models["AzureDataExplorerConnectionProperties"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Model named `AzureDataExplorerConnectionProperties`")
+	}
+	field, ok := model.Fields["RecordPropertyAndItemRemovals"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Field named `RecordPropertyAndItemRemovals`")
+	}
+	field.ObjectDefinition = &models.ObjectDefinition{
+		Type: models.ObjectDefinitionBoolean,
+	}
+	model.Fields["RecordPropertyAndItemRemovals"] = field
+	resource.Models["AzureDataExplorerConnectionProperties"] = model
+
+	if _, ok := resource.Constants["RecordPropertyAndItemRemovals"]; !ok {
+		return nil, fmt.Errorf("expected a Constant named `RecordPropertyAndItemRemovals`")
+	}
+	delete(resource.Constants, "RecordPropertyAndItemRemovals")
+
+	apiDefinition.Resources["TimeSeriesDatabaseConnections"] = resource
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -9,6 +9,7 @@ import (
 
 var workarounds = []workaround{
 	workaroundAuthorization25080{},
+	workaroundDigitalTwins25120{},
 	workaroundAutomation25108{},
 	workaroundBatch21291{},
 	workaroundContainerService21394{},


### PR DESCRIPTION
Unblocks https://github.com/hashicorp/terraform-provider-azurerm/pull/22782