### PR TITLE
refactor: moving the `swagger` submodule to `submodules/rest-api-specs`

### DIFF
--- a/.github/workflows/automation-msgraph-metadata-importer.yaml
+++ b/.github/workflows/automation-msgraph-metadata-importer.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           gh pr create --title "$PR_TITLE" --body "$PR_BODY" -H "$PR_SOURCE" -B "$PR_TARGET"
         env:
-          PR_TITLE: "Data: regenerating based on ${{ github.sha }}"
+          PR_TITLE: "Data: Microsoft Graph - regenerating based on ${{ github.sha }}"
           PR_BODY: "This PR is automatically generated based on the commit ${{ github.sha }}"
           PR_SOURCE: "data/regeneration-from-${{ github.sha }}"
           PR_TARGET: "main"

--- a/.github/workflows/automation-rest-api-specs-importer.yaml
+++ b/.github/workflows/automation-rest-api-specs-importer.yaml
@@ -6,7 +6,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'config/**'
-      - 'swagger'
+      - 'submodules/rest-api-specs'
       - 'tools/importer-rest-api-specs/**'
 
 
@@ -62,7 +62,7 @@ jobs:
         run: |
           gh pr create --title "$PR_TITLE" --body "$PR_BODY" -H "$PR_SOURCE" -B "$PR_TARGET"
         env:
-          PR_TITLE: "Data: regenerating based on ${{ github.sha }}"
+          PR_TITLE: "Data: Rest Api Specs - regenerating based on ${{ github.sha }}"
           PR_BODY: "This PR is automatically generated based on the commit ${{ github.sha }}"
           PR_SOURCE: "data/regeneration-from-${{ github.sha }}"
           PR_TARGET: "main"

--- a/.github/workflows/automation-version-bumper.yaml
+++ b/.github/workflows/automation-version-bumper.yaml
@@ -7,7 +7,7 @@ on:
       - '.github/workflows/**'
       - 'config/**'
       - 'submodules/msgraph-metadata'
-      - 'swagger'
+      - 'submodules/rest-api-specs'
       - 'tools/version-bumper/**'
 
 jobs:

--- a/.github/workflows/unit-test-rest-api-specs-importer.yaml
+++ b/.github/workflows/unit-test-rest-api-specs-importer.yaml
@@ -6,7 +6,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'config/**'
-      - 'swagger'
+      - 'submodules/rest-api-specs'
       - 'tools/importer-rest-api-specs/**'
 
 jobs:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "swagger"]
-	path = swagger
-	url = git@github.com:Azure/azure-rest-api-specs.git
 [submodule "msgraph-metadata"]
 	path = submodules/msgraph-metadata
 	url = git@github.com:microsoftgraph/msgraph-metadata.git
+[submodule "submodules/rest-api-specs"]
+	path = submodules/rest-api-specs
+	url = git@github.com:Azure/azure-rest-api-specs.git

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Pandora's primarily intended to be run in automation (using both Github Actions 
 
 * Once a Pull Request is merged that updates one of the following paths, the Rest API Specs Importer is run.
   * The Resource Manager Config (`./config/resource-manager.hcl`).
-  * The Resource Manager Swagger Git Submodule (`./swagger`).
+  * The Resource Manager Swagger Git Submodule (`./submodules/rest-api-specs`).
   * Any of the tooling within `./tools`.
 * If the Rest API Specs Importer outputs any changes to the Imported API Definitions, those are committed and a Pull Request is opened.
 * Once that PR is merged, if there's any changes then the `hashicorp/go-azure-sdk` repository is updated in the same fashion via the Go SDK Generator (outputting any new/changes to the Go SDK).
@@ -58,9 +58,11 @@ More information on [how to import a new Resource Manager Service/API Version fo
 - `./config/resource-manager.hcl` - contains the list of Resource Manager Services and API Versions which should be imported.
 - `./data` - contains the Data API, containing the transformed Azure API Definitions in the intermediate C# format.
 - `./docs` - contains documentation.
-- `./swagger` - contains the Git Submodule to [the Azure Rest API Specs repository](https://github.com/Azure/azure-rest-api-specs) - containing the OpenAPI/Swagger definitions for Azure Resource Manager.
+- `./submodules/msgraph-metadata` - contains the Git Submodule to [the `microsoftgraph/msgraph-metadata` repository](https://github.com/microsoftgraph/msgraph-metadata) - containing the OpenAPI/Swagger definitions for Microsoft Graph.
+- `./submodules/rest-api-specs` - contains the Git Submodule to [the `Azure/azure-rest-api-specs` repository](https://github.com/Azure/azure-rest-api-specs) - containing the OpenAPI/Swagger definitions for Azure Resource Manager.
 - `./tools/generator-go-sdk` - contains the Go SDK Generator, pulling information from the Data API.
 - `./tools/generator-terraform` - contains the Terraform Generator, pulling information from the Data API.
+- `./tools/importer-msgraph-metadata` - contains the Importer for the Microsoft Graph API Definitions.
 - `./tools/importer-rest-api-specs` - contains the Importer for the Azure Resource Manager OpenAPI/Swagger definitions.
 - `./tools/version-bumper` - contains a small tool to add new Services and new API Versions for existing Services to the config.
 

--- a/scripts/automation-generate-and-commit-go-sdk.sh
+++ b/scripts/automation-generate-and-commit-go-sdk.sh
@@ -108,7 +108,7 @@ function cleanup {
 
 function main {
   local dataApiAssemblyPath="data/Pandora.Api/bin/Debug/net7.0/Pandora.Api.dll"
-  local swaggerSubmodule="./swagger"
+  local swaggerSubmodule="./submodules/rest-api-specs"
   local outputDirectory="tmp/go-azure-sdk"
   local sdkRepo="git@github.com:hashicorp/go-azure-sdk.git"
   local sha

--- a/tools/importer-rest-api-specs/README.md
+++ b/tools/importer-rest-api-specs/README.md
@@ -1,6 +1,6 @@
 ## Tool: `importer-rest-api-specs`
 
-This tool imports data from the `Azure/azure-rest-api-specs` repository (accessible in the Git Submodule located at `./swagger`)
+This tool imports data from the `Azure/azure-rest-api-specs` repository (accessible in the Git Submodule located at `./submodules/rest-api-specs`)
 into the Data format used by the Data API.
 
 For most use-cases you'll want to run `make import` which will parse and process the Swagger Data into the Definitions used by the Data API.
@@ -12,7 +12,7 @@ However the binary supports a couple of other commands:
 Usage: importer-rest-api-specs [--version] [--help] <command> [<args>]
 
 Available commands are:
-    import      Parses and Processes the Data from the './swagger' submodule
+    import      Parses and Processes the Data from the './submodules/rest-api-specs' submodule
     segments    Outputs a list of Segments used in the Resource IDs
-    validate    Validates that the data within the './swagger' submodule can be parsed
+    validate    Validates that the data within the './submodules/rest-api-specs' submodule can be parsed
 ```

--- a/tools/importer-rest-api-specs/cmd/import.go
+++ b/tools/importer-rest-api-specs/cmd/import.go
@@ -33,7 +33,7 @@ type ImportCommand struct {
 }
 
 func (ImportCommand) Help() string {
-	return `Import parses and processes the Swagger Data from the './swagger' submodule, determining
+	return `Import parses and processes the Swagger Data from the './submodules/rest-api-specs' submodule, determining
 which Terraform Data Sources & Resources can be generated - and then finally
 outputs this Data in the format used by the Data API.
 
@@ -91,5 +91,5 @@ func (c ImportCommand) Run(args []string) int {
 }
 
 func (ImportCommand) Synopsis() string {
-	return "Parses and Processes the Data from the './swagger' submodule"
+	return "Parses and Processes the Data from the './submodules/rest-api-specs' submodule"
 }

--- a/tools/importer-rest-api-specs/cmd/validate.go
+++ b/tools/importer-rest-api-specs/cmd/validate.go
@@ -30,7 +30,7 @@ type ValidateCommand struct {
 }
 
 func (ValidateCommand) Help() string {
-	return "Validates that the data within the './swagger' submodule can be parsed"
+	return "Validates that the data within the './submodules/rest-api-specs' submodule can be parsed"
 }
 
 func (c ValidateCommand) Run(args []string) int {
@@ -62,5 +62,5 @@ func (c ValidateCommand) Run(args []string) int {
 }
 
 func (ValidateCommand) Synopsis() string {
-	return "Validates that the data within the './swagger' submodule can be parsed"
+	return "Validates that the data within the './submodules/rest-api-specs' submodule can be parsed"
 }

--- a/tools/importer-rest-api-specs/components/parser/parser_test.go
+++ b/tools/importer-rest-api-specs/components/parser/parser_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/discovery"
 )
 
-const swaggerDirectory = "../../../swagger/specification"
+const swaggerDirectory = "../../../submodules/rest-api-specs/specification"
 const runAllEnvVar = "ALL"
 
 func TestAllSwaggersUsingParser(t *testing.T) {

--- a/tools/importer-rest-api-specs/main.go
+++ b/tools/importer-rest-api-specs/main.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	outputDirectory          = "../../data/"
-	swaggerDirectory         = "../../swagger"
+	swaggerDirectory         = "../../submodules/rest-api-specs"
 	resourceManagerConfig    = "../../config/resource-manager.hcl"
 	terraformDefinitionsPath = "../../config/resources/"
 )

--- a/tools/importer-rest-api-specs/pipeline/run_validate_can_parse_data_test.go
+++ b/tools/importer-rest-api-specs/pipeline/run_validate_can_parse_data_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	outputDirectory       = "../../../data/"
-	swaggerDirectory      = "../../../swagger"
+	swaggerDirectory      = "../../../submodules/rest-api-specs"
 	resourceManagerConfig = "../../../config/resource-manager.hcl"
 )
 

--- a/tools/version-bumper/README.md
+++ b/tools/version-bumper/README.md
@@ -7,7 +7,7 @@ This tool will update the Configs for Resource Manager (and other API's in the F
 This does this by:
 
 * Parsing the config (`./config/resource-manager.hcl`)
-* Retrieving a list of Services and Service Versions from the `./swagger/specification` Git Submodule.
+* Retrieving a list of Services and Service Versions from the `./submodules/rest-api-specs` Git Submodule.
 * If it's a new Service (that is, we're not defining it already) - we pick the latest version available (preferring a Stable version, but accepting a Preview version if necessary).
 * If we already define that Service, we only add the version if it's a new Stable version. New Preview Versions can be added by updating the Config directly.
 

--- a/tools/version-bumper/main.go
+++ b/tools/version-bumper/main.go
@@ -29,7 +29,7 @@ func run(directory string) error {
 	servicesToUpdate := map[string]ServiceLocator{
 		// TODO: active-directory / data-plane in time
 		"resource-manager": ResourceManagerService{
-			swaggerDirectory: "../../swagger",
+			swaggerDirectory: "../../submodules/rest-api-specs",
 		},
 	}
 	for name, service := range servicesToUpdate {


### PR DESCRIPTION
This matches the Microsoft Graph one, and since we're gonna need to run `git submodule init` we might as well do this now too