### PR TITLE
`tools/importer-rest-api-specs`: New Common IDs for Kusto Cluster and Kusto Database

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_cluster.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdKustoCluster{}
+
+type commonIdKustoCluster struct{}
+
+func (c commonIdKustoCluster) id() models.ParsedResourceId {
+	name := "KustoCluster"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("staticProviders", "providers"),
+			models.ResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
+			models.StaticResourceIDSegment("staticClusters", "clusters"),
+			models.UserSpecifiedResourceIDSegment("kustoClusterName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_database.go
@@ -1,0 +1,30 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdKustoDatabase{}
+
+type commonIdKustoDatabase struct{}
+
+func (c commonIdKustoDatabase) id() models.ParsedResourceId {
+	name := "KustoDatabase"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("staticProviders", "providers"),
+			models.ResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
+			models.StaticResourceIDSegment("staticClusters", "clusters"),
+			models.UserSpecifiedResourceIDSegment("kustoClusterName"),
+			models.StaticResourceIDSegment("staticDatabases", "databases"),
+			models.UserSpecifiedResourceIDSegment("kustoDatabaseName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -24,6 +24,10 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdVirtualNetwork{},
 	commonIdVPNConnection{},
 
+	// Kusto
+	commonIdKustoCluster{},
+	commonIdKustoDatabase{},
+
 	// RP Specific
 	commonIdCloudServicesIPConfiguration{},
 	commonIdCloudServicesPublicIPAddress{},


### PR DESCRIPTION
Dependent on https://github.com/hashicorp/go-azure-helpers/pull/186