### PR TITLE
tools/importer-rest-api-specs: adding a workaround for machine learning registry

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_machinelearning_25142.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_machinelearning_25142.go
@@ -1,0 +1,43 @@
+package dataworkarounds
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundMachineLearning25142{}
+
+// workaroundMachineLearning25142 works around the missed 202 status code.
+// Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/25142
+type workaroundMachineLearning25142 struct {
+}
+
+func (workaroundMachineLearning25142) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	serviceMatches := apiDefinition.ServiceName == "MachineLearningServices"
+	apiVersionMatches := apiDefinition.ApiVersion == "2023-04-01"
+	return serviceMatches && apiVersionMatches
+}
+
+func (workaroundMachineLearning25142) Name() string {
+	return "MachineLearningServices / 25142"
+}
+
+func (workaroundMachineLearning25142) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resource, ok := apiDefinition.Resources["RegistryManagement"]
+	if !ok {
+		return nil, fmt.Errorf("couldn't find API Resource MachineLearningServices")
+	}
+
+	operation, ok := resource.Operations["RegistriesCreateOrUpdate"]
+	if !ok {
+		return nil, fmt.Errorf("couldn't find Operation RegistriesCreateOrUpdate")
+	}
+
+	operation.ExpectedStatusCodes = append(operation.ExpectedStatusCodes, http.StatusAccepted)
+	resource.Operations["RegistriesCreateOrUpdate"] = operation
+
+	apiDefinition.Resources["RegistryManagement"] = resource
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_machinelearning_25142.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_machinelearning_25142.go
@@ -27,7 +27,7 @@ func (workaroundMachineLearning25142) Name() string {
 func (workaroundMachineLearning25142) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["RegistryManagement"]
 	if !ok {
-		return nil, fmt.Errorf("couldn't find API Resource MachineLearningServices")
+		return nil, fmt.Errorf("couldn't find API Resource RegistryManagement")
 	}
 
 	operation, ok := resource.Operations["RegistriesCreateOrUpdate"]

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -23,6 +23,8 @@ var workarounds = []workaround{
 
 	// @tombuildsstuff: we also have to account for package names which aren't valid in Go:
 	workaroundInvalidGoPackageNames{},
+
+	workaroundMachineLearning25142{},
 }
 
 func ApplyWorkarounds(input []models.AzureApiDefinition, logger hclog.Logger) (*[]models.AzureApiDefinition, error) {

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -16,6 +16,7 @@ var workarounds = []workaround{
 	workaroundDataFactory23013{},
 	workaroundLoadTest20961{},
 	workaroundRedis22407{},
+	workaroundMachineLearning25142{},
 
 	// @tombuildsstuff: this is an odd place for this however this allows working around inconsistencies in the Swagger
 	// we should look at moving this into the `resourceids` package when time allows.
@@ -23,8 +24,6 @@ var workarounds = []workaround{
 
 	// @tombuildsstuff: we also have to account for package names which aren't valid in Go:
 	workaroundInvalidGoPackageNames{},
-
-	workaroundMachineLearning25142{},
 }
 
 func ApplyWorkarounds(input []models.AzureApiDefinition, logger hclog.Logger) (*[]models.AzureApiDefinition, error) {


### PR DESCRIPTION
a workaound for https://github.com/Azure/azure-rest-api-specs/issues/25119 also fix https://github.com/hashicorp/pandora/issues/2889
