### PR TITLE
tools/importer-rest-api-specs: adding Common ID for Storage Account and Storage Container

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_account.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_account.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdStorageAccount{}
+
+type commonIdStorageAccount struct{}
+
+func (c commonIdStorageAccount) id() models.ParsedResourceId {
+	name := "StorageAccount"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
+			models.StaticResourceIDSegment("storageAccounts", "storageAccounts"),
+			models.UserSpecifiedResourceIDSegment("storageAccountName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_container.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_container.go
@@ -1,0 +1,32 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdStorageContainer{}
+
+type commonIdStorageContainer struct{}
+
+func (c commonIdStorageContainer) id() models.ParsedResourceId {
+	name := "StorageContainer"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
+			models.StaticResourceIDSegment("storageAccounts", "storageAccounts"),
+			models.UserSpecifiedResourceIDSegment("storageAccountName"),
+			models.StaticResourceIDSegment("blobServices", "blobServices"),
+			models.StaticResourceIDSegment("default", "default"),
+			models.StaticResourceIDSegment("containers", "containers"),
+			models.UserSpecifiedResourceIDSegment("containerName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -55,6 +55,10 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdKeyVaultKeyVersion{},
 	commonIdKeyVaultPrivateEndpointConnection{},
 
+	// Storage
+	commonIdStorageAccount{},
+	commonIdStorageContainer{},
+
 	// Parent IDs
 	commonIdKubernetesCluster{},
 }


### PR DESCRIPTION
Dependent on https://github.com/hashicorp/go-azure-helpers/pull/173

Fixes #2875