### PR TITLE
`importer`: fix sort uri logic `generateNamesForResourceIds` which may cause eventual consistency

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
@@ -33,6 +33,9 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, log hclog.Logg
 	}
 
 	sort.Slice(sortedUris, func(x, y int) bool {
+		if len(sortedUris[x]) < len(sortedUris[y]) {
+			return true
+		}
 		return sortedUris[x] < sortedUris[y]
 	})
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
@@ -33,7 +33,7 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, log hclog.Logg
 	}
 
 	sort.Slice(sortedUris, func(x, y int) bool {
-		return len(sortedUris[x]) < len(sortedUris[y])
+		return sortedUris[x] < sortedUris[y]
 	})
 
 	candidateNamesToUris := make(map[string]models.ParsedResourceId, 0)

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
@@ -33,10 +33,10 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, log hclog.Logg
 	}
 
 	sort.Slice(sortedUris, func(x, y int) bool {
-		if len(sortedUris[x]) < len(sortedUris[y]) {
-			return true
+		if len(sortedUris[x]) == len(sortedUris[y]) {
+			return sortedUris[x] < sortedUris[y]
 		}
-		return sortedUris[x] < sortedUris[y]
+		return len(sortedUris[x]) < len(sortedUris[y])
 	})
 
 	candidateNamesToUris := make(map[string]models.ParsedResourceId, 0)


### PR DESCRIPTION
fix #1509

for these resource ids with the same length, the old sort logic will cause unstable result like below. this PR try to compare the uri itself to fix the EC issue.

![automanage1](https://github.com/hashicorp/pandora/assets/2633022/5c1165ce-9692-415d-8943-1eaa40fa47f6)
![automanage2](https://github.com/hashicorp/pandora/assets/2633022/5118c742-c6bb-40ca-a354-1d9aea5e69bf)
