### PR TITLE
config: generating `dev_center` and `dev_center_project`

### DIFF
--- a/config/resources/devcenter.hcl
+++ b/config/resources/devcenter.hcl
@@ -1,7 +1,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-/*
 service "DevCenter" {
   terraform_package = "devcenter"
 
@@ -25,4 +24,3 @@ service "DevCenter" {
     }
   }
 }
-*/


### PR DESCRIPTION
This PR generates `azurerm_dev_center` and `azurerm_dev_center_project`

Dependent on https://github.com/hashicorp/terraform-provider-azurerm/pull/23530

Supersedes https://github.com/hashicorp/terraform-provider-azurerm/pull/23522