### PR TITLE
tooling: fixing an issue where the branch name was duplicated

### DIFF
--- a/.github/workflows/automation-msgraph-metadata-importer.yaml
+++ b/.github/workflows/automation-msgraph-metadata-importer.yaml
@@ -66,6 +66,6 @@ jobs:
         env:
           PR_TITLE: "Data: regenerating based on ${{ github.sha }}"
           PR_BODY: "This PR is automatically generated based on the commit ${{ github.sha }}"
-          PR_SOURCE: "data/regeneration-from-${{ github.sha }}"
+          PR_SOURCE: "data/regeneration-from-${{ github.sha }}-graph"
           PR_TARGET: "main"
           GITHUB_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PANDORA_TOKEN }}

--- a/.github/workflows/automation-rest-api-specs-importer.yaml
+++ b/.github/workflows/automation-rest-api-specs-importer.yaml
@@ -64,6 +64,6 @@ jobs:
         env:
           PR_TITLE: "Data: regenerating based on ${{ github.sha }}"
           PR_BODY: "This PR is automatically generated based on the commit ${{ github.sha }}"
-          PR_SOURCE: "data/regeneration-from-${{ github.sha }}"
+          PR_SOURCE: "data/regeneration-from-${{ github.sha }}-rest-api-specs"
           PR_TARGET: "main"
           GITHUB_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PANDORA_TOKEN }}


### PR DESCRIPTION
This means the first job to complete would win, the other would fail - and we'd not import all the data