### PR TITLE
scripts: updating the Terraform automation to use `auto-pandora-pr` rather than `auto-pr`

### DIFF
--- a/scripts/automation-generate-and-commit-terraform.sh
+++ b/scripts/automation-generate-and-commit-terraform.sh
@@ -92,7 +92,7 @@ function runFmtImportsAndGenerate {
 function conditionallyCommitAndPushTerraformProvider {
   local workingDirectory=$1
   local sha=$2
-  local branch="auto-pr/$sha"
+  local branch="auto-pandora-pr/$sha"
 
   cd "${DIR}"
   cd "$workingDirectory"


### PR DESCRIPTION
This allows the `hashicorp/terraform-provider-azurerm` repository to differentiate between Pandora and Go SDK PRs

x-ref: https://github.com/hashicorp/terraform-provider-azurerm/pull/23565