### PR TITLE
`tools/importer-rest-api-specs`: simplifying the Operation names if possible

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -1805,6 +1805,32 @@ func TestParseModelMultipleTopLevelInheritance(t *testing.T) {
 	}
 }
 
+func TestParseModelMultipleWithStuttering(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "operations_multiple_with_stuttering.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+	exampleTag, ok := result.Resources["ExampleTag"]
+	if !ok {
+		t.Fatalf("expected a resource named `ExampleTag` but didn't get one")
+	}
+	if len(exampleTag.Operations) != 2 {
+		t.Fatalf("expected the resource `ExampleTag` to have 2 operations but got %q", len(exampleTag.Operations))
+	}
+	if _, ok := exampleTag.Operations["There"]; !ok {
+		t.Fatalf("expected the resource to have an operation named `There` but didn't get one")
+	}
+	if _, ok := exampleTag.Operations["World"]; !ok {
+		t.Fatalf("expected the resource to have an operation named `World` but didn't get one")
+	}
+}
+
 func TestParseModelWithLocation(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "model_with_location.json")
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_multiple_with_stuttering.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_multiple_with_stuttering.json
@@ -1,0 +1,111 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/there": {
+      "head": {
+        "tags": [
+          "Example Tag"
+        ],
+        "operationId": "ExampleTag_There",
+        "description": "A HEAD request with no body returned.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ThingParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    },
+    "/world": {
+      "head": {
+        "tags": [
+          "Example Tag"
+        ],
+        "operationId": "ExampleTag_World",
+        "description": "A HEAD request with no body returned.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ThingParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The API version to be used with the HTTP request."
+    },
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription ID."
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "The name of the resource group that contains the resource."
+    },
+    "ThingParameter": {
+      "name": "thing",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "The name of the thing."
+    }
+  }
+}


### PR DESCRIPTION
When all Operations within a API Resource begin with the same prefix, and that prefix is the API Resource name, we can trim the API Resource from the name of each Operation to simplify this. This means that for example `AlertProcessingRulesCreateOrUpdate` within the `AlertProcessingRules` package becomes `CreateOrUpdate`.

This simplifies these callers, and since this only occurs when all operations contain the prefix, there can't be any conflicting operations.

This scenario happens when the Swagger Tag contains spaces and differs from the prefix used for the Operation ID (e.g. a Swagger Tag of `Example Value` with an OperationID of `ExampleValue_SomeOperation`)