### PR TITLE
config: add network 2022-07-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -361,7 +361,7 @@ service "netapp" {
 }
 service "network" {
   name      = "Network"
-  available = ["2023-04-01", "2023-05-01", "2023-06-01"]
+  available = ["2022-07-01", "2023-04-01", "2023-05-01", "2023-06-01"]
 }
 service "networkcloud" {
   name      = "NetworkCloud"


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-azurerm/pull/23398, directly upgrading to new API version may have some breaking changes, can we first migrate SDK only?

---

**Appilication Gateway resource API change from 2022-07-01 to 2023-02-01 or higher version:**

From the [doc](https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview#default-tls-policy), the 2023-02-01 or later version of the application gateway has defaultPredefinedSslPolicy:[AppGwSslPolicy20220101](https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview#predefined-tls-policy), so in config if the ssl_profile.ssl_policy.policy_name is not configured as AppGwSslPolicy20220101, ssl_policy block is required to be specified to avoid conflict.

This API policy conflict is also present in current API version 2022-09-01 wich has the predefined policy [AppGwSslPolicy20150501](https://learn.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview#predefined-tls-policy) as default.