### PR TITLE
`tools/importer`: skip build model if input schema is only for property

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -535,6 +535,7 @@ func (d SwaggerDefinition) parseObjectDefinition(
 			return d.parseObjectDefinition(inheritedModel.Title, propertyName, &inheritedModel, result, true)
 		}
 
+		// check for / avoid circular references,
 		// however, we should only do this when we're parsing a model (`parsingModel`) directly rather than when parsing a model from a field - and only if we haven't already parsed this model
 		if _, ok := result.Models[modelName]; !ok && parsingModel {
 			nestedResult, err := d.parseModel(modelName, *input)

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -535,9 +535,7 @@ func (d SwaggerDefinition) parseObjectDefinition(
 			return d.parseObjectDefinition(inheritedModel.Title, propertyName, &inheritedModel, result, true)
 		}
 
-		// check for / avoid circular references
-		// only parse model when modelName equals PropertyName, otherwise the `input` Schema may not for the modelName
-		// if parsing a top-level or an inlined model, should pass the propertyName just the same as the modelName
+		// however, we should only do this when we're parsing a model (`parsingModel`) directly rather than when parsing a model from a field - and only if we haven't already parsed this model
 		if _, ok := result.Models[modelName]; !ok && parsingModel {
 			nestedResult, err := d.parseModel(modelName, *input)
 			if err != nil {

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -1861,3 +1861,20 @@ func TestParseModelWithLocation(t *testing.T) {
 		t.Fatalf("expected example.Fields['Location'] to be a Location but got %q", string(*field.CustomFieldType))
 	}
 }
+
+func TestParseModelBug2675DuplicateModel(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "models_bug_2675_duplicate_model.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+
+	example, ok := result.Resources["Example"]
+	if !ok {
+		t.Fatal("the Resource 'Example' was not found")
+	}
+
+	t.Logf("%d", len(example.Operations))
+}

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -1876,5 +1876,15 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 		t.Fatal("the Resource 'Example' was not found")
 	}
 
-	t.Logf("%d", len(example.Operations))
+	if len(example.Operations) != 3 {
+		t.Fatalf("expected the resource `Example` to have 3 operation but got %d", len(example.Operations))
+	}
+
+	if len(example.Models) != 7 {
+		t.Fatalf("expected the resource `Example` to have 7 models but got %d", len(example.Models))
+	}
+
+	if _, ok := example.Models["ExampleEnvironmentUpdatePropertiesCreatorRoleAssignment"]; !ok {
+		t.Fatalf("expected the resource `Example` to have a model named `ExampleEnvironmentUpdatePropertiesCreatorRoleAssignment` but didn't get one")
+	}
 }

--- a/tools/importer-rest-api-specs/components/parser/operations.go
+++ b/tools/importer-rest-api-specs/components/parser/operations.go
@@ -417,7 +417,8 @@ func (p operationsParser) requestObjectForOperation(input parsedOperation, known
 
 	for _, param := range unexpandedOperation.Parameters {
 		if strings.EqualFold(param.In, "body") {
-			objectDefinition, result, err := p.swaggerDefinition.parseObjectDefinition(param.Schema.Title, param.Schema.Title, param.Schema, known, true)
+			parsingModel := true
+			objectDefinition, result, err := p.swaggerDefinition.parseObjectDefinition(param.Schema.Title, param.Schema.Title, param.Schema, known, parsingModel)
 			if err != nil {
 				return nil, nil, fmt.Errorf("parsing request object for parameter %q: %+v", param.Name, err)
 			}
@@ -473,7 +474,8 @@ func (p operationsParser) responseObjectForOperation(input parsedOperation, know
 			continue
 		}
 
-		objectDefinition, nestedResult, err := p.swaggerDefinition.parseObjectDefinition(details.ResponseProps.Schema.Title, details.ResponseProps.Schema.Title, details.ResponseProps.Schema, result, true)
+		parsingModel := true
+		objectDefinition, nestedResult, err := p.swaggerDefinition.parseObjectDefinition(details.ResponseProps.Schema.Title, details.ResponseProps.Schema.Title, details.ResponseProps.Schema, result, parsingModel)
 		if err != nil {
 			return nil, nil, fmt.Errorf("parsing response object from status code %d: %+v", statusCode, err)
 		}

--- a/tools/importer-rest-api-specs/components/parser/operations.go
+++ b/tools/importer-rest-api-specs/components/parser/operations.go
@@ -346,11 +346,11 @@ func (p operationsParser) optionsForOperation(input parsedOperation, logger hclo
 
 			// looks like these can be dates etc too
 			// ./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "name": "reportedEndTime",
-			//./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "in": "query",
-			//./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "required": true,
-			//./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "type": "string",
-			//./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json:            "format": "date-time",
-			//./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "description": "The end of the time range to retrieve data for."
+			// ./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "in": "query",
+			// ./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "required": true,
+			// ./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "type": "string",
+			// ./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json:            "format": "date-time",
+			// ./commerce/resource-manager/Microsoft.Commerce/preview/2015-06-01-preview/commerce.json-            "description": "The end of the time range to retrieve data for."
 			objectDefinition, err := p.determineObjectDefinitionForOption(param)
 			if err != nil {
 				return nil, nil, fmt.Errorf("determining field type for operation: %+v", err)
@@ -417,7 +417,7 @@ func (p operationsParser) requestObjectForOperation(input parsedOperation, known
 
 	for _, param := range unexpandedOperation.Parameters {
 		if strings.EqualFold(param.In, "body") {
-			objectDefinition, result, err := p.swaggerDefinition.parseObjectDefinition(param.Schema.Title, param.Schema.Title, param.Schema, known)
+			objectDefinition, result, err := p.swaggerDefinition.parseObjectDefinition(param.Schema.Title, param.Schema.Title, param.Schema, known, true)
 			if err != nil {
 				return nil, nil, fmt.Errorf("parsing request object for parameter %q: %+v", param.Name, err)
 			}
@@ -473,7 +473,7 @@ func (p operationsParser) responseObjectForOperation(input parsedOperation, know
 			continue
 		}
 
-		objectDefinition, nestedResult, err := p.swaggerDefinition.parseObjectDefinition(details.ResponseProps.Schema.Title, details.ResponseProps.Schema.Title, details.ResponseProps.Schema, result)
+		objectDefinition, nestedResult, err := p.swaggerDefinition.parseObjectDefinition(details.ResponseProps.Schema.Title, details.ResponseProps.Schema.Title, details.ResponseProps.Schema, result, true)
 		if err != nil {
 			return nil, nil, fmt.Errorf("parsing response object from status code %d: %+v", statusCode, err)
 		}
@@ -520,7 +520,7 @@ type parsedOperation struct {
 func (d *SwaggerDefinition) findOperationsMatchingTag(tag *string) *[]parsedOperation {
 	result := make([]parsedOperation, 0)
 	for httpMethod, operation := range d.swaggerSpecExpanded.Operations() {
-		//operation = inferMissingTags(operation, tag)
+		// operation = inferMissingTags(operation, tag)
 		for uri, operationDetails := range operation {
 			if !operationMatchesTag(operationDetails, tag) {
 				continue

--- a/tools/importer-rest-api-specs/components/parser/testdata/models_bug_2675_duplicate_model.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/models_bug_2675_duplicate_model.json
@@ -1,0 +1,205 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/environments/{environmentName}": {
+      "get": {
+        "tags": [
+          "Example"
+        ],
+        "description": "Gets an example environment.",
+        "parameters": [
+          {
+            "name": "environmentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "operationId": "Example_Get",
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExampleEnvironment"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Example"
+        ],
+        "description": "Creates or updates an example environment.",
+        "parameters": [
+          {
+            "name": "environmentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExampleEnvironment"
+            }
+          }
+        ],
+        "operationId": "Example_CreateOrUpdate",
+        "responses": {
+          "200": {
+            "description": "Succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExampleEnvironment"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Example"
+        ],
+        "description": "Patches an example environment.",
+        "parameters": [
+          {
+            "name": "environmentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Updatable project environment type properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExampleEnvironmentUpdate"
+            }
+          }
+        ],
+        "operationId": "Example_Update",
+        "responses": {
+          "200": {
+            "description": "The resource was updated.",
+            "schema": {
+              "$ref": "#/definitions/ExampleEnvironment"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ExampleEnvironment": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ExampleEnvironmentProperties"
+        },
+        "location": {
+          "type": "string"
+        }
+      }
+    },
+    "ExampleEnvironmentUpdateProperties": {
+      "type": "object",
+      "properties": {
+        "deploymentTargetId": {
+          "type": "string"
+        },
+        "creatorRoleAssignment": {
+          "type": "object",
+          "properties": {
+            "roles": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/EnvironmentRole"
+              }
+            }
+          }
+        },
+        "userRoleAssignments": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserRoleAssignment"
+          }
+        }
+      }
+    },
+    "ExampleEnvironmentProperties": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleEnvironmentUpdateProperties"
+        }
+      ],
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ExampleEnvironmentUpdate": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ExampleEnvironmentUpdateProperties"
+        },
+        "example": {
+          "type": "string"
+        }
+      }
+    },
+    "UserRoleAssignment": {
+      "type": "object",
+      "x-ms-client-name": "userRoleAssignmentValue",
+      "properties": {
+        "roles": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/EnvironmentRole"
+          }
+        }
+      }
+    },
+    "EnvironmentRole": {
+      "type": "object",
+      "properties": {
+        "roleName": {
+          "type": "string",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {
+  }
+}


### PR DESCRIPTION
should fix the importer issue of #2675. also cherry-picked @tombuildsstuff 's commit of adding Unit Test for it: https://github.com/hashicorp/pandora/commit/d2ea0bbda48287bccd3aa705a7832879ae8b9542

```
--- PASS: TestParseModelBug2675DuplicateModel (0.02s)
PASS
```

I have regenerated all services and it caused no different from main branch's data, (except the DevCenter service):

![image](https://github.com/hashicorp/pandora/assets/2633022/da58379c-1716-437b-9770-d94170ad0a25)
