### PR TITLE
tools/importer-rest-api-specs: updating the `metadata` file to include the SourceData and SourceInformation

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/api_version_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/api_version_definition.go
@@ -12,9 +12,6 @@ type ApiVersionDefinition struct {
 	// Generate specifies whether this API Version should be generated or not.
 	Generate bool `json:"generate"`
 
-	// Source specifies where the source data for this API version came from.
-	Source ApiDefinitionsSource `json:"source"` // TODO: move this into the MetaData file?
-
 	// Resources specifies a list of Api Resource names that exist within this API version.
 	Resources []string `json:"resources"`
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/metadata.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/metadata.go
@@ -2,8 +2,14 @@ package models
 
 // MetaData contains Meta Data about this
 type MetaData struct {
-	// TODO: the license information could make sense to go in here, since all items within a
-	// directory should be under the same license
+	// DataSource specifies the type of Data that this Source is related to
+	// for example `AzureResourceManager`. This allows multiple directories
+	// to be used to populate the same Data Source (for example, auto-generated
+	// and handwritten) and then coalesced together.
+	DataSource DataSource `json:"dataSource"`
+
+	// SourceInformation specifies where the data within this directory was sourced.
+	SourceInformation ApiDefinitionsSource `json:"sourceInformation"`
 
 	// GitRevision specified the Git Revision (SHA) of the Repository
 	// where this data has been sourced from.
@@ -11,6 +17,16 @@ type MetaData struct {
 	// the `microsoftgraph/msgraph-metadata` repository (for MS Graph) - or null (for handwritten).
 	GitRevision *string `json:"gitRevision"`
 }
+
+type DataSource string
+
+const (
+	// AzureResourceManagerDataSource specifies that this Data is related to Azure Resource Manager.
+	AzureResourceManagerDataSource DataSource = "AzureResourceManager"
+
+	// MicrosoftGraphDataSource specifies that this Data is for Microsoft Graph.
+	MicrosoftGraphDataSource DataSource = "MicrosoftGraph"
+)
 
 type ApiDefinitionsSource string
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/revision_id.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/revision_id.go
@@ -11,7 +11,9 @@ import (
 
 func OutputMetaData(workingDirectory, swaggerGitSha string) error {
 	metaData := dataApiModels.MetaData{
-		GitRevision: pointer.To(swaggerGitSha),
+		DataSource:        dataApiModels.AzureResourceManagerDataSource,
+		SourceInformation: dataApiModels.AzureRestApiSpecsRepositoryApiDefinitionsSource,
+		GitRevision:       pointer.To(swaggerGitSha),
 	}
 
 	data, err := json.MarshalIndent(&metaData, "", "\t")

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_api_version_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_api_version_definition.go
@@ -11,7 +11,6 @@ func buildApiVersionDefinition(apiVersion string, isPreview bool, resources map[
 	versionDefinition := dataApiModels.ApiVersionDefinition{
 		ApiVersion: apiVersion,
 		IsPreview:  isPreview,
-		Source:     dataApiModels.AzureRestApiSpecsRepositoryApiDefinitionsSource,
 		Generate:   true,
 	}
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_models.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_models.go
@@ -25,6 +25,7 @@ func codeForModel(modelName string, model importerModels.ModelDetails, parentMod
 	}
 
 	dataApiModel := dataApiModels.Model{
+		Name:   modelName,
 		Fields: *fields,
 	}
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -13,18 +13,10 @@ import (
 )
 
 func codeForOperation(operationName string, input importerModels.OperationDetails, knownConstants map[string]resourcemanager.ConstantDetails, knownModels map[string]importerModels.ModelDetails) ([]byte, error) {
-	statusCodes := make([]int, 0)
-	if usesNonDefaultStatusCodes(input) {
-		for _, sc := range input.ExpectedStatusCodes {
-			statusCodes = append(statusCodes, sc)
-		}
-		sort.Ints(statusCodes)
-	}
-
 	output := dataApiModels.Operation{
 		Name:                             operationName,
 		ContentType:                      input.ContentType,
-		ExpectedStatusCodes:              statusCodes,
+		ExpectedStatusCodes:              input.ExpectedStatusCodes,
 		FieldContainingPaginationDetails: input.FieldContainingPaginationDetails,
 		LongRunning:                      input.LongRunning,
 		HTTPMethod:                       strings.ToUpper(input.Method),
@@ -91,36 +83,6 @@ func codeForOperation(operationName string, input importerModels.OperationDetail
 	}
 
 	return data, nil
-}
-
-func usesNonDefaultStatusCodes(operation importerModels.OperationDetails) bool {
-	defaultStatusCodes := map[string][]int{
-		"get":    {200},
-		"post":   {200, 201},
-		"put":    {200, 201},
-		"delete": {200, 201},
-		"patch":  {200, 201},
-	}
-	expected, ok := defaultStatusCodes[strings.ToLower(operation.Method)]
-	if !ok {
-		// potentially an unsupported use-case but fine for now
-		return true
-	}
-
-	if len(expected) != len(operation.ExpectedStatusCodes) {
-		return true
-	}
-
-	sort.Ints(expected)
-	sort.Ints(operation.ExpectedStatusCodes)
-	for i, ev := range expected {
-		av := operation.ExpectedStatusCodes[i]
-		if ev != av {
-			return true
-		}
-	}
-
-	return false
 }
 
 var internalObjectDefinitionsToOptionObjectDefinitionTypes = map[importerModels.ObjectDefinitionType]dataApiModels.OptionObjectDefinitionType{

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -42,16 +42,6 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 		uriSuffix = *operation.UriSuffix
 	}
 
-	responseObject, err := mapObjectDefinition(operation.ResponseObject, knownConstants, knownModels)
-	if err != nil {
-		return nil, fmt.Errorf("mapping the object definition: %+v", err)
-	}
-
-	requestObject, err := mapObjectDefinition(operation.RequestObject, knownConstants, knownModels)
-	if err != nil {
-		return nil, fmt.Errorf("mapping the object definition: %+v", err)
-	}
-
 	op := dataApiModels.Operation{
 		Name:                             operationName,
 		ContentType:                      contentType,
@@ -60,9 +50,22 @@ func codeForOperation(operationName string, operation importerModels.OperationDe
 		LongRunning:                      longRunning,
 		HTTPMethod:                       strings.ToUpper(operation.Method),
 		ResourceIdName:                   pointer.To(resourceId),
-		RequestObject:                    responseObject,
-		ResponseObject:                   requestObject,
 		UriSuffix:                        pointer.To(uriSuffix),
+	}
+
+	if operation.RequestObject != nil {
+		requestObject, err := mapObjectDefinition(operation.RequestObject, knownConstants, knownModels)
+		if err != nil {
+			return nil, fmt.Errorf("mapping the request object definition: %+v", err)
+		}
+		op.RequestObject = requestObject
+	}
+	if operation.ResponseObject != nil {
+		responseObject, err := mapObjectDefinition(operation.ResponseObject, knownConstants, knownModels)
+		if err != nil {
+			return nil, fmt.Errorf("mapping the response object definition: %+v", err)
+		}
+		op.ResponseObject = responseObject
 	}
 
 	if len(operation.Options) > 0 {

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_resource_id.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_resource_id.go
@@ -83,9 +83,6 @@ func mapResourceIdSegment(input resourcemanager.ResourceIdSegment) (*dataApiMode
 	}
 
 	if input.Type == resourcemanager.SubscriptionIdSegment {
-		if input.FixedValue == nil {
-			return nil, fmt.Errorf("static segment type with missing fixed value: %+v", input)
-		}
 		return &dataApiModels.ResourceIdSegment{
 			Type: dataApiModels.SubscriptionIdResourceIdSegmentType,
 			Name: input.Name,


### PR DESCRIPTION
This PR adds the fields `SourceData` and `SourceInformation` to the `metadata` file, allowing for multiple data sources (i.e. directories, `resource-manager` for generated and `handwritten-resource-manager` for handwritten) to provide Data for a single Service (e.g. AzureResourceManager/MicrosoftGraph) - so that the Data API can be configured to load this.

This also fixes a couple of other bugs spotted when generating the full data set:

* Operations - `ContentType` and `ExpectedStatusCodes` must always be output (the Go SDK generator assumes both are returned from the Data API, and these default values previously came from the base types in C#)
* Operations - `ResourceIdName` and `UriSuffix` are now pointers rather than empty strings, both generators rely on these being nil when omitted (since both can be specified together or individually)
* Models - outputting the `Name` field