### PR TITLE
tools/importer-rest-api-specs: fixing a bug where operation names may start with a rogue `s`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -1820,8 +1820,11 @@ func TestParseModelMultipleWithStuttering(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected a resource named `ExampleTag` but didn't get one")
 	}
-	if len(exampleTag.Operations) != 2 {
+	if len(exampleTag.Operations) != 3 {
 		t.Fatalf("expected the resource `ExampleTag` to have 2 operations but got %q", len(exampleTag.Operations))
+	}
+	if _, ok := exampleTag.Operations["Mars"]; !ok {
+		t.Fatalf("expected the resource to have an operation named `Mars` but didn't get one")
 	}
 	if _, ok := exampleTag.Operations["There"]; !ok {
 		t.Fatalf("expected the resource to have an operation named `There` but didn't get one")

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -92,7 +92,15 @@ func (d *SwaggerDefinition) simplifyOperationNamesForResource(resource models.Az
 	output := make(map[string]models.OperationDetails)
 	for key, value := range resource.Operations {
 		updatedKey := key[len(resourceNameLower):]
-		// trim off any spurious `s` at the start, to handle tags with singular vs plural
+		// Trim off any spurious `s` at the start. This happens when the Swagger Tag and the Operation ID
+		// use different pluralizations (e.g. one is Singular and the other is Plural)
+		//
+		// Whilst it's possible this could happen for other suffixes (e.g. `ies`, or `y`)
+		// the Data only shows `s` at this point in time, so this is sufficient for now:
+		// https://github.com/hashicorp/pandora/pull/3016#pullrequestreview-1612987765
+		//
+		// Any other examples will generate successfully but be unusable in the Go SDK since these
+		// will be treated as unexported methods - and can be addressed then.
 		if strings.HasPrefix(updatedKey, "s") {
 			updatedKey = updatedKey[1:]
 		}

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -92,6 +92,11 @@ func (d *SwaggerDefinition) simplifyOperationNamesForResource(resource models.Az
 	output := make(map[string]models.OperationDetails)
 	for key, value := range resource.Operations {
 		updatedKey := key[len(resourceNameLower):]
+		// trim off any spurious `s` at the start, to handle tags with singular vs plural
+		if strings.HasPrefix(updatedKey, "s") {
+			updatedKey = updatedKey[1:]
+		}
+
 		d.logger.Trace(fmt.Sprintf("Simplifying Operation %q to %q", key, updatedKey))
 		output[updatedKey] = value
 	}

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_multiple_with_stuttering.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_multiple_with_stuttering.json
@@ -18,6 +18,34 @@
   "security": [],
   "securityDefinitions": {},
   "paths": {
+    "/mars": {
+      "head": {
+        "tags": [
+          "Example Tag"
+        ],
+        "operationId": "ExampleTags_Mars",
+        "description": "A HEAD request with no body returned.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ThingParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    },
     "/there": {
       "head": {
         "tags": [


### PR DESCRIPTION
Fixes https://github.com/hashicorp/pandora/pull/3016#pullrequestreview-1612987765