### PR TITLE
`tools/importer-rest-api-specs`: refactoring the V2 API Definitions for Models/Fields/Object Definitions

### DIFF
--- a/api-definitions/README.md
+++ b/api-definitions/README.md
@@ -1,0 +1,5 @@
+## API Definitions (for Data API v2)
+
+This directory contains the API Definitions used in V2 of the Data API, which is currently under development.
+
+More details will follow when the data is populated - however at the moment this file is a placeholder to ensure the directory exists.

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_api_versions.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_api_versions.go
@@ -14,10 +14,10 @@ func (s Generator) generateApiVersions(apiVersion models.AzureApiDefinition) err
 	for resourceName, resource := range apiVersion.Resources {
 		s.logger.Trace(fmt.Sprintf("Generating Resource %q for API Version %q", resourceName, apiVersion.ApiVersion))
 		outputDirectory := s.workingDirectoryForResource(resourceName)
-		resourceMetadata := s.resourceDetails(resourceName)
-		s.logger.Debug("%s, %s", outputDirectory, resourceMetadata)
-		if err := s.generateResources(resourceName, resourceMetadata, resource, outputDirectory); err != nil {
-			return fmt.Errorf("generating Resource %q for %s: %+v", resourceName, resourceMetadata, err)
+		s.logger.Debug(fmt.Sprintf("Outputting API Resource %q to %q", resourceName, outputDirectory))
+		logger := s.logger.Named(fmt.Sprintf("Service %q / API Version %q / Resource %q", s.serviceName, apiVersion, resourceName))
+		if err := s.generateResources(resourceName, resource, outputDirectory, logger); err != nil {
+			return fmt.Errorf("generating Resource %q: %+v", resourceName, err)
 		}
 	}
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_api_versions.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_api_versions.go
@@ -15,7 +15,7 @@ func (s Generator) generateApiVersions(apiVersion models.AzureApiDefinition) err
 		s.logger.Trace(fmt.Sprintf("Generating Resource %q for API Version %q", resourceName, apiVersion.ApiVersion))
 		outputDirectory := s.workingDirectoryForResource(resourceName)
 		s.logger.Debug(fmt.Sprintf("Outputting API Resource %q to %q", resourceName, outputDirectory))
-		logger := s.logger.Named(fmt.Sprintf("Service %q / API Version %q / Resource %q", s.serviceName, apiVersion, resourceName))
+		logger := s.logger.Named(fmt.Sprintf("Service %q / API Version %q / Resource %q", s.serviceName, apiVersion.ApiVersion, resourceName))
 		if err := s.generateResources(resourceName, resource, outputDirectory, logger); err != nil {
 			return fmt.Errorf("generating Resource %q: %+v", resourceName, err)
 		}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/helpers.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/helpers.go
@@ -9,10 +9,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-func (s Generator) resourceDetails(resourceName string) string {
-	return fmt.Sprintf("%s %s %s", s.serviceName, s.apiVersionPackageName, s.packageNameForResource(resourceName))
-}
-
 func (s Generator) packageNameForResource(resourceName string) string {
 	return strings.Title(resourceName)
 }
@@ -22,7 +18,7 @@ func (s Generator) workingDirectoryForResource(resource string) string {
 	return path.Join(dir, resource)
 }
 
-func RecreateDirectory(directory string, logger hclog.Logger) error {
+func recreateDirectory(directory string, logger hclog.Logger) error {
 	logger.Trace(fmt.Sprintf("Deleting any existing directory at %q..", directory))
 	if err := os.RemoveAll(directory); err != nil {
 		return fmt.Errorf("removing any existing directory at %q: %+v", directory, err)

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/interface.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/interface.go
@@ -6,7 +6,6 @@ import (
 
 type Generator struct {
 	apiVersionPackageName         string
-	logger                        hclog.Logger
 	outputDirectory               string
 	resourceProvider              *string
 	serviceName                   string
@@ -15,4 +14,7 @@ type Generator struct {
 	workingDirectoryForService    string
 	workingDirectoryForApiVersion string
 	workingDirectoryForTerraform  string
+
+	// TODO: pass this into methods as needed, so that we can ensure the logger is always named as required?
+	logger hclog.Logger
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/models.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/models.go
@@ -1,0 +1,29 @@
+package models
+
+// NOTE: these types are intentionally undocumented atm, these'll be added in a follow-up PR
+
+type Model struct {
+	Name string `json:"name"`
+
+	Fields []ModelField `json:"fields"`
+
+	DiscriminatedParentModelName *string `json:"discriminatedParentModelName,omitempty"`
+
+	DiscriminatedTypeValue *string `json:"discriminatedTypeValue,omitempty"`
+}
+
+type ModelField struct {
+	ContainsDiscriminatedTypeValue bool `json:"containsDiscriminatedTypeValue"`
+
+	DateFormat *DateFormat `json:"dateFormat,omitempty"`
+
+	JsonName string `json:"jsonName"`
+
+	Name string `json:"name"`
+
+	ObjectDefinition ObjectDefinition `json:"objectDefinition"`
+
+	Optional bool `json:"optional"`
+
+	Required bool `json:"required"`
+}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/object_definition.go
@@ -1,0 +1,59 @@
+package models
+
+// NOTE: these types are intentionally undocumented atm, these'll be added in a follow-up PR
+
+type ObjectDefinition struct {
+	Type ObjectDefinitionType `json:"type"`
+
+	ReferenceName *string `json:"referenceName"` // NOTE: we could split this into ConstantName and ModelName in time, but not today.
+
+	NestedItem *ObjectDefinition `json:"nestedItem,omitempty"`
+
+	// NOTE: these 3 fields were previously located against the Field but instead should be located against the Object Definition
+	// as such we'll need to update the Data API to account for this
+	MaxItems   *int        `json:"maxItems,omitempty"`
+	MinItems   *int        `json:"minItems,omitempty"`
+	DateFormat *DateFormat `json:"dateFormat,omitempty"`
+}
+
+type ObjectDefinitionType string
+
+const (
+	// BooleanObjectDefinitionType is used to signify that this type is a simple Boolean.
+	BooleanObjectDefinitionType   ObjectDefinitionType = "Boolean"
+	DateTimeObjectDefinitionType  ObjectDefinitionType = "DateTime"
+	IntegerObjectDefinitionType   ObjectDefinitionType = "Integer"
+	FloatObjectDefinitionType     ObjectDefinitionType = "Float"
+	RawFileObjectDefinitionType   ObjectDefinitionType = "RawFile"
+	RawObjectObjectDefinitionType ObjectDefinitionType = "RawObject"
+	ReferenceObjectDefinitionType ObjectDefinitionType = "Reference"
+	StringObjectDefinitionType    ObjectDefinitionType = "String"
+
+	CsvObjectDefinitionType        ObjectDefinitionType = "Csv"
+	DictionaryObjectDefinitionType ObjectDefinitionType = "Dictionary"
+	ListObjectDefinitionType       ObjectDefinitionType = "List"
+
+	EdgeZoneObjectDefinitionType                                ObjectDefinitionType = "EdgeZone"
+	LocationObjectDefinitionType                                ObjectDefinitionType = "Location"
+	TagsObjectDefinitionType                                    ObjectDefinitionType = "Tags"
+	SystemAssignedIdentityObjectDefinitionType                  ObjectDefinitionType = "SystemAssignedIdentity"
+	SystemAndUserAssignedIdentityListObjectDefinitionType       ObjectDefinitionType = "SystemAndUserAssignedIdentityList"
+	SystemAndUserAssignedIdentityMapObjectDefinitionType        ObjectDefinitionType = "SystemAndUserAssignedIdentityMap"
+	LegacySystemAndUserAssignedIdentityListObjectDefinitionType ObjectDefinitionType = "LegacySystemAndUserAssignedIdentityList"
+	LegacySystemAndUserAssignedIdentityMapObjectDefinitionType  ObjectDefinitionType = "LegacySystemAndUserAssignedIdentityMap"
+	SystemOrUserAssignedIdentityListObjectDefinitionType        ObjectDefinitionType = "SystemOrUserAssignedIdentityList"
+	SystemOrUserAssignedIdentityMapObjectDefinitionType         ObjectDefinitionType = "SystemOrUserAssignedIdentityMap"
+	UserAssignedIdentityListObjectDefinitionType                ObjectDefinitionType = "UserAssignedIdentityList"
+	UserAssignedIdentityMapObjectDefinitionType                 ObjectDefinitionType = "UserAssignedIdentityMap"
+	SystemDataObjectDefinitionType                              ObjectDefinitionType = "SystemData"
+	ZoneObjectDefinitionType                                    ObjectDefinitionType = "Zone"
+	ZonesObjectDefinitionType                                   ObjectDefinitionType = "Zones"
+)
+
+type DateFormat string
+
+const (
+	RFC3339DateFormat DateFormat = "RFC3339"
+	// TODO: others in the future https://github.com/hashicorp/pandora/issues/8 e.g.
+	// RFC3339NanoDateFormat DateFormat = "RFC3339Nano"
+)

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_models.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_models.go
@@ -7,40 +7,46 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/go-hclog"
+	dataApiModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigeneratorjson/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-type Model struct {
-	Fields          []Field `json:"Fields"`
-	IsDiscriminator *bool   `json:"IsDiscriminator,omitempty"`
-	ParentModelName *string `json:"ParentModelName,omitempty"`
-	// TODO rename, and should this be a slice? haven't found examples where there are multiple of these
-	ValueForType *string `json:"ValueForType,omitempty"`
-}
-
-type Field struct {
-	Name             string           `json:"Name"`
-	JsonName         string           `json:"JsonName"`
-	Required         *bool            `json:"Required,omitempty"`
-	Optional         *bool            `json:"Optional,omitempty"`
-	ObjectDefinition ObjectDefinition `json:"ObjectDefinition"`
-	MinItems         *int             `json:"MinItems,omitempty"`
-	MaxItems         *int             `json:"MaxItems,omitempty"`
-	DateFormat       *string          `json:"DateFormat,omitempty"`
-	ProvidesTypeHint *bool            `json:"ProvidesTypeHint,omitempty"`
-}
-
-type ObjectDefinition struct {
-	Type          ObjectDefinitionType `json:"Type"`
-	ReferenceName *string              `json:"ReferenceName,omitempty"`
-	NestedItem    *ObjectDefinition    `json:"ObjectDefinition,omitempty"`
-}
-
-func codeForModel(metadata string, modelName string, model models.ModelDetails, parentModel *models.ModelDetails, knownConstants map[string]resourcemanager.ConstantDetails, knownModels map[string]models.ModelDetails) ([]byte, error) {
+func codeForModel(modelName string, model importerModels.ModelDetails, parentModel *importerModels.ModelDetails, knownConstants map[string]resourcemanager.ConstantDetails, knownModels map[string]importerModels.ModelDetails, logger hclog.Logger) ([]byte, error) {
+	// TODO: thread through logging
 	if len(model.Fields) == 0 {
-		return nil, fmt.Errorf("the model %q in namespace %q has no fields", modelName, metadata)
+		return nil, fmt.Errorf("the model %q has no fields", modelName)
 	}
+
+	fields, err := mapFieldsForModel(model, parentModel, knownConstants, knownModels, logger)
+	if err != nil {
+		return nil, fmt.Errorf("mapping fields for model %q: %+v", modelName, err)
+	}
+
+	dataApiModel := dataApiModels.Model{
+		Fields: *fields,
+	}
+
+	// NOTE: `Parent` types don't get a `TypeHintIn` or `TypeHintValue`
+	// meaning that only
+	if model.ParentTypeName != nil {
+		dataApiModel.DiscriminatedParentModelName = model.ParentTypeName
+	}
+	if model.TypeHintValue != nil {
+		dataApiModel.DiscriminatedTypeValue = model.TypeHintValue
+	}
+
+	data, err := json.MarshalIndent(dataApiModel, "", " ")
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func mapFieldsForModel(model importerModels.ModelDetails, parentModel *importerModels.ModelDetails, knownConstants map[string]resourcemanager.ConstantDetails, knownModels map[string]importerModels.ModelDetails, logger hclog.Logger) (*[]dataApiModels.ModelField, error) {
+	// TODO: thread through logging
 
 	// ensure consistency in the output
 	sortedFieldNames := make([]string, 0)
@@ -49,7 +55,7 @@ func codeForModel(metadata string, modelName string, model models.ModelDetails, 
 	}
 	sort.Strings(sortedFieldNames)
 
-	fields := make([]Field, 0)
+	fields := make([]dataApiModels.ModelField, 0)
 
 	for _, fieldName := range sortedFieldNames {
 		// we should skip outputting this field if it's present on the parent
@@ -71,7 +77,7 @@ func codeForModel(metadata string, modelName string, model models.ModelDetails, 
 
 		field := model.Fields[fieldName]
 		isTypeHint := model.TypeHintIn != nil && strings.EqualFold(*model.TypeHintIn, fieldName)
-		fieldCode, err := codeForField(fieldName, field, isTypeHint, knownConstants, knownModels)
+		fieldCode, err := mapField(fieldName, field, isTypeHint, knownConstants, knownModels)
 		if err != nil {
 			return nil, fmt.Errorf("generating code for field %q: %+v", fieldName, err)
 		}
@@ -79,265 +85,156 @@ func codeForModel(metadata string, modelName string, model models.ModelDetails, 
 		fields = append(fields, *fieldCode)
 	}
 
-	var DataApiModel Model
+	return &fields, nil
+}
 
-	DataApiModel.Fields = fields
-
-	if model.TypeHintIn != nil {
-		DataApiModel.IsDiscriminator = pointer.To(true)
-		if model.ParentTypeName != nil {
-			DataApiModel.ParentModelName = model.ParentTypeName
-		}
-	}
-
-	if model.TypeHintValue != nil {
-		DataApiModel.ValueForType = model.TypeHintValue
-	}
-
-	data, err := json.MarshalIndent(DataApiModel, "", " ")
+func mapField(fieldName string, fieldDetails importerModels.FieldDetails, isTypeHint bool, constants map[string]resourcemanager.ConstantDetails, knownModels map[string]importerModels.ModelDetails) (*dataApiModels.ModelField, error) {
+	// TODO: thread through logging
+	objectDefinition, err := mapObjectDefinitionForField(fieldDetails, constants, knownModels)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("mapping the ObjectDefinition for field %q: %+v", fieldName, err)
 	}
 
-	return data, nil
+	return &dataApiModels.ModelField{
+		ContainsDiscriminatedTypeValue: isTypeHint,
+		JsonName:                       fieldDetails.JsonName,
+		Name:                           fieldName,
+		ObjectDefinition:               *objectDefinition,
+		// TODO: support Optional being a distinct value in-time so we can have ReadOnly fields too
+		Optional: !fieldDetails.Required,
+		Required: fieldDetails.Required,
+	}, nil
 }
 
-func codeForField(fieldName string, fieldDetails models.FieldDetails, isTypeHint bool, constants map[string]resourcemanager.ConstantDetails, knownModels map[string]models.ModelDetails) (*Field, error) {
-	var field Field
+var customFieldTypesToObjectDefinitionTypes = map[importerModels.CustomFieldType]dataApiModels.ObjectDefinitionType{
+	importerModels.CustomFieldTypeEdgeZone:                                dataApiModels.EdgeZoneObjectDefinitionType,
+	importerModels.CustomFieldTypeLocation:                                dataApiModels.LocationObjectDefinitionType,
+	importerModels.CustomFieldTypeSystemAssignedIdentity:                  dataApiModels.SystemAssignedIdentityObjectDefinitionType,
+	importerModels.CustomFieldTypeSystemAndUserAssignedIdentityList:       dataApiModels.SystemAndUserAssignedIdentityListObjectDefinitionType,
+	importerModels.CustomFieldTypeSystemAndUserAssignedIdentityMap:        dataApiModels.SystemAndUserAssignedIdentityMapObjectDefinitionType,
+	importerModels.CustomFieldTypeLegacySystemAndUserAssignedIdentityList: dataApiModels.LegacySystemAndUserAssignedIdentityListObjectDefinitionType,
+	importerModels.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap:  dataApiModels.LegacySystemAndUserAssignedIdentityMapObjectDefinitionType,
+	importerModels.CustomFieldTypeSystemOrUserAssignedIdentityList:        dataApiModels.SystemOrUserAssignedIdentityListObjectDefinitionType,
+	importerModels.CustomFieldTypeSystemOrUserAssignedIdentityMap:         dataApiModels.SystemOrUserAssignedIdentityMapObjectDefinitionType,
+	importerModels.CustomFieldTypeUserAssignedIdentityList:                dataApiModels.UserAssignedIdentityListObjectDefinitionType,
+	importerModels.CustomFieldTypeUserAssignedIdentityMap:                 dataApiModels.UserAssignedIdentityMapObjectDefinitionType,
+	importerModels.CustomFieldTypeTags:                                    dataApiModels.TagsObjectDefinitionType,
+	importerModels.CustomFieldTypeSystemData:                              dataApiModels.SystemDataObjectDefinitionType,
+	importerModels.CustomFieldTypeZone:                                    dataApiModels.ZoneObjectDefinitionType,
+	importerModels.CustomFieldTypeZones:                                   dataApiModels.ZonesObjectDefinitionType,
+}
 
-	field.Name = fieldName
-	field.JsonName = fieldDetails.JsonName
+var internalObjectDefinitionsToObjectDefinitionTypes = map[importerModels.ObjectDefinitionType]dataApiModels.ObjectDefinitionType{
+	importerModels.ObjectDefinitionBoolean:    dataApiModels.BooleanObjectDefinitionType,
+	importerModels.ObjectDefinitionCsv:        dataApiModels.CsvObjectDefinitionType,
+	importerModels.ObjectDefinitionDateTime:   dataApiModels.DateTimeObjectDefinitionType,
+	importerModels.ObjectDefinitionDictionary: dataApiModels.DictionaryObjectDefinitionType,
+	importerModels.ObjectDefinitionInteger:    dataApiModels.IntegerObjectDefinitionType,
+	importerModels.ObjectDefinitionFloat:      dataApiModels.FloatObjectDefinitionType,
+	importerModels.ObjectDefinitionList:       dataApiModels.ListObjectDefinitionType,
+	importerModels.ObjectDefinitionRawFile:    dataApiModels.RawFileObjectDefinitionType,
+	importerModels.ObjectDefinitionRawObject:  dataApiModels.RawObjectObjectDefinitionType,
+	importerModels.ObjectDefinitionReference:  dataApiModels.ReferenceObjectDefinitionType,
+	importerModels.ObjectDefinitionString:     dataApiModels.StringObjectDefinitionType,
+}
 
-	fieldType, err := typeNameForField(fieldDetails, constants, knownModels)
+func mapObjectDefinitionForField(details importerModels.FieldDetails, constants map[string]resourcemanager.ConstantDetails, models map[string]importerModels.ModelDetails) (*dataApiModels.ObjectDefinition, error) {
+	// if it's a CustomFieldType then it can't contain another item
+	if details.CustomFieldType != nil {
+		typeVal, ok := customFieldTypesToObjectDefinitionTypes[*details.CustomFieldType]
+		if !ok {
+			return nil, fmt.Errorf("internal-error: no ObjectDefinition mapping is defined for the CustomFieldType %q", string(*details.CustomFieldType))
+		}
+		return &dataApiModels.ObjectDefinition{
+			Type:          typeVal,
+			ReferenceName: nil,
+			NestedItem:    nil,
+		}, nil
+	}
+
+	if details.ObjectDefinition == nil {
+		return nil, fmt.Errorf("internal-error: neither a CustomFieldType or an ObjectDefinition was defined for this field")
+	}
+
+	objectDefinition, err := mapObjectDefinition(details.ObjectDefinition, constants, models)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("mapping the object definition: %+v", err)
 	}
 
-	field.ObjectDefinition.Type = ObjectDefinitionType(*fieldType)
-
-	if fieldDetails.ObjectDefinition != nil {
-		innerObjectDefinition := topLevelObjectDefinition(*fieldDetails.ObjectDefinition)
-		if innerObjectDefinition.Minimum != nil {
-			field.MinItems = innerObjectDefinition.Minimum
-		}
-		if innerObjectDefinition.Maximum != nil {
-			field.MaxItems = innerObjectDefinition.Maximum
-		}
-
-		if fieldDetails.ObjectDefinition.Type == models.ObjectDefinitionDateTime {
-			// TODO: support for custom date formats
-			field.DateFormat = pointer.To("RFC3339")
-		}
-	}
-
-	if isTypeHint {
-		field.ProvidesTypeHint = pointer.To(true)
-	}
-
-	if fieldDetails.Required {
-		field.Required = pointer.To(true)
-	} else {
-		field.Optional = pointer.To(true)
-	}
-
-	return &field, nil
+	return objectDefinition, nil
 }
 
-func typeNameForField(field models.FieldDetails, constants map[string]resourcemanager.ConstantDetails, models map[string]models.ModelDetails) (*string, error) {
-	if field.CustomFieldType != nil {
-		return typeNameForCustomType(*field.CustomFieldType)
+func mapObjectDefinition(definition *importerModels.ObjectDefinition, constants map[string]resourcemanager.ConstantDetails, models map[string]importerModels.ModelDetails) (*dataApiModels.ObjectDefinition, error) {
+	typeVal, ok := internalObjectDefinitionsToObjectDefinitionTypes[definition.Type]
+	if !ok {
+		return nil, fmt.Errorf("internal-error: no ObjectDefinition mapping is defined for the ObjectDefinition Type %q", string(definition.Type))
 	}
 
-	return typeNameForObjectDefinition(field.ObjectDefinition, constants, models)
+	output := dataApiModels.ObjectDefinition{
+		Type:          typeVal,
+		ReferenceName: nil,
+		NestedItem:    nil,
+	}
+
+	if definition.ReferenceName != nil {
+		output.ReferenceName = definition.ReferenceName
+	}
+
+	if definition.NestedItem != nil {
+		nestedItem, err := mapObjectDefinition(definition.NestedItem, constants, models)
+		if err != nil {
+			return nil, fmt.Errorf("mapping nested object definition: %+v", err)
+		}
+		output.NestedItem = nestedItem
+	}
+
+	if definition.Maximum != nil {
+		output.MaxItems = definition.Maximum
+	}
+	if definition.Minimum != nil {
+		output.MinItems = definition.Minimum
+	}
+	if output.Type == dataApiModels.DateTimeObjectDefinitionType {
+		// TODO: support additional types of Date Formats (#8)
+		output.DateFormat = pointer.To(dataApiModels.RFC3339DateFormat)
+	}
+
+	// finally let's do some sanity-checking to ensure the data being output looks legit
+	if err := validateObjectDefinition(output, constants, models); err != nil {
+		return nil, fmt.Errorf("validating mapped ObjectDefinition: %+v", err)
+	}
+
+	return &output, nil
 }
 
-func typeNameForCustomType(input models.CustomFieldType) (*string, error) {
-	var nilableType = func(in string) (*string, error) {
-		return &in, nil
+func validateObjectDefinition(input dataApiModels.ObjectDefinition, constants map[string]resourcemanager.ConstantDetails, models map[string]importerModels.ModelDetails) error {
+	requiresNestedItem := input.Type == dataApiModels.CsvObjectDefinitionType ||
+		input.Type == dataApiModels.DictionaryObjectDefinitionType ||
+		input.Type == dataApiModels.ListObjectDefinitionType
+	requiresReference := input.Type == dataApiModels.ReferenceObjectDefinitionType
+	if requiresNestedItem && input.NestedItem == nil {
+		return fmt.Errorf("a Nested Object Definition must be specified for a %q type but didn't get one", string(input.Type))
 	}
-
-	switch input {
-	case models.CustomFieldTypeEdgeZone:
-		return nilableType("CustomTypes.EdgeZone")
-
-	case models.CustomFieldTypeLocation:
-		return nilableType("CustomTypes.Location")
-
-	case models.CustomFieldTypeTags:
-		return nilableType("CustomTypes.Tags")
-
-	case models.CustomFieldTypeSystemAssignedIdentity:
-		return nilableType("CustomTypes.SystemAssignedIdentity")
-
-	case models.CustomFieldTypeSystemAndUserAssignedIdentityList:
-		return nilableType("CustomTypes.SystemAndUserAssignedIdentityList")
-
-	case models.CustomFieldTypeSystemAndUserAssignedIdentityMap:
-		return nilableType("CustomTypes.SystemAndUserAssignedIdentityMap")
-
-	case models.CustomFieldTypeLegacySystemAndUserAssignedIdentityList:
-		return nilableType("CustomTypes.LegacySystemAndUserAssignedIdentityList")
-
-	case models.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap:
-		return nilableType("CustomTypes.LegacySystemAndUserAssignedIdentityMap")
-
-	case models.CustomFieldTypeSystemOrUserAssignedIdentityList:
-		return nilableType("CustomTypes.SystemOrUserAssignedIdentityList")
-
-	case models.CustomFieldTypeSystemOrUserAssignedIdentityMap:
-		return nilableType("CustomTypes.SystemOrUserAssignedIdentityMap")
-
-	case models.CustomFieldTypeUserAssignedIdentityList:
-		return nilableType("CustomTypes.UserAssignedIdentityList")
-
-	case models.CustomFieldTypeUserAssignedIdentityMap:
-		return nilableType("CustomTypes.UserAssignedIdentityMap")
-
-	case models.CustomFieldTypeSystemData:
-		return nilableType("CustomTypes.SystemData")
-
-	case models.CustomFieldTypeZone:
-		return nilableType("CustomTypes.Zone")
-
-	case models.CustomFieldTypeZones:
-		return nilableType("CustomTypes.Zones")
+	if !requiresNestedItem && input.NestedItem != nil {
+		return fmt.Errorf("a Nested Object Definition must not be specified for a %q type but got %q", string(input.Type), string(input.NestedItem.Type))
 	}
-
-	return nil, fmt.Errorf("unmapped Custom Type %q", string(input))
-}
-
-func typeNameForObjectDefinition(input *models.ObjectDefinition, constants map[string]resourcemanager.ConstantDetails, knownModels map[string]models.ModelDetails) (*string, error) {
-	if input == nil {
-		return nil, fmt.Errorf("missing object definition")
-	}
-
-	var nilableValue = func(in string) (*string, error) {
-		return &in, nil
-	}
-
-	switch input.Type {
-	case models.ObjectDefinitionCsv:
-		{
-			if input.ReferenceName != nil {
-				if _, isConstant := constants[*input.ReferenceName]; isConstant {
-					return nilableValue(fmt.Sprintf("Csv%sConstant", *input.ReferenceName))
-				}
-				if _, isModel := knownModels[*input.ReferenceName]; isModel {
-					return nilableValue(fmt.Sprintf("Csv%sModel", *input.ReferenceName))
-				}
-
-				return nil, fmt.Errorf("reference %q was not found as a constant or a model", *input.ReferenceName)
-			}
-
-			if input.NestedItem == nil {
-				return nil, fmt.Errorf("a Csv must have a reference or a nested item but got neither")
-			}
-
-			innerType, err := typeNameForObjectDefinition(input.NestedItem, constants, knownModels)
-			if err != nil {
-				return nil, fmt.Errorf("determining inner type for object definition: %+v", err)
-			}
-			return nilableValue(fmt.Sprintf("Csv%s", *innerType))
+	if requiresReference {
+		if input.ReferenceName == nil {
+			return fmt.Errorf("a Reference must be specified for a %q type but didn't get one", string(input.Type))
 		}
 
-	case models.ObjectDefinitionDictionary:
-		{
-			if input.ReferenceName != nil {
-				if _, isConstant := constants[*input.ReferenceName]; isConstant {
-					return nilableValue(fmt.Sprintf("Dictionary<string, %sConstant>", *input.ReferenceName))
-				}
-				if _, isModel := knownModels[*input.ReferenceName]; isModel {
-					return nilableValue(fmt.Sprintf("Dictionary<string, %sModel>", *input.ReferenceName))
-				}
-
-				return nil, fmt.Errorf("reference %q was not found as a constant or a model", *input.ReferenceName)
-			}
-
-			if input.NestedItem == nil {
-				return nil, fmt.Errorf("a dictionary must have a reference or a nested item but got neither")
-			}
-
-			innerType, err := typeNameForObjectDefinition(input.NestedItem, constants, knownModels)
-			if err != nil {
-				return nil, fmt.Errorf("determining inner type for object definition: %+v", err)
-			}
-			return nilableValue(fmt.Sprintf("Dictionary<string, %s>", *innerType))
+		_, isConstant := constants[*input.ReferenceName]
+		_, isModel := models[*input.ReferenceName]
+		if !isConstant && !isModel {
+			return fmt.Errorf("reference %q was not found as a constant or a model", *input.ReferenceName)
 		}
-
-	case models.ObjectDefinitionList:
-		{
-			if input.ReferenceName != nil {
-				if _, isConstant := constants[*input.ReferenceName]; isConstant {
-					return nilableValue(fmt.Sprintf("List<%sConstant>", *input.ReferenceName))
-				}
-				if _, isModel := knownModels[*input.ReferenceName]; isModel {
-					return nilableValue(fmt.Sprintf("List<%sModel>", *input.ReferenceName))
-				}
-
-				return nil, fmt.Errorf("reference %q was not found as a constant or a model", *input.ReferenceName)
-			}
-
-			if input.NestedItem == nil {
-				return nil, fmt.Errorf("a list item must have a reference or a nested item but got neither")
-			}
-
-			innerType, err := typeNameForObjectDefinition(input.NestedItem, constants, knownModels)
-			if err != nil {
-				return nil, fmt.Errorf("determining inner type for object definition: %+v", err)
-			}
-			return nilableValue(fmt.Sprintf("List<%s>", *innerType))
+		if isConstant && isModel {
+			return fmt.Errorf("internal-error: %q was found as BOTH a Constant and a Model")
 		}
-
-	case models.ObjectDefinitionReference:
-		{
-			if input.ReferenceName == nil {
-				return nil, fmt.Errorf("a reference must have a reference name but didn't get one")
-			}
-
-			// is this a constant or a model
-			if _, isConstant := constants[*input.ReferenceName]; isConstant {
-				val := fmt.Sprintf("%s", *input.ReferenceName)
-				return &val, nil
-			}
-			if _, isModel := knownModels[*input.ReferenceName]; isModel {
-				val := fmt.Sprintf("%s", *input.ReferenceName)
-				return &val, nil
-			}
-
-			return nil, fmt.Errorf("the Reference %q wasn't found as a Constant or a Model", *input.ReferenceName)
-		}
-
-	case models.ObjectDefinitionBoolean:
-		return nilableValue("bool")
-
-	case models.ObjectDefinitionDateTime:
-		return nilableValue("DateTime")
-
-	case models.ObjectDefinitionFloat:
-		return nilableValue("float")
-
-	case models.ObjectDefinitionInteger:
-		return nilableValue("int")
-
-	// this is using RawFile and not `byte[]` since byte streams are also possible but aren't files
-	case models.ObjectDefinitionRawFile:
-		return nilableValue("CustomTypes.RawFile")
-
-	case models.ObjectDefinitionRawObject:
-		return nilableValue("object")
-
-	case models.ObjectDefinitionString:
-		return nilableValue("string")
+	}
+	if !requiresReference && input.ReferenceName != nil {
+		return fmt.Errorf("a Reference must not be specified for a %q type but got %q", string(input.Type), *input.ReferenceName)
 	}
 
-	return nil, fmt.Errorf("unmapped object definition value: %+v", *input)
-}
-
-// topLevelObjectDefinition returns the top level object definition, that is a Constant or Model (or simple type) directly
-func topLevelObjectDefinition(input models.ObjectDefinition) models.ObjectDefinition {
-	if input.NestedItem != nil {
-		return topLevelObjectDefinition(*input.NestedItem)
-	}
-
-	return input
+	return nil
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_models.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_models.go
@@ -229,7 +229,7 @@ func validateObjectDefinition(input dataApiModels.ObjectDefinition, constants ma
 			return fmt.Errorf("reference %q was not found as a constant or a model", *input.ReferenceName)
 		}
 		if isConstant && isModel {
-			return fmt.Errorf("internal-error: %q was found as BOTH a Constant and a Model")
+			return fmt.Errorf("internal-error: %q was found as BOTH a Constant and a Model", *input.ReferenceName)
 		}
 	}
 	if !requiresReference && input.ReferenceName != nil {

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -24,6 +24,13 @@ type Operation struct {
 	UriSuffix                        string           `json:"UriSuffix,omitempty"`
 }
 
+type ObjectDefinition struct {
+	// TODO: update to use the existing `ObjectDefinition` in models
+	Type          ObjectDefinitionType `json:"Type"`
+	ReferenceName *string              `json:"ReferenceName,omitempty"`
+	NestedItem    *ObjectDefinition    `json:"ObjectDefinition,omitempty"`
+}
+
 type OptionsObject struct {
 	Name    string   `json:"Name"`
 	Options []Option `json:"Options"`

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -70,10 +70,11 @@ func codeForOperation(operationName string, operation models.OperationDetails, r
 		longRunning = true
 	}
 
+	// TODO: refactor this to use the ObjectDefinition in `./models`
 	requestObject := ObjectDefinition{}
 	if operation.RequestObject != nil {
 		requestObject.ReferenceName = operation.RequestObject.ReferenceName
-		requestObject.Type = ObjectDefinitionType(operation.ResponseObject.Type)
+		requestObject.Type = ObjectDefinitionType(operation.RequestObject.Type)
 
 	} else if strings.EqualFold(operation.Method, "POST") || strings.EqualFold(operation.Method, "PUT") {
 		// Post and Put operations should have one but it's possible they don't

--- a/tools/importer-rest-api-specs/main.go
+++ b/tools/importer-rest-api-specs/main.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	outputDirectoryCS        = "../../data/"
-	outputDirectoryJson      = "../../api-definitions/"
+	outputDirectoryJson      = "../../api-definitions/resource-manager"
 	swaggerDirectory         = "../../submodules/rest-api-specs"
 	resourceManagerConfig    = "../../config/resource-manager.hcl"
 	terraformDefinitionsPath = "../../config/resources/"

--- a/tools/importer-rest-api-specs/pipeline/run_importer.go
+++ b/tools/importer-rest-api-specs/pipeline/run_importer.go
@@ -48,7 +48,7 @@ func runImporter(input RunInput, generationData []discovery.ServiceInput, swagge
 		}
 
 		if featureflags.GenerateV2APIDefinitions {
-			serviceDirectoryYaml := fmt.Sprintf("%s%s/%s", input.OutputDirectoryJson, "resource-manager", serviceName)
+			serviceDirectoryYaml := fmt.Sprintf("%s/%s", input.OutputDirectoryJson, serviceName)
 			logger.Debug("recreating JSON directory %q for Service %q", serviceDirectoryYaml, serviceName)
 			if err := dataapigenerator.RecreateDirectory(serviceDirectoryYaml, logger); err != nil {
 				fmt.Errorf("recreating JSON directory %q for service %q", serviceDirectoryYaml, serviceName)

--- a/tools/importer-rest-api-specs/pipeline/run_importer.go
+++ b/tools/importer-rest-api-specs/pipeline/run_importer.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"fmt"
+	"path"
 	"sort"
 
 	"github.com/hashicorp/go-hclog"
@@ -40,18 +41,18 @@ func runImporter(input RunInput, generationData []discovery.ServiceInput, swagge
 		logger := input.Logger.Named(fmt.Sprintf("Importer for Service %q", serviceName))
 
 		if featureflags.GenerateV1APIDefinitions {
-			serviceDirectoryCSharp := fmt.Sprintf("%s%s/%s", input.OutputDirectoryCS, "Pandora.Definitions.ResourceManager", serviceName)
-			logger.Debug("recreating C# directory %q for Service %q", serviceDirectoryCSharp, serviceName)
-			if err := dataapigenerator.RecreateDirectory(serviceDirectoryCSharp, logger); err != nil {
-				fmt.Errorf("recreating C# directory %q for service %q", serviceDirectoryCSharp, serviceName)
+			serviceDirectoryV1 := fmt.Sprintf("%s%s/%s", input.OutputDirectoryCS, "Pandora.Definitions.ResourceManager", serviceName)
+			logger.Debug("recreating the V1 working directory at %q for Service %q", serviceDirectoryV1, serviceName)
+			if err := dataapigenerator.RecreateDirectory(serviceDirectoryV1, logger); err != nil {
+				fmt.Errorf("recreating C# directory %q for service %q", serviceDirectoryV1, serviceName)
 			}
 		}
 
 		if featureflags.GenerateV2APIDefinitions {
-			serviceDirectoryYaml := fmt.Sprintf("%s/%s", input.OutputDirectoryJson, serviceName)
-			logger.Debug("recreating JSON directory %q for Service %q", serviceDirectoryYaml, serviceName)
-			if err := dataapigenerator.RecreateDirectory(serviceDirectoryYaml, logger); err != nil {
-				fmt.Errorf("recreating JSON directory %q for service %q", serviceDirectoryYaml, serviceName)
+			serviceDirectoryV2 := path.Join(input.OutputDirectoryJson, serviceName)
+			logger.Debug("recreating the V2 working directory at %q for Service %q", serviceDirectoryV2, serviceName)
+			if err := dataapigenerator.RecreateDirectory(serviceDirectoryV2, logger); err != nil {
+				fmt.Errorf("recreating JSON directory %q for service %q", serviceDirectoryV2, serviceName)
 			}
 		}
 

--- a/tools/importer-rest-api-specs/pipeline/task_generate_data_api_definitions_v2.go
+++ b/tools/importer-rest-api-specs/pipeline/task_generate_data_api_definitions_v2.go
@@ -14,6 +14,8 @@ func (pipelineTask) generateApiDefinitionsV2(serviceName string, apiVersions []m
 		return nil
 	}
 
+	// TODO: we should recreate the folder for this service
+
 	// Generate each of the API Versions for this Service
 	for _, apiVersion := range apiVersions {
 		logger.Debug("Generating Data API Definition in JSON..")


### PR DESCRIPTION
This PR refactors the V2 API Definitions for Models/Fields/Object Definitions - such that:

* Updates the structs for Models, Field (now `ModelField`, to differentiate it from a Terraform Schema Field) and ObjectDefinition to fix issues outlined in https://github.com/hashicorp/pandora/pull/3185 (and spotted whilst passing through0
* A working directory is assumed to exist at `./api-definitions` - as such `importer-rest-api-specs` can rely on this existing and generate a `resource-manager` directory within it.
* Removes the `namespace` fields used within V2 of the API Definitions (since this is specific to V1)

---

There's one change to V2 of the API Definitions which doesn't exist in V1 worth mentioning, which is that the fields `MaxItems`, `MinItems` and `DateFormat` are now housed within the ObjectDefinition and not against the field. Neither `MaxItems`, `MinItems` (or the other, unmapped field, `UniqueItems`) are currently used in the Go SDK - these exist purely for the Terraform generation functionality to determine how to build up the Schema in the case of a Csv/Dictionary/List.

As such when we come to expose this in Data API V2, when parsing the data we'll need to account for this in the short-term (so that we can keep this working in the current schema/structure being returned from the API) and then (in the future) output this within the `ObjectDefinition` types so that we can migrate this across. It'd be worth adding an issue for that, but I figured it'd be worth calling that out here first.