### PR TITLE
tools/importer-rest-api-specs: ignoring more LROs

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/internal/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/helpers.go
@@ -3,9 +3,11 @@ package internal
 import "strings"
 
 func OperationShouldBeIgnored(operationUri string) bool {
+	loweredOperationUri := strings.ToLower(operationUri)
+
 	// we're not concerned with exposing the "operations" API's at this time - e.g.
 	// /providers/Microsoft.CognitiveServices/operations
-	if strings.HasPrefix(strings.ToLower(operationUri), "/providers/") {
+	if strings.HasPrefix(loweredOperationUri, "/providers/") {
 		split := strings.Split(strings.TrimPrefix(operationUri, "/"), "/")
 		if len(split) == 3 && strings.EqualFold(split[2], "operations") {
 			return true
@@ -13,54 +15,36 @@ func OperationShouldBeIgnored(operationUri string) bool {
 	}
 
 	// LRO's shouldn't be directly exposed
-	if strings.Contains(strings.ToLower(operationUri), "/ascoperations/") {
-		return true
+	pathsContainingLROs := map[string]struct{}{
+		"/ascoperations/":                       {},
+		"/azureasyncoperations/":                {},
+		"/backupcrroperationresults/":           {},
+		"/backupoperationresults/":              {},
+		"/backupvalidateoperationresults/":      {},
+		"/costdetailsoperationresults/":         {},
+		"/deploymentstatus/":                    {},
+		"/managedclusteroperations/":            {},
+		"/managedclusteroperationresults/":      {},
+		"/manageddatabasemoveoperationresults/": {},
+		"/operationresults/":                    {},
+		"/operationstatus/":                     {},
+		"/operationstatuses/":                   {},
+		"/operationsstatus/":                    {},
+		"/privatelinkscopeoperationstatuses/":   {},
+
+		// we can't just use `/operations` since some APIs (e.g. API Management) expose these, so we're intentionally
+		// checking more (but not all) of the path
+		"/providers/microsoft.storagesync/locations/{locationname}/workflows/{workflowid}/operations/{operationid}": {},
+		"/providers/microsoft.storagesync/locations/{locationName}/operations/{operationid}":                        {},
 	}
-	if strings.Contains(strings.ToLower(operationUri), "/azureasyncoperations/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/backupcrroperationresults/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/backupoperationresults/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/backupvalidateoperationresults/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/costdetailsoperationresults/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/deploymentstatus/") { // web
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/managedclusteroperations/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/managedclusteroperationresults/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/manageddatabasemoveoperationresults/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/operationresults/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/operationstatus/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/operationstatuses/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/operationsstatus/") {
-		return true
-	}
-	if strings.Contains(strings.ToLower(operationUri), "/privatelinkscopeoperationstatuses/") {
-		return true
+	for key := range pathsContainingLROs {
+		if strings.Contains(loweredOperationUri, key) {
+			return true
+		}
 	}
 
 	// we're not concerned with the associated `trigger` operations at this time
-	if strings.Contains(strings.ToLower(operationUri), "/backuptriggervalidateoperation/") {
+	if strings.Contains(loweredOperationUri, "/backuptriggervalidateoperation/") {
 		return true
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/internal/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/helpers.go
@@ -16,26 +16,36 @@ func OperationShouldBeIgnored(operationUri string) bool {
 
 	// LRO's shouldn't be directly exposed
 	pathsContainingLROs := map[string]struct{}{
-		"/ascoperations/":                       {},
-		"/azureasyncoperations/":                {},
-		"/backupcrroperationresults/":           {},
-		"/backupoperationresults/":              {},
-		"/backupvalidateoperationresults/":      {},
-		"/costdetailsoperationresults/":         {},
-		"/deploymentstatus/":                    {},
-		"/managedclusteroperations/":            {},
-		"/managedclusteroperationresults/":      {},
-		"/manageddatabasemoveoperationresults/": {},
-		"/operationresults/":                    {},
-		"/operationstatus/":                     {},
-		"/operationstatuses/":                   {},
-		"/operationsstatus/":                    {},
-		"/privatelinkscopeoperationstatuses/":   {},
+		"/ascoperations/":                             {},
+		"/azureasyncoperations/":                      {},
+		"/backupcrroperationresults/":                 {},
+		"/backupoperationresults/":                    {},
+		"/backupvalidateoperationresults/":            {},
+		"/costdetailsoperationresults/":               {},
+		"/deploymentstatus/":                          {},
+		"/managedclusteroperations/":                  {},
+		"/managedclusteroperationresults/":            {},
+		"/manageddatabasemoveoperationresults/":       {},
+		"/mediaservicesoperationresults/":             {},
+		"/mediaservicesoperationstatuses/":            {},
+		"/operationlocations/":                        {},
+		"/operationresults/":                          {},
+		"/operationstatus/":                           {},
+		"/operationstatuses/":                         {},
+		"/operationsstatus/":                          {},
+		"/privatelinkscopeoperationstatuses/":         {},
+		"/recommendedactionsessionsoperationresults/": {},
 
 		// we can't just use `/operations` since some APIs (e.g. API Management) expose these, so we're intentionally
 		// checking more (but not all) of the path
-		"/providers/microsoft.storagesync/locations/{locationname}/workflows/{workflowid}/operations/{operationid}": {},
-		"/providers/microsoft.storagesync/locations/{locationName}/operations/{operationid}":                        {},
+		// /providers/Microsoft.KubernetesConfiguration/extensions/{extensionName}/operations/{operationId}
+		"/providers/microsoft.dataprotection/backupvaults/{backupvaultname}/backupjobs/operations/{operationid}":           {},
+		"/providers/microsoft.kubernetesconfiguration/fluxconfigurations/{fluxconfigurationname}/operations/{operationid}": {},
+		"/providers/microsoft.kubernetesconfiguration/extensions/{extensionname}/operations/{operationid}":                 {},
+		"/providers/microsoft.sql/servers/{servername}/databases/{databasename}/operations/{operationid}":                  {},
+		"/providers/microsoft.sql/managedinstances/{managedinstancename}/operations/{operationid}":                         {},
+		"/providers/microsoft.storagesync/locations/{locationname}/workflows/{workflowid}/operations/{operationid}":        {},
+		"/providers/microsoft.storagesync/locations/{locationName}/operations/{operationid}":                               {},
 	}
 	for key := range pathsContainingLROs {
 		if strings.Contains(loweredOperationUri, key) {

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags.go
@@ -6,8 +6,9 @@ import (
 )
 
 var tagsToIgnore = map[string]struct{}{
-	"tags":  {},
-	"usage": {},
+	"deploymentoperations": {},
+	"tags":                 {},
+	"usage":                {},
 }
 
 func (d *SwaggerDefinition) findTags() []string {


### PR DESCRIPTION
This PR filters out a bunch of LROs that we're importing when we shouldn't be - for the moment I've left some from the SQL (ManagedInstances) Service/Resource, although I suspect they can be removed in the future.

Result:

```
	modified:   ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/ExtensionOperationStatus/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/ExtensionOperationStatus/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/ExtensionOperationStatus/Model-ErrorDetail.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/ExtensionOperationStatus/Model-OperationStatusResult.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/ExtensionOperationStatus/Operation-OperationStatusGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/ExtensionOperationStatus/ResourceId-OperationScopedId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/FluxConfigurationOperationStatus/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/FluxConfigurationOperationStatus/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/FluxConfigurationOperationStatus/Model-ErrorDetail.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/FluxConfigurationOperationStatus/Model-OperationStatusResult.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/FluxConfigurationOperationStatus/Operation-FluxConfigOperationStatusGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_03_01/FluxConfigurationOperationStatus/ResourceId-FluxConfigurationOperationScopedId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/ExtensionOperationStatus/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/ExtensionOperationStatus/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/ExtensionOperationStatus/Model-ErrorDetail.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/ExtensionOperationStatus/Model-OperationStatusResult.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/ExtensionOperationStatus/Operation-OperationStatusGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/ExtensionOperationStatus/ResourceId-OperationScopedId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/FluxConfigurationOperationStatus/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/FluxConfigurationOperationStatus/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/FluxConfigurationOperationStatus/Model-ErrorDetail.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/FluxConfigurationOperationStatus/Model-OperationStatusResult.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/FluxConfigurationOperationStatus/Operation-FluxConfigOperationStatusGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2022_11_01/FluxConfigurationOperationStatus/ResourceId-FluxConfigurationOperationScopedId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/ExtensionOperationStatus/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/ExtensionOperationStatus/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/ExtensionOperationStatus/Model-ErrorDetail.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/ExtensionOperationStatus/Model-OperationStatusResult.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/ExtensionOperationStatus/Operation-OperationStatusGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/ExtensionOperationStatus/ResourceId-OperationScopedId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/FluxConfigurationOperationStatus/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/FluxConfigurationOperationStatus/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/FluxConfigurationOperationStatus/Model-ErrorDetail.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/FluxConfigurationOperationStatus/Model-OperationStatusResult.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/FluxConfigurationOperationStatus/Operation-FluxConfigOperationStatusGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/KubernetesConfiguration/v2023_05_01/FluxConfigurationOperationStatus/ResourceId-FluxConfigurationOperationScopedId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/MariaDB/v2018_06_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/MariaDB/v2018_06_01/LocationBasedRecommendedActionSessionsResult/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/MariaDB/v2018_06_01/LocationBasedRecommendedActionSessionsResult/Model-RecommendationAction.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/MariaDB/v2018_06_01/LocationBasedRecommendedActionSessionsResult/Model-RecommendationActionProperties.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/MariaDB/v2018_06_01/LocationBasedRecommendedActionSessionsResult/Operation-List.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/MariaDB/v2018_06_01/LocationBasedRecommendedActionSessionsResult/ResourceId-RecommendedActionSessionsOperationResultId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Media/v2021_11_01/Accounts/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2021_11_01/Accounts/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2021_11_01/Accounts/Model-ErrorDetail.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2021_11_01/Accounts/Model-MediaServiceOperationStatus.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2021_11_01/Accounts/Operation-MediaServicesOperationResultsGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2021_11_01/Accounts/Operation-MediaServicesOperationStatusesGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2021_11_01/Accounts/ResourceId-MediaServicesOperationResultId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2021_11_01/Accounts/ResourceId-MediaServicesOperationStatusId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/LiveEvents/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/LiveEvents/Operation-OperationLocation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/LiveEvents/ResourceId-OperationLocationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/LiveOutputs/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/LiveOutputs/Operation-OperationLocation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/LiveOutputs/ResourceId-LiveOutputOperationLocationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/StreamingEndpoints/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/StreamingEndpoints/Operation-OperationLocation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Media/v2022_08_01/StreamingEndpoints/ResourceId-StreamingEndpointOperationLocationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/PostgreSql/v2018_06_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/PostgreSql/v2018_06_01/LocationBasedRecommendedActionSessionsResult/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/PostgreSql/v2018_06_01/LocationBasedRecommendedActionSessionsResult/Model-RecommendationAction.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/PostgreSql/v2018_06_01/LocationBasedRecommendedActionSessionsResult/Model-RecommendationActionProperties.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/PostgreSql/v2018_06_01/LocationBasedRecommendedActionSessionsResult/Operation-List.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/PostgreSql/v2018_06_01/LocationBasedRecommendedActionSessionsResult/ResourceId-RecommendedActionSessionsOperationResultId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Constant-ProvisioningOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Model-DeploymentOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Model-DeploymentOperationProperties.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Model-ErrorResponse.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Model-HTTPMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Model-StatusMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Model-TargetResource.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-Get.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-GetAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-GetAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-GetAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-GetAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-List.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-ListAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-ListAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-ListAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/Operation-ListAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-OperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-ProviderDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-Providers2DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-Providers2DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-ScopedDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_06_01/DeploymentOperations/ResourceId-ScopedOperationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Constant-ProvisioningOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Model-DeploymentOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Model-DeploymentOperationProperties.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Model-ErrorResponse.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Model-HTTPMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Model-StatusMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Model-TargetResource.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-Get.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-GetAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-GetAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-GetAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-GetAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-List.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-ListAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-ListAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-ListAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/Operation-ListAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-OperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-ProviderDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-Providers2DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-Providers2DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-ScopedDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2020_10_01/DeploymentOperations/ResourceId-ScopedOperationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Constant-ProvisioningOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Model-DeploymentOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Model-DeploymentOperationProperties.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Model-ErrorResponse.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Model-HTTPMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Model-StatusMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Model-TargetResource.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-Get.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-GetAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-GetAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-GetAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-GetAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-List.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-ListAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-ListAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-ListAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/Operation-ListAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-OperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-ProviderDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-Providers2DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-Providers2DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-ScopedDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2021_04_01/DeploymentOperations/ResourceId-ScopedOperationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Constant-ProvisioningOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Model-DeploymentOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Model-DeploymentOperationProperties.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Model-ErrorResponse.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Model-HTTPMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Model-StatusMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Model-TargetResource.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-Get.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-GetAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-GetAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-GetAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-GetAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-List.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-ListAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-ListAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-ListAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/Operation-ListAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-OperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-ProviderDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-Providers2DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-Providers2DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-ScopedDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2022_09_01/DeploymentOperations/ResourceId-ScopedOperationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/ApiVersionDefinition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Constant-ProvisioningOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Model-DeploymentOperation.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Model-DeploymentOperationProperties.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Model-ErrorAdditionalInfo.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Model-ErrorResponse.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Model-HTTPMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Model-StatusMessage.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Model-TargetResource.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-Get.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-GetAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-GetAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-GetAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-GetAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-List.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-ListAtManagementGroupScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-ListAtScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-ListAtSubscriptionScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/Operation-ListAtTenantScope.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-OperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-ProviderDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-Providers2DeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-Providers2DeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-ResourceGroupDeploymentOperationId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-ScopedDeploymentId.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/Resources/v2023_07_01/DeploymentOperations/ResourceId-ScopedOperationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/StorageSync/v2020_03_01/OperationStatus/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/StorageSync/v2020_03_01/OperationStatus/Model-OperationStatus.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/StorageSync/v2020_03_01/OperationStatus/Operation-OperationStatusGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/StorageSync/v2020_03_01/OperationStatus/ResourceId-WorkflowOperationId.cs
	modified:   ../../data/Pandora.Definitions.ResourceManager/StorageSync/v2022_09_01/OperationStatus/Definition.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/StorageSync/v2022_09_01/OperationStatus/Model-OperationStatus.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/StorageSync/v2022_09_01/OperationStatus/Operation-OperationStatusGet.cs
	deleted:    ../../data/Pandora.Definitions.ResourceManager/StorageSync/v2022_09_01/OperationStatus/ResourceId-WorkflowOperationId.cs
```