### PR TITLE
tools/importer-rest-api-specs: sorting the `expectedStatusCodes` property to remove eventual consistency issues

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -13,10 +13,12 @@ import (
 )
 
 func codeForOperation(operationName string, input importerModels.OperationDetails, knownConstants map[string]resourcemanager.ConstantDetails, knownModels map[string]importerModels.ModelDetails) ([]byte, error) {
+	expectedStatusCodes := input.ExpectedStatusCodes
+	sort.Ints(expectedStatusCodes)
 	output := dataApiModels.Operation{
 		Name:                             operationName,
 		ContentType:                      input.ContentType,
-		ExpectedStatusCodes:              input.ExpectedStatusCodes,
+		ExpectedStatusCodes:              expectedStatusCodes,
 		FieldContainingPaginationDetails: input.FieldContainingPaginationDetails,
 		LongRunning:                      input.LongRunning,
 		HTTPMethod:                       strings.ToUpper(input.Method),


### PR DESCRIPTION
See #3279 as to why, but example changes from this PR:


```diff
diff --git a/api-definitions/resource-manager/Workloads/2023-04-01/Monitors/Operation-Delete.json b/api-definitions/resource-manager/Workloads/2023-04-01/Monitors/Operation-Delete.json
index 3991fb0ac5..5231d803ae 100644
--- a/api-definitions/resource-manager/Workloads/2023-04-01/Monitors/Operation-Delete.json
+++ b/api-definitions/resource-manager/Workloads/2023-04-01/Monitors/Operation-Delete.json
@@ -2,9 +2,9 @@
  "name": "Delete",
  "contentType": "application/json",
  "expectedStatusCodes": [
-  204,
   200,
-  202
+  202,
+  204
  ],
  "longRunning": true,
  "httpMethod": "DELETE",
diff --git a/api-definitions/resource-manager/Workloads/2023-04-01/ProviderInstances/Operation-Delete.json b/api-definitions/resource-manager/Workloads/2023-04-01/ProviderInstances/Operation-Delete.json
index 09d50f351f..f51bcf7983 100644
--- a/api-definitions/resource-manager/Workloads/2023-04-01/ProviderInstances/Operation-Delete.json
+++ b/api-definitions/resource-manager/Workloads/2023-04-01/ProviderInstances/Operation-Delete.json
@@ -2,9 +2,9 @@
  "name": "Delete",
  "contentType": "application/json",
  "expectedStatusCodes": [
-  204,
   200,
-  202
+  202,
+  204
  ],
  "longRunning": true,
  "httpMethod": "DELETE",
```