### PR TITLE
tools/importer-rest-api-specs: updating the v2 models to use camelCase

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/constants.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/constants.go
@@ -42,14 +42,14 @@ type ConstantValue struct {
 	// an identifier.
 	//
 	// Example: `StandardA1`.
-	Key string `json:"Key"`
+	Key string `json:"key"`
 
 	// Value specifies the literal value for this Constant as defined in API.
 	//
 	// Example: `Standard_A1`.
-	Value string `json:"Value"`
+	Value string `json:"value"`
 
 	// Description is an optional description for this constant value - providing
 	// further context as required.
-	Description *string `json:"Description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/metadata.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/metadata.go
@@ -1,0 +1,13 @@
+package models
+
+// MetaData contains Meta Data about this
+type MetaData struct {
+	// TODO: the license information could make sense to go in here, since all items within a
+	// directory should be under the same license
+
+	// GitRevision specified the Git Revision (SHA) of the Repository
+	// where this data has been sourced from.
+	// This is either going to be the SHA of the `Azure/azure-rest-api-specs` repository (for ARM),
+	// the `microsoftgraph/msgraph-metadata` repository (for MS Graph) - or null (for handwritten).
+	GitRevision *string `json:"gitRevision"`
+}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/revision_id.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/revision_id.go
@@ -3,9 +3,9 @@ package dataapigeneratorjson
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"path"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	dataApiModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigeneratorjson/models"
 )
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/revision_id.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/revision_id.go
@@ -3,20 +3,23 @@ package dataapigeneratorjson
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"path"
+
+	dataApiModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigeneratorjson/models"
 )
 
 func OutputMetaData(workingDirectory, swaggerGitSha string) error {
-	revision := map[string]string{
-		"SwaggerRevision": swaggerGitSha,
+	metaData := dataApiModels.MetaData{
+		GitRevision: pointer.To(swaggerGitSha),
 	}
 
-	data, err := json.MarshalIndent(&revision, "", `	`)
+	data, err := json.MarshalIndent(&metaData, "", "\t")
 	if err != nil {
 		return err
 	}
 
-	revisionIdFileName := path.Join(workingDirectory, "SwaggerRevision.json") // TODO: rename to metadata.json
+	revisionIdFileName := path.Join(workingDirectory, "metadata.json")
 	if err := writeJsonToFile(revisionIdFileName, data); err != nil {
 		return fmt.Errorf("writing Swagger Revision ID for %q: %+v", revisionIdFileName, err)
 	}


### PR DESCRIPTION
Given the conventions in JSON, we should conform to this - the side-effect is this gives us an easy tell for models which have been reviewed/refactored verses those which haven't.

This PR also splits out a struct for `MetaData`, since we'll want to reuse this for both ARM, MS Graph and handwritten data - and honestly could make sense for us to serve from the Data API (for example, allowing the new differ tool to output a `compare` link, to show differences in the source data) - so splitting this out into a dedicated struct seems worthwhile.