### PR TITLE
github actions: `l` -> `large`

### DIFF
--- a/.github/workflows/automation-regenerate-go-sdk.yaml
+++ b/.github/workflows/automation-regenerate-go-sdk.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   regenerate-go-sdk:
-    runs-on: custom-linux-l
+    runs-on: custom-linux-large
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 

--- a/.github/workflows/automation-regenerate-terraform.yaml
+++ b/.github/workflows/automation-regenerate-terraform.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   regenerate-terraform-provider:
-    runs-on: custom-linux-l
+    runs-on: custom-linux-large
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 


### PR DESCRIPTION
Whilst `xl` exists, `l` doesn't exist for `large`.

Unblocks https://github.com/hashicorp/pandora/actions/runs/6247014090
Unblocks https://github.com/hashicorp/pandora/actions/runs/6247014093