### PR TITLE
tools/generator-go-sdk: reverting `KeyVault` to the old base layer for the moment

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -66,6 +66,10 @@ func main() {
 		"ContainerService",
 		"LoadTestService",
 		"ManagedIdentity",
+
+		// @tombuildsstuff: KeyVault requires that the exact casing retrieved from the API is re-sent back to the API
+		// as such will require custom work in the Provider (potentially a custom unmarshaller from the HTTP Body) to support this
+		"KeyVault",
 	)
 
 	var serviceNames string


### PR DESCRIPTION
Postponing this switch for now