### PR TITLE
tools/generator-go-sdk: updating keyvault to use the new base layer

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -41,7 +41,6 @@ func main() {
 		"DataShare",
 		"FrontDoor",
 		"Insights",
-		"KeyVault",
 		"Kusto",
 		"Maintenance",
 		"ManagedServices",


### PR DESCRIPTION
Github bug didn't pick up the changes pushed to this branch - this has been previously reviewed here: https://github.com/hashicorp/pandora/pull/2456#issuecomment-1693155912