### PR TITLE
tools/importer-rest-api-specs: New Common IDs for SQL

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_database.go
@@ -1,0 +1,30 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdSqlDatabase{}
+
+type commonIdSqlDatabase struct{}
+
+func (c commonIdSqlDatabase) id() models.ParsedResourceId {
+	name := "SqlDatabase"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			models.StaticResourceIDSegment("servers", "servers"),
+			models.UserSpecifiedResourceIDSegment("serverName"),
+			models.StaticResourceIDSegment("databases", "databases"),
+			models.UserSpecifiedResourceIDSegment("databaseName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_elastic_pool.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_elastic_pool.go
@@ -1,0 +1,30 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdSqlElasticPool{}
+
+type commonIdSqlElasticPool struct{}
+
+func (c commonIdSqlElasticPool) id() models.ParsedResourceId {
+	name := "SqlElasticPool"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			models.StaticResourceIDSegment("servers", "servers"),
+			models.UserSpecifiedResourceIDSegment("serverName"),
+			models.StaticResourceIDSegment("elasticPools", "elasticPools"),
+			models.UserSpecifiedResourceIDSegment("elasticPoolName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdSqlManagedInstance{}
+
+type commonIdSqlManagedInstance struct{}
+
+func (c commonIdSqlManagedInstance) id() models.ParsedResourceId {
+	name := "SqlManagedInstance"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			models.StaticResourceIDSegment("managedInstances", "managedInstances"),
+			models.UserSpecifiedResourceIDSegment("managedInstanceName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance_database.go
@@ -1,0 +1,30 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdSqlManagedInstanceDatabase{}
+
+type commonIdSqlManagedInstanceDatabase struct{}
+
+func (c commonIdSqlManagedInstanceDatabase) id() models.ParsedResourceId {
+	name := "SqlManagedInstanceDatabase"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			models.StaticResourceIDSegment("managedInstances", "managedInstances"),
+			models.UserSpecifiedResourceIDSegment("managedInstanceName"),
+			models.StaticResourceIDSegment("databases", "databases"),
+			models.UserSpecifiedResourceIDSegment("databaseName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_server.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_server.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdSqlServer{}
+
+type commonIdSqlServer struct{}
+
+func (c commonIdSqlServer) id() models.ParsedResourceId {
+	name := "SqlServer"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			models.StaticResourceIDSegment("servers", "servers"),
+			models.UserSpecifiedResourceIDSegment("serverName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -55,6 +55,13 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdKeyVaultKeyVersion{},
 	commonIdKeyVaultPrivateEndpointConnection{},
 
+	// SQL
+	commonIdSqlDatabase{},
+	commonIdSqlElasticPool{},
+	commonIdSqlManagedInstance{},
+	commonIdSqlManagedInstanceDatabase{},
+	commonIdSqlServer{},
+
 	// Storage
 	commonIdStorageAccount{},
 	commonIdStorageContainer{},


### PR DESCRIPTION
Adds SqlDatabase, SqlElasticPool, SqlManagedInstanceDatabase, SqlManagedInstance and SqlServer

Dependent on https://github.com/hashicorp/go-azure-helpers/pull/193