### PR TITLE
`tools/importer-rest-api-specs`: refactoring the Operation models within the `dataapigeneratorjson` package into a `models` directory

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_package.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_package.go
@@ -53,7 +53,7 @@ func (s Generator) generateResources(resourceName string, resource models.AzureA
 	s.logger.Debug("Generating Operations..")
 	for operationName, operation := range resource.Operations {
 		s.logger.Trace(fmt.Sprintf("Generating Operation %q..", operationName))
-		code, err := codeForOperation(operationName, operation, resource)
+		code, err := codeForOperation(operationName, operation, resource.Constants, resource.Models)
 		if err != nil {
 			return fmt.Errorf("marshaling Operation %q: %+v", operationName, err)
 		}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
@@ -54,7 +54,7 @@ const (
 	// StringObjectDefinitionType signifies that this field contains a String.
 	StringObjectDefinitionType ObjectDefinitionType = "String"
 
-	// CsvObjectDefinitionType signifies that this field contains a CSV of simple types e.g. String, Integer, Float
+	// CsvObjectDefinitionType signifies that this field contains a CSV of simple types e.g. String, Integer, Float.
 	CsvObjectDefinitionType ObjectDefinitionType = "Csv"
 
 	// DictionaryObjectDefinitionType signifies that this field contains a Dictionary, the Dictionary's Value Type is defined as Nested Object Definition.

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
@@ -1,7 +1,5 @@
 package models
 
-import "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-
 // ObjectDefinition specifies additional information about a specific Object and any associated nested Objects
 type ObjectDefinition struct {
 	// ObjectDefinitionType defines what kind of ObjectDefinition this is, such as a Reference, String or List
@@ -87,17 +85,3 @@ const (
 	// TODO: others in the future https://github.com/hashicorp/pandora/issues/8 e.g.
 	// RFC3339NanoDateFormat DateFormat = "RFC3339Nano"
 )
-
-func ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input *models.ObjectDefinition) *ObjectDefinition {
-	if input == nil {
-		return nil
-	}
-
-	objectDefinition := ObjectDefinition{
-		ReferenceName: input.ReferenceName,
-		Type:          ObjectDefinitionType(input.Type),
-		NestedItem:    ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input.NestedItem),
-	}
-
-	return &objectDefinition
-}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
@@ -1,12 +1,16 @@
 package models
 
-// NOTE: these types are intentionally undocumented atm, these'll be added in a follow-up PR
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
 
+// ObjectDefinition specifies additional information about a specific Object and any associated nested Objects
 type ObjectDefinition struct {
 	Type ObjectDefinitionType `json:"type"`
 
 	ReferenceName *string `json:"referenceName"` // NOTE: we could split this into ConstantName and ModelName in time, but not today.
 
+	// NestedItem is a nested ObjectDefinition when Type is a Dictionary or List
 	NestedItem *ObjectDefinition `json:"nestedItem,omitempty"`
 
 	// NOTE: these 3 fields were previously located against the Field but instead should be located against the Object Definition
@@ -14,6 +18,20 @@ type ObjectDefinition struct {
 	MaxItems   *int        `json:"maxItems,omitempty"`
 	MinItems   *int        `json:"minItems,omitempty"`
 	DateFormat *DateFormat `json:"dateFormat,omitempty"`
+}
+
+func ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input *models.ObjectDefinition) *ObjectDefinition {
+	if input == nil {
+		return nil
+	}
+
+	objectDefinition := ObjectDefinition{
+		ReferenceName: input.ReferenceName,
+		Type:          ObjectDefinitionType(input.Type),
+		NestedItem:    ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input.NestedItem),
+	}
+
+	return &objectDefinition
 }
 
 type ObjectDefinitionType string

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
@@ -30,19 +30,38 @@ type ObjectDefinition struct {
 type ObjectDefinitionType string
 
 const (
-	// BooleanObjectDefinitionType is used to signify that this type is a simple Boolean.
-	BooleanObjectDefinitionType   ObjectDefinitionType = "Boolean"
-	DateTimeObjectDefinitionType  ObjectDefinitionType = "DateTime"
-	IntegerObjectDefinitionType   ObjectDefinitionType = "Integer"
-	FloatObjectDefinitionType     ObjectDefinitionType = "Float"
-	RawFileObjectDefinitionType   ObjectDefinitionType = "RawFile"
-	RawObjectObjectDefinitionType ObjectDefinitionType = "RawObject"
-	ReferenceObjectDefinitionType ObjectDefinitionType = "Reference"
-	StringObjectDefinitionType    ObjectDefinitionType = "String"
+	// BooleanObjectDefinitionType signifies that this type is a simple Boolean.
+	BooleanObjectDefinitionType ObjectDefinitionType = "Boolean"
 
-	CsvObjectDefinitionType        ObjectDefinitionType = "Csv"
+	// DateTimeObjectDefinitionType signifies that this field contains a DateTime value.
+	DateTimeObjectDefinitionType ObjectDefinitionType = "DateTime"
+
+	// IntegerObjectDefinitionType signifies that this field contains an Integer.
+	IntegerObjectDefinitionType ObjectDefinitionType = "Integer"
+
+	// FloatObjectDefinitionType signifies that this field contains a Float.
+	FloatObjectDefinitionType ObjectDefinitionType = "Float"
+
+	// RawFileObjectDefinitionType signifies that this field contains a byte value e.g. []byte.
+	RawFileObjectDefinitionType ObjectDefinitionType = "RawFile"
+
+	// RawObjectObjectDefinitionType signifies that this field contains an interface value e.g. interface{}.
+	RawObjectObjectDefinitionType ObjectDefinitionType = "RawObject"
+
+	// ReferenceObjectDefinitionType signifies that this field points to a Constant or a Model.
+	ReferenceObjectDefinitionType ObjectDefinitionType = "Reference"
+
+	// StringObjectDefinitionType signifies that this field contains a String.
+	StringObjectDefinitionType ObjectDefinitionType = "String"
+
+	// CsvObjectDefinitionType signifies that this field contains a CSV of simple types e.g. String, Integer, Float
+	CsvObjectDefinitionType ObjectDefinitionType = "Csv"
+
+	// DictionaryObjectDefinitionType signifies that this field contains a Dictionary, the Dictionary's Value Type is defined as Nested Object Definition.
 	DictionaryObjectDefinitionType ObjectDefinitionType = "Dictionary"
-	ListObjectDefinitionType       ObjectDefinitionType = "List"
+
+	// ListObjectDefinitionType signifies that this field contains a List, the List's Value Type is defined as a Nested Object Definition.
+	ListObjectDefinitionType ObjectDefinitionType = "List"
 
 	EdgeZoneObjectDefinitionType                                ObjectDefinitionType = "EdgeZone"
 	LocationObjectDefinitionType                                ObjectDefinitionType = "Location"

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
@@ -1,37 +1,30 @@
 package models
 
-import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-)
+import "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 
 // ObjectDefinition specifies additional information about a specific Object and any associated nested Objects
 type ObjectDefinition struct {
+	// ObjectDefinitionType defines what kind of ObjectDefinition this is, such as a Reference, String or List
 	Type ObjectDefinitionType `json:"type"`
 
-	ReferenceName *string `json:"referenceName"` // NOTE: we could split this into ConstantName and ModelName in time, but not today.
+	// NOTE: we could split this into ConstantName and ModelName in time, but not today.
+	// ReferenceName is the name of the Constant or Model that this is a reference to
+	ReferenceName *string `json:"referenceName"`
 
 	// NestedItem is a nested ObjectDefinition when Type is a Dictionary or List
 	NestedItem *ObjectDefinition `json:"nestedItem,omitempty"`
 
 	// NOTE: these 3 fields were previously located against the Field but instead should be located against the Object Definition
 	// as such we'll need to update the Data API to account for this
-	MaxItems   *int        `json:"maxItems,omitempty"`
-	MinItems   *int        `json:"minItems,omitempty"`
+
+	// MaxItems specifies the maximum number of items a CSV/Dictionary/List can have, this field is only relevant for the Terraform Schema
+	MaxItems *int `json:"maxItems,omitempty"`
+
+	// MinItems specifies the minimum number of items a CSV/Dictionary/List can have, this field is only relevant for the Terraform Schema
+	MinItems *int `json:"minItems,omitempty"`
+
+	// DateFormat specifies the format a date field should have, this field is only relevant for the Terraform Schema
 	DateFormat *DateFormat `json:"dateFormat,omitempty"`
-}
-
-func ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input *models.ObjectDefinition) *ObjectDefinition {
-	if input == nil {
-		return nil
-	}
-
-	objectDefinition := ObjectDefinition{
-		ReferenceName: input.ReferenceName,
-		Type:          ObjectDefinitionType(input.Type),
-		NestedItem:    ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input.NestedItem),
-	}
-
-	return &objectDefinition
 }
 
 type ObjectDefinitionType string
@@ -75,3 +68,17 @@ const (
 	// TODO: others in the future https://github.com/hashicorp/pandora/issues/8 e.g.
 	// RFC3339NanoDateFormat DateFormat = "RFC3339Nano"
 )
+
+func ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input *models.ObjectDefinition) *ObjectDefinition {
+	if input == nil {
+		return nil
+	}
+
+	objectDefinition := ObjectDefinition{
+		ReferenceName: input.ReferenceName,
+		Type:          ObjectDefinitionType(input.Type),
+		NestedItem:    ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input.NestedItem),
+	}
+
+	return &objectDefinition
+}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
@@ -10,6 +10,7 @@ type ObjectDefinition struct {
 	ReferenceName *string `json:"referenceName"`
 
 	// NestedItem is a nested ObjectDefinition when Type is a Dictionary or List
+	// NOTE: that it's possible to have deeply-nested ObjectDefinitions, e.g. a List of a List of a Dictionary[String (key, fixed as a string) : Integer (value)
 	NestedItem *ObjectDefinition `json:"nestedItem,omitempty"`
 
 	// NOTE: these 3 fields were previously located against the Field but instead should be located against the Object Definition
@@ -21,7 +22,7 @@ type ObjectDefinition struct {
 	// MinItems specifies the minimum number of items a CSV/Dictionary/List can have, this field is only relevant for the Terraform Schema
 	MinItems *int `json:"minItems,omitempty"`
 
-	// DateFormat specifies the format a date field should have, this field is only relevant for the Terraform Schema
+	// DateFormat specifies the format a date field should have, which allows us to generate helper methods (Get and Set) for this date format
 	DateFormat *DateFormat `json:"dateFormat,omitempty"`
 }
 
@@ -55,7 +56,8 @@ const (
 	// CsvObjectDefinitionType signifies that this field contains a CSV of simple types e.g. String, Integer, Float.
 	CsvObjectDefinitionType ObjectDefinitionType = "Csv"
 
-	// DictionaryObjectDefinitionType signifies that this field contains a Dictionary, the Dictionary's Value Type is defined as Nested Object Definition.
+	// DictionaryObjectDefinitionType signifies that this field contains a Dictionary, the
+	// Key for a Dictionary is always a String - the Value Type is defined as Nested Object Definition.
 	DictionaryObjectDefinitionType ObjectDefinitionType = "Dictionary"
 
 	// ListObjectDefinitionType signifies that this field contains a List, the List's Value Type is defined as a Nested Object Definition.

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
@@ -58,6 +58,6 @@ type Option struct {
 	// Field specifies the DisplayName of the Option (e.g. `ConstantOption`, `SecondVal`)
 	Field string `json:"field"`
 
-	// FieldType specifies what kind of Option this is (e.g. `String`, `Bool`)
-	FieldType ObjectDefinitionType `json:"fieldType"`
+	// OptionsObjectDefinition describes the information contained within the Field
+	ObjectDefinition *OptionObjectDefinition `json:"optionsObjectDefinition"`
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
@@ -6,48 +6,38 @@ type Operation struct {
 	Name string `json:"Name"`
 
 	// ContentType specifies the format of the information being sent with the Operation (e.g. `application/json; charset=utf-8`)
-	ContentType string `json:"ContentType,omitempty"`
+	ContentType string `json:"ContentType"`
 
 	// ExpectedStatusCodes specifies is a list of Status Codes which are expected to be returned (e.g. 200, 201)
-	ExpectedStatusCodes []int `json:"ExpectedStatusCodes,omitempty"`
+	ExpectedStatusCodes []int `json:"ExpectedStatusCodes"`
 
 	// FieldContainingPaginationDetails is a reference to the field within the Response
 	// which contains the pagination details, (e.g. `nextLink`)
-	FieldContainingPaginationDetails string `json:"FieldContainingPaginationDetails,omitempty"`
+	FieldContainingPaginationDetails *string `json:"FieldContainingPaginationDetails,omitempty"`
 
 	// LongRunning specifies if this is a Long Running Operation, meaning that Clients
 	// should follow any `Location` headers to track the result of this operation
-	LongRunning bool `json:"LongRunning,omitempty"`
+	LongRunning bool `json:"LongRunning"`
 
 	// HTTPMethod is the Method used for this operation, (e.g. `GET`, `POST`)
-	HTTPMethod string `json:"HTTPMethod,omitempty"`
-
-	// todo do we need this OptionsObject as well as Options?
-	OptionsObject OptionsObject `json:"OptionsObject,omitempty"`
+	HTTPMethod string `json:"HTTPMethod"`
 
 	// Options is a list of options which can be specified for this operation
 	// these are querystring parameters such as 'limit' or 'forceDelete' or similar
 	Options []Option `json:"Options,omitempty"`
 
 	// ResourceId specifies the optional Resource ID used for this operation
-	ResourceId string `json:"ResourceId,omitempty"`
+	ResourceId *string `json:"ResourceId,omitempty"`
 
 	// RequestObject specifies the optional ObjectDefinition to be specified in the Request
-	RequestObject ObjectDefinition `json:"RequestObject,omitempty"`
+	RequestObject *ObjectDefinition `json:"RequestObject,omitempty"`
 
 	// RequestObject specifies the optional ObjectDefinition to be returned by the Request
-	ResponseObject ObjectDefinition `json:"ResponseObject,omitempty"`
+	ResponseObject *ObjectDefinition `json:"ResponseObject,omitempty"`
 
 	// UriSuffix specifies the suffix which should be appended to the ResourceID for this operation
 	// (e.g. `/shutdown`)
-	UriSuffix string `json:"UriSuffix,omitempty"`
-}
-
-// OptionsObject todo figure out if we need this
-type OptionsObject struct {
-	// Name
-	Name    string   `json:"Name"`
-	Options []Option `json:"Options"`
+	UriSuffix *string `json:"UriSuffix,omitempty"`
 }
 
 type Option struct {
@@ -69,5 +59,5 @@ type Option struct {
 	Field string `json:"Field"`
 
 	// FieldType specifies what kind of Option this is (e.g. `String`, `Bool`)
-	FieldType string `json:"FieldType"`
+	FieldType ObjectDefinitionType `json:"FieldType"`
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
@@ -3,61 +3,61 @@ package models
 type Operation struct {
 	// Name specifies the Display Name for this Operation (e.g. `Create`) which is also
 	// valid as an identifier.
-	Name string `json:"Name"`
+	Name string `json:"name"`
 
 	// ContentType specifies the format of the information being sent with the Operation (e.g. `application/json; charset=utf-8`)
-	ContentType string `json:"ContentType"`
+	ContentType string `json:"contentType"`
 
 	// ExpectedStatusCodes specifies is a list of Status Codes which are expected to be returned (e.g. 200, 201)
-	ExpectedStatusCodes []int `json:"ExpectedStatusCodes"`
+	ExpectedStatusCodes []int `json:"expectedStatusCodes"`
 
 	// FieldContainingPaginationDetails is a reference to the field within the Response
 	// which contains the pagination details, (e.g. `nextLink`)
-	FieldContainingPaginationDetails *string `json:"FieldContainingPaginationDetails,omitempty"`
+	FieldContainingPaginationDetails *string `json:"fieldContainingPaginationDetails,omitempty"`
 
 	// LongRunning specifies if this is a Long Running Operation, meaning that Clients
 	// should follow any `Location` headers to track the result of this operation
-	LongRunning bool `json:"LongRunning"`
+	LongRunning bool `json:"longRunning"`
 
 	// HTTPMethod is the Method used for this operation, (e.g. `GET`, `POST`)
-	HTTPMethod string `json:"HTTPMethod"`
+	HTTPMethod string `json:"httpMethod"`
 
 	// Options is a list of options which can be specified for this operation
 	// these are querystring parameters such as 'limit' or 'forceDelete' or similar
-	Options []Option `json:"Options,omitempty"`
+	Options []Option `json:"options,omitempty"`
 
 	// ResourceId specifies the optional Resource ID used for this operation
-	ResourceId *string `json:"ResourceId,omitempty"`
+	ResourceId *string `json:"resourceId,omitempty"`
 
 	// RequestObject specifies the optional ObjectDefinition to be specified in the Request
-	RequestObject *ObjectDefinition `json:"RequestObject,omitempty"`
+	RequestObject *ObjectDefinition `json:"requestObject,omitempty"`
 
 	// RequestObject specifies the optional ObjectDefinition to be returned by the Request
-	ResponseObject *ObjectDefinition `json:"ResponseObject,omitempty"`
+	ResponseObject *ObjectDefinition `json:"responseObject,omitempty"`
 
 	// UriSuffix specifies the suffix which should be appended to the ResourceID for this operation
 	// (e.g. `/shutdown`)
-	UriSuffix *string `json:"UriSuffix,omitempty"`
+	UriSuffix *string `json:"uriSuffix,omitempty"`
 }
 
 type Option struct {
 	// HeaderName is the name of the Http Header which this Option should be set into
 	// (e.g. `If-Match`, `x-ms-client-request-id`)
-	HeaderName *string `json:"HeaderName,omitempty"`
+	HeaderName *string `json:"headerName,omitempty"`
 
 	// Optional specifies whether this Option could be specified in the Request
-	Optional bool `json:"Optional"`
+	Optional bool `json:"optional"`
 
 	// QueryStringName is the Key which should be used for this Option in the QueryString
 	// (e.g. `createTimeMax`, `isActive`)
-	QueryString *string `json:"QueryString,omitempty"`
+	QueryString *string `json:"queryString,omitempty"`
 
 	// Required specifies whether this Option must be specified in the Request
-	Required bool `json:"Required"`
+	Required bool `json:"required"`
 
 	// Field specifies the DisplayName of the Option (e.g. `ConstantOption`, `SecondVal`)
-	Field string `json:"Field"`
+	Field string `json:"field"`
 
 	// FieldType specifies what kind of Option this is (e.g. `String`, `Bool`)
-	FieldType ObjectDefinitionType `json:"FieldType"`
+	FieldType ObjectDefinitionType `json:"fieldType"`
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
@@ -26,8 +26,8 @@ type Operation struct {
 	// these are querystring parameters such as 'limit' or 'forceDelete' or similar
 	Options []Option `json:"options,omitempty"`
 
-	// ResourceId specifies the optional Resource ID used for this operation
-	ResourceId *string `json:"resourceId,omitempty"`
+	// ResourceIdName specifies the name of the optional Resource ID used for this operation
+	ResourceIdName *string `json:"resourceId,omitempty"`
 
 	// RequestObject specifies the optional ObjectDefinition to be specified in the Request
 	RequestObject *ObjectDefinition `json:"requestObject,omitempty"`

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
@@ -23,8 +23,8 @@ type Operation struct {
 	HTTPMethod string `json:"httpMethod"`
 
 	// Options is a list of options which can be specified for this operation
-	// these are querystring parameters such as 'limit' or 'forceDelete' or similar
-	Options []Option `json:"options,omitempty"`
+	// which are either HTTP Headers or QueryString parameters, for example 'limit' or 'forceDelete' or similar
+	Options *[]Option `json:"options,omitempty"`
 
 	// ResourceIdName specifies the name of the optional Resource ID used for this operation
 	ResourceIdName *string `json:"resourceId,omitempty"`
@@ -36,6 +36,7 @@ type Operation struct {
 	ResponseObject *ObjectDefinition `json:"responseObject,omitempty"`
 
 	// UriSuffix specifies the suffix which should be appended to the ResourceID for this operation
+	// NOTE: that a UriSuffix can be specified instead of, as well as in addition to, a ResourceID.
 	// (e.g. `/shutdown`)
 	UriSuffix *string `json:"uriSuffix,omitempty"`
 }
@@ -46,6 +47,8 @@ type Option struct {
 	HeaderName *string `json:"headerName,omitempty"`
 
 	// Optional specifies whether this Option could be specified in the Request
+	// NOTE: this is intentionally not inferred from Required to allow retrieving HTTP Header
+	// and QueryString values in the Response in the future.
 	Optional bool `json:"optional"`
 
 	// QueryStringName is the Key which should be used for this Option in the QueryString
@@ -56,6 +59,7 @@ type Option struct {
 	Required bool `json:"required"`
 
 	// Field specifies the DisplayName of the Option (e.g. `ConstantOption`, `SecondVal`)
+	// which is valid as an identifier.
 	Field string `json:"field"`
 
 	// OptionsObjectDefinition describes the information contained within the Field

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
@@ -1,0 +1,73 @@
+package models
+
+type Operation struct {
+	// Name specifies the Display Name for this Operation (e.g. `Create`) which is also
+	// valid as an identifier.
+	Name string `json:"Name"`
+
+	// ContentType specifies the format of the information being sent with the Operation (e.g. `application/json; charset=utf-8`)
+	ContentType string `json:"ContentType,omitempty"`
+
+	// ExpectedStatusCodes specifies is a list of Status Codes which are expected to be returned (e.g. 200, 201)
+	ExpectedStatusCodes []int `json:"ExpectedStatusCodes,omitempty"`
+
+	// FieldContainingPaginationDetails is a reference to the field within the Response
+	// which contains the pagination details, (e.g. `nextLink`)
+	FieldContainingPaginationDetails string `json:"FieldContainingPaginationDetails,omitempty"`
+
+	// LongRunning specifies if this is a Long Running Operation, meaning that Clients
+	// should follow any `Location` headers to track the result of this operation
+	LongRunning bool `json:"LongRunning,omitempty"`
+
+	// HTTPMethod is the Method used for this operation, (e.g. `GET`, `POST`)
+	HTTPMethod string `json:"HTTPMethod,omitempty"`
+
+	// todo do we need this OptionsObject as well as Options?
+	OptionsObject OptionsObject `json:"OptionsObject,omitempty"`
+
+	// Options is a list of options which can be specified for this operation
+	// these are querystring parameters such as 'limit' or 'forceDelete' or similar
+	Options []Option `json:"Options,omitempty"`
+
+	// ResourceId specifies the optional Resource ID used for this operation
+	ResourceId string `json:"ResourceId,omitempty"`
+
+	// RequestObject specifies the optional ObjectDefinition to be specified in the Request
+	RequestObject ObjectDefinition `json:"RequestObject,omitempty"`
+
+	// RequestObject specifies the optional ObjectDefinition to be returned by the Request
+	ResponseObject ObjectDefinition `json:"ResponseObject,omitempty"`
+
+	// UriSuffix specifies the suffix which should be appended to the ResourceID for this operation
+	// (e.g. `/shutdown`)
+	UriSuffix string `json:"UriSuffix,omitempty"`
+}
+
+// OptionsObject todo figure out if we need this
+type OptionsObject struct {
+	// Name
+	Name    string   `json:"Name"`
+	Options []Option `json:"Options"`
+}
+
+type Option struct {
+	// HeaderName is the name of the Http Header which this Option should be set into
+	// (e.g. `If-Match`, `x-ms-client-request-id`)
+	HeaderName *string `json:"HeaderName,omitempty"`
+
+	// Optional specifies whether this Option could be specified in the Request
+	Optional bool `json:"Optional"`
+
+	// QueryStringName is the Key which should be used for this Option in the QueryString
+	// (e.g. `createTimeMax`, `isActive`)
+	QueryString *string `json:"QueryString,omitempty"`
+
+	// Required specifies whether this Option must be specified in the Request
+	Required bool `json:"Required"`
+
+	// Field specifies the DisplayName of the Option (e.g. `ConstantOption`, `SecondVal`)
+	Field string `json:"Field"`
+
+	// FieldType specifies what kind of Option this is (e.g. `String`, `Bool`)
+	FieldType string `json:"FieldType"`
+}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/operations.go
@@ -27,7 +27,7 @@ type Operation struct {
 	Options *[]Option `json:"options,omitempty"`
 
 	// ResourceIdName specifies the name of the optional Resource ID used for this operation
-	ResourceIdName *string `json:"resourceId,omitempty"`
+	ResourceIdName *string `json:"resourceIdName,omitempty"`
 
 	// RequestObject specifies the optional ObjectDefinition to be specified in the Request
 	RequestObject *ObjectDefinition `json:"requestObject,omitempty"`

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/options_object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/options_object_definition.go
@@ -9,7 +9,7 @@ type OptionObjectDefinition struct {
 	// ReferenceName is the name of the Constant that this is a reference to
 	ReferenceName *string `json:"referenceName"`
 
-	// NestedItem is a nested OptionObjectDefinition when Type is a List
+	// NestedItem is a nested OptionObjectDefinition when Type is a CSV or a List
 	NestedItem *OptionObjectDefinition `json:"nestedItem,omitempty"`
 }
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/options_object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/options_object_definition.go
@@ -1,14 +1,12 @@
 package models
 
-import "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-
 // OptionObjectDefinition specifies the type of values that the HTTP Operation supports and sends at Request time in either the
 // HTTP Header and/or the QueryString
 type OptionObjectDefinition struct {
 	// OptionObjectDefinitionType defines what kind of ObjectDefinition this is, such as a Reference, String or List
 	Type OptionObjectDefinitionType `json:"type"`
 
-	// ReferenceName is the name of the Constant or Model that this is a reference to
+	// ReferenceName is the name of the Constant that this is a reference to
 	ReferenceName *string `json:"referenceName"`
 
 	// NestedItem is a nested OptionObjectDefinition when Type is a List
@@ -36,20 +34,6 @@ const (
 	// ListOptionObjectDefinitionType signifies that this field contains a List, the List's Value Type is defined as a Nested Object Definition.
 	ListOptionObjectDefinitionType OptionObjectDefinitionType = "List"
 
-	// ReferenceOptionObjectDefinitionType signifies that this field points to a Constant or a Model.
+	// ReferenceOptionObjectDefinitionType signifies that this field points to a Constant.
 	ReferenceOptionObjectDefinitionType OptionObjectDefinitionType = "Reference"
 )
-
-func OptionObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input *models.ObjectDefinition) *OptionObjectDefinition {
-	if input == nil {
-		return nil
-	}
-
-	objectDefinition := OptionObjectDefinition{
-		ReferenceName: input.ReferenceName,
-		Type:          OptionObjectDefinitionType(input.Type),
-		NestedItem:    OptionObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input.NestedItem),
-	}
-
-	return &objectDefinition
-}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/options_object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/options_object_definition.go
@@ -1,0 +1,55 @@
+package models
+
+import "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+
+// OptionObjectDefinition specifies the type of values that the HTTP Operation supports and sends at Request time in either the
+// HTTP Header and/or the QueryString
+type OptionObjectDefinition struct {
+	// OptionObjectDefinitionType defines what kind of ObjectDefinition this is, such as a Reference, String or List
+	Type OptionObjectDefinitionType `json:"type"`
+
+	// ReferenceName is the name of the Constant or Model that this is a reference to
+	ReferenceName *string `json:"referenceName"`
+
+	// NestedItem is a nested OptionObjectDefinition when Type is a List
+	NestedItem *OptionObjectDefinition `json:"nestedItem,omitempty"`
+}
+
+type OptionObjectDefinitionType string
+
+const (
+	// BooleanOptionObjectDefinitionType signifies that this type is a simple Boolean.
+	BooleanOptionObjectDefinitionType OptionObjectDefinitionType = "Boolean"
+
+	// IntegerOptionObjectDefinitionType signifies that this field contains an Integer.
+	IntegerOptionObjectDefinitionType OptionObjectDefinitionType = "Integer"
+
+	// FloatOptionObjectDefinitionType signifies that this field contains a Float.
+	FloatOptionObjectDefinitionType OptionObjectDefinitionType = "Float"
+
+	// StringOptionObjectDefinitionType signifies that this field contains a String.
+	StringOptionObjectDefinitionType OptionObjectDefinitionType = "String"
+
+	// CsvOptionObjectDefinitionType signifies that this field contains a CSV of simple types e.g. String, Integer, Float.
+	CsvOptionObjectDefinitionType OptionObjectDefinitionType = "Csv"
+
+	// ListOptionObjectDefinitionType signifies that this field contains a List, the List's Value Type is defined as a Nested Object Definition.
+	ListOptionObjectDefinitionType OptionObjectDefinitionType = "List"
+
+	// ReferenceOptionObjectDefinitionType signifies that this field points to a Constant or a Model.
+	ReferenceOptionObjectDefinitionType OptionObjectDefinitionType = "Reference"
+)
+
+func OptionObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input *models.ObjectDefinition) *OptionObjectDefinition {
+	if input == nil {
+		return nil
+	}
+
+	objectDefinition := OptionObjectDefinition{
+		ReferenceName: input.ReferenceName,
+		Type:          OptionObjectDefinitionType(input.Type),
+		NestedItem:    OptionObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(input.NestedItem),
+	}
+
+	return &objectDefinition
+}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -103,7 +103,7 @@ func codeForOperation(operationName string, operation models.OperationDetails, r
 		LongRunning:                      longRunning,
 		HTTPMethod:                       HTTPMethod,
 		Options:                          options,
-		ResourceId:                       pointer.To(resourceId),
+		ResourceIdName:                   pointer.To(resourceId),
 		RequestObject:                    operationModels.ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(operation.RequestObject),
 		ResponseObject:                   operationModels.ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(operation.ResponseObject),
 		UriSuffix:                        pointer.To(uriSuffix),

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -37,11 +37,6 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 		longRunning = true
 	}
 
-	if operation.RequestObject == nil && (strings.EqualFold(operation.Method, "POST") || strings.EqualFold(operation.Method, "PUT")) {
-		// Post and Put operations should have a RequestObject one but it's possible they don't
-		// TODO what goes here?
-	}
-
 	resourceId := ""
 	if operation.ResourceIdName != nil {
 		resourceId = *operation.ResourceIdName
@@ -123,7 +118,7 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 
 			options = append(options, option)
 		}
-		op.Options = options
+		op.Options = pointer.To(options)
 	}
 
 	data, err := json.MarshalIndent(op, "", " ")

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -26,11 +26,6 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 		sort.Ints(statusCodes)
 	}
 
-	fieldContainingPaginationDetails := ""
-	if operation.FieldContainingPaginationDetails != nil {
-		fieldContainingPaginationDetails = *operation.FieldContainingPaginationDetails
-	}
-
 	longRunning := false
 	if operation.LongRunning {
 		// TODO: we can use the `LongRunning` operation base types too
@@ -48,17 +43,6 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 	}
 
 	HTTPMethod := strings.Title(strings.ToLower(operation.Method))
-	if operation.FieldContainingPaginationDetails != nil {
-		HTTPMethod = "List"
-		// TODO is there a todo here?
-		// since this is a List operation we need to additionally output the HttpMethod
-		// since it's possible that these are non-standard (e.g. AppConfig 2020-06-01 ListKeys
-		// is a POST not a GET for a List operation)
-		//if !strings.EqualFold(operation.Method, "GET") {
-		//	method := dotNetNameForHttpMethod(operation.Method)
-		//	code = append(code, fmt.Sprintf(`		public override System.Net.Http.HttpMethod Method() => System.Net.Http.%s;`, method))
-		//}
-	}
 
 	responseObject, err := mapObjectDefinition(operation.ResponseObject, knownConstants, knownModels)
 	if err != nil {
@@ -74,7 +58,7 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 		Name:                             operationName,
 		ContentType:                      contentType,
 		ExpectedStatusCodes:              statusCodes,
-		FieldContainingPaginationDetails: pointer.To(fieldContainingPaginationDetails),
+		FieldContainingPaginationDetails: operation.FieldContainingPaginationDetails,
 		LongRunning:                      longRunning,
 		HTTPMethod:                       HTTPMethod,
 		ResourceIdName:                   pointer.To(resourceId),

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	operationModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigeneratorjson/models"
+	dataApiModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigeneratorjson/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -46,7 +46,7 @@ func codeForOperation(operationName string, operation models.OperationDetails, r
 		resourceId = *operation.ResourceIdName
 	}
 
-	options := make([]operationModels.Option, 0)
+	options := make([]dataApiModels.Option, 0)
 	if len(operation.Options) > 0 {
 		sortedOptionsKeys := make([]string, 0)
 		for k := range operation.Options {
@@ -61,11 +61,11 @@ func codeForOperation(operationName string, operation models.OperationDetails, r
 				return nil, fmt.Errorf("missing object definition")
 			}
 
-			option := operationModels.Option{
-				HeaderName:  optionDetails.HeaderName,
-				QueryString: optionDetails.QueryStringName,
-				Field:       optionName,
-				FieldType:   operationModels.ObjectDefinitionType(optionDetails.ObjectDefinition.Type),
+			option := dataApiModels.Option{
+				HeaderName:       optionDetails.HeaderName,
+				QueryString:      optionDetails.QueryStringName,
+				Field:            optionName,
+				ObjectDefinition: dataApiModels.OptionObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(optionDetails.ObjectDefinition),
 			}
 
 			if !optionDetails.Required {
@@ -95,7 +95,7 @@ func codeForOperation(operationName string, operation models.OperationDetails, r
 		//	code = append(code, fmt.Sprintf(`		public override System.Net.Http.HttpMethod Method() => System.Net.Http.%s;`, method))
 		//}
 	}
-	op := operationModels.Operation{
+	op := dataApiModels.Operation{
 		Name:                             operationName,
 		ContentType:                      contentType,
 		ExpectedStatusCodes:              statusCodes,
@@ -104,8 +104,8 @@ func codeForOperation(operationName string, operation models.OperationDetails, r
 		HTTPMethod:                       HTTPMethod,
 		Options:                          options,
 		ResourceIdName:                   pointer.To(resourceId),
-		RequestObject:                    operationModels.ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(operation.RequestObject),
-		ResponseObject:                   operationModels.ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(operation.ResponseObject),
+		RequestObject:                    dataApiModels.ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(operation.RequestObject),
+		ResponseObject:                   dataApiModels.ObjectDefinitionFromSchemaFieldFromImporterRestApiSpecs(operation.ResponseObject),
 		UriSuffix:                        pointer.To(uriSuffix),
 	}
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -42,8 +42,6 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 		uriSuffix = *operation.UriSuffix
 	}
 
-	HTTPMethod := strings.Title(strings.ToLower(operation.Method))
-
 	responseObject, err := mapObjectDefinition(operation.ResponseObject, knownConstants, knownModels)
 	if err != nil {
 		return nil, fmt.Errorf("mapping the object definition: %+v", err)
@@ -60,7 +58,7 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 		ExpectedStatusCodes:              statusCodes,
 		FieldContainingPaginationDetails: operation.FieldContainingPaginationDetails,
 		LongRunning:                      longRunning,
-		HTTPMethod:                       HTTPMethod,
+		HTTPMethod:                       strings.ToUpper(operation.Method),
 		ResourceIdName:                   pointer.To(resourceId),
 		RequestObject:                    responseObject,
 		ResponseObject:                   requestObject,


### PR DESCRIPTION
I have a few todos to track down:

- [x] Options vs OptionsObject
- [x] Do we need to do anything with that todo? 
```
if operation.ResponseObject != nil {
		responseObject.ReferenceName = operation.ResponseObject.ReferenceName
		responseObject.Type = operationModels.ObjectDefinitionType(operation.ResponseObject.Type)

		// TODO
		//if operation.FieldContainingPaginationDetails == nil {
		//	code = append(code, fmt.Sprintf(`		public override Type? ResponseObject() => typeof(%[1]s);`, *responseOperationTypeName))
		//} else {
		//	code = append(code, fmt.Sprintf(`		public override Type NestedItemType() => typeof(%[1]s);`, *responseOperationTypeName))
		//}
	}
```

- [x] and this todo
```
if operation.FieldContainingPaginationDetails != nil {
		HTTPMethod = "List"
		// TODO is there a todo here?
		// since this is a List operation we need to additionally output the HttpMethod
		// since it's possible that these are non-standard (e.g. AppConfig 2020-06-01 ListKeys
		// is a POST not a GET for a List operation)
		//if !strings.EqualFold(operation.Method, "GET") {
		//	method := dotNetNameForHttpMethod(operation.Method)
		//	code = append(code, fmt.Sprintf(`		public override System.Net.Http.HttpMethod Method() => System.Net.Http.%s;`, method))
		//}
	}
```
