### PR TITLE
Github: Adding a Run button

### DIFF
--- a/.github/workflows/automation-msgraph-metadata-importer.yaml
+++ b/.github/workflows/automation-msgraph-metadata-importer.yaml
@@ -9,6 +9,7 @@ on:
       - 'config/microsoft-graph.hcl'
       - 'submodules/msgraph-metadata'
       - 'tools/importer-msgraph/**'
+   workflow_dispatch: # for manual invocations
 
 
 concurrency:

--- a/.github/workflows/automation-regenerate-go-sdk.yaml
+++ b/.github/workflows/automation-regenerate-go-sdk.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'data/**'
       - 'tools/generator-go-sdk/**'
+    workflow_dispatch: # for manual invocations
 
 concurrency:
   group: 'regengosdk-${{ github.head_ref }}'

--- a/.github/workflows/automation-regenerate-terraform.yaml
+++ b/.github/workflows/automation-regenerate-terraform.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'data/**'
       - 'tools/generator-terraform/**'
+    workflow_dispatch: # for manual invocations
 
 concurrency:
   group: 'regenterraform-${{ github.head_ref }}'

--- a/.github/workflows/automation-rest-api-specs-importer.yaml
+++ b/.github/workflows/automation-rest-api-specs-importer.yaml
@@ -8,6 +8,7 @@ on:
       - 'config/**'
       - 'submodules/rest-api-specs'
       - 'tools/importer-rest-api-specs/**'
+    workflow_dispatch: # for manual invocations
 
 
 concurrency:

--- a/.github/workflows/automation-version-bumper.yaml
+++ b/.github/workflows/automation-version-bumper.yaml
@@ -9,6 +9,7 @@ on:
       - 'submodules/msgraph-metadata'
       - 'submodules/rest-api-specs'
       - 'tools/version-bumper/**'
+    workflow_dispatch: # for manual invocations
 
 jobs:
   run-version-bumper:


### PR DESCRIPTION
This allows us to force these from `main` in the event of a Github Actions outage, as I believe could be in progress (the GHA's didn't get picked up for #3288, but should have done?)