### PR TITLE
Config : adding `ChaosStudio` @ `2023-04-15-preview` 

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -67,7 +67,7 @@ service "blueprint" {
 }
 service "chaos" {
   name      = "ChaosStudio"
-  available = ["2022-07-01-preview", "2023-04-15-preview"]
+  available = ["2023-04-15-preview"]
 }
 service "cognitiveservices" {
   name      = "Cognitive"

--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -67,7 +67,7 @@ service "blueprint" {
 }
 service "chaos" {
   name      = "ChaosStudio"
-  available = ["2022-07-01-preview"]
+  available = ["2022-07-01-preview", "2023-04-15-preview"]
 }
 service "cognitiveservices" {
   name      = "Cognitive"


### PR DESCRIPTION
Support new service `ChaosStudio`. 

Swagger: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-04-15-preview