### PR TITLE
config : adding API Versions for Redis Enterprise

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -450,7 +450,7 @@ service "redis" {
 }
 service "redisenterprise" {
   name      = "RedisEnterprise"
-  available = ["2022-01-01", "2023-07-01"]
+  available = ["2022-01-01", "2023-07-01", "2023-10-01-preview"]
 }
 service "relay" {
   name      = "Relay"


### PR DESCRIPTION
Swagger : https://github.com/Azure/azure-rest-api-specs/blob/main/specification/redisenterprise/resource-manager/Microsoft.Cache/preview/2023-10-01-preview/redisenterprise.json

Although this is a preview release, the service team has promised that there won't be any breaking changes.