### PR TITLE
changes to add support for sqlmi threat protection

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -454,7 +454,7 @@ service "search" {
 }
 service "security" {
   name      = "Security"
-  available = ["2017-08-01-preview", "2019-01-01", "2019-01-01-preview", "2020-01-01", "2021-06-01", "2022-03-01", "2022-05-01", "2023-01-01", "2023-05-01"]
+  available = ["2017-08-01-preview", "2019-01-01", "2019-01-01-preview", "2020-01-01", "2021-06-01", "2022-03-01", "2022-05-01", "2022-08-01-preview", "2023-01-01", "2023-05-01"]
 }
 service "securityinsights" {
   name      = "SecurityInsights"

--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -488,6 +488,10 @@ service "solutions" {
   name      = "ManagedApplications"
   available = ["2019-07-01", "2021-07-01"]
 }
+service "sql" {
+  name      = "Sql"
+  available = ["2022-08-01-preview"]
+}
 service "sqlvirtualmachine" {
   name      = "SqlVirtualMachine"
   available = ["2022-02-01"]

--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -454,7 +454,7 @@ service "search" {
 }
 service "security" {
   name      = "Security"
-  available = ["2017-08-01-preview", "2019-01-01", "2019-01-01-preview", "2020-01-01", "2021-06-01", "2022-03-01", "2022-05-01", "2022-08-01-preview", "2023-01-01", "2023-05-01"]
+  available = ["2017-08-01-preview", "2019-01-01", "2019-01-01-preview", "2020-01-01", "2021-06-01", "2022-03-01", "2022-05-01", "2023-01-01", "2023-05-01"]
 }
 service "securityinsights" {
   name      = "SecurityInsights"


### PR DESCRIPTION
Added `sql` service with api version `2022-08-01-preview`  for supporting threat protection on sql managed instances.

**Swagger**: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/sql/resource-manager/Microsoft.Sql/preview/2022-08-01-preview/ManagedDatabaseAdvancedThreatProtectionSettings.json

**Ref**: https://learn.microsoft.com/en-us/rest/api/sql/2022-08-01-preview/managed-instance-advanced-threat-protection-settings/create-or-update?tabs=HTTP#managedinstanceadvancedthreatprotection