### PR TITLE
tools/importer-rest-api-specs: fixing the segment `datareferences` to `dataReferences` for MachineLearningWorkspaces

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
+++ b/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
@@ -112,7 +112,8 @@ func NormalizeSegment(input string, camelCase bool) string {
 		"continuouswebjobs":                 "continuousWebJobs",
 		"customimages":                      "customImages",
 		"customipprefixes":                  "customIPPrefixes",
-		"databases":                         "databases", // handles Databases
+		"databases":                         "databases",      // handles Databases
+		"datareferences":                    "dataReferences", // handles MachineLearningServices
 		"dataconnections":                   "dataConnections",
 		"datastores":                        "dataStores",
 		"dedicatedsqlminimaltlssettings":    "dedicatedSQLMinimalTLSSettings",


### PR DESCRIPTION
Fixes https://github.com/hashicorp/pandora/pull/3209