### PR TITLE
Data API V2: thread through `TypeHintIn`, `Description` and add validation around discriminators

### DIFF
--- a/tools/data-api/internal/endpoints/v1/mappings.go
+++ b/tools/data-api/internal/endpoints/v1/mappings.go
@@ -27,7 +27,6 @@ func mapSchemaFields(input map[string]repositories.FieldDetails) map[string]mode
 	for k, field := range input {
 
 		fields[k] = models.FieldDetails{
-			Default:          field.Default,
 			DateFormat:       pointer.To(models.DateFormat(pointer.From(field.DateFormat))),
 			ForceNew:         field.ForceNew,
 			IsTypeHint:       field.IsTypeHint,

--- a/tools/data-api/internal/repositories/models.go
+++ b/tools/data-api/internal/repositories/models.go
@@ -141,7 +141,6 @@ type FieldValidationDetails struct {
 }
 
 type FieldDetails struct {
-	Default          *interface{}
 	DateFormat       *DateFormat
 	ForceNew         bool
 	IsTypeHint       bool

--- a/tools/data-api/internal/repositories/models/models.go
+++ b/tools/data-api/internal/repositories/models/models.go
@@ -15,8 +15,11 @@ type Model struct {
 	// DiscriminatedParentModelName contains the name of the Parent Model that this Model would implement
 	DiscriminatedParentModelName *string `json:"discriminatedParentModelName,omitempty"`
 
-	// TODO DiscriminatedTypeValue - what's this
+	// DiscriminatedTypeValue contains the name of the model that implements a discriminated type
 	DiscriminatedTypeValue *string `json:"discriminatedTypeValue,omitempty"`
+
+	// TypeHintIn specifies the field which gives the type hint for the model that implements a discriminated type
+	TypeHintIn *string `json:"typeHintIn,omitempty"`
 }
 
 // ModelField describes the fields within a Model
@@ -43,4 +46,7 @@ type ModelField struct {
 	// Required specifies that this field is Required - since a field can either be
 	// Required or Optional, but not both.
 	Required bool `json:"required"`
+
+	// Description contains the description for this field
+	Description string `json:"description"`
 }

--- a/tools/data-api/internal/repositories/models/models.go
+++ b/tools/data-api/internal/repositories/models/models.go
@@ -18,7 +18,8 @@ type Model struct {
 	// DiscriminatedTypeValue contains the name of the model that implements a discriminated type
 	DiscriminatedTypeValue *string `json:"discriminatedTypeValue,omitempty"`
 
-	// TypeHintIn specifies the field which gives the type hint for the model that implements a discriminated type
+	// TypeHintIn specifies the field which contains the type hint for the model that implements
+	// a discriminated type
 	TypeHintIn *string `json:"typeHintIn,omitempty"`
 }
 

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -346,8 +346,6 @@ func parseModelFromFilePath(filePath string) (*ModelDetails, error) {
 			Optional:    field.Optional,
 			Required:    field.Required,
 			Description: field.Description,
-			// TODO this field is still missing - where is this information taken from?
-			//ForceNew:         false,
 		}
 
 		objectDefinition, err := mapObjectDefinition(&field.ObjectDefinition)

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -773,7 +773,7 @@ func parseResourceIdFromFilePath(filePath string, constants map[string]ConstantD
 		case ResourceGroupResourceIdSegmentType:
 			s.ExampleValue = "example-resource-group"
 		case ResourceProviderResourceIdSegmentType:
-			continue
+			s.ExampleValue = pointer.From(segment.Value)
 		case ScopeResourceIdSegmentType:
 			s.ExampleValue = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/some-resource-group"
 		case StaticResourceIdSegmentType:

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/models.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/models.go
@@ -15,8 +15,11 @@ type Model struct {
 	// DiscriminatedParentModelName contains the name of the Parent Model that this Model would implement
 	DiscriminatedParentModelName *string `json:"discriminatedParentModelName,omitempty"`
 
-	// TODO DiscriminatedTypeValue - what's this
+	// DiscriminatedTypeValue contains the name of the model that implements a discriminated type
 	DiscriminatedTypeValue *string `json:"discriminatedTypeValue,omitempty"`
+
+	// TypeHintIn specifies the field which gives the type hint for the model that implements a discriminated type
+	TypeHintIn *string `json:"typeHintIn,omitempty"`
 }
 
 // ModelField describes the fields within a Model
@@ -43,4 +46,7 @@ type ModelField struct {
 	// Required specifies that this field is Required - since a field can either be
 	// Required or Optional, but not both.
 	Required bool `json:"required"`
+
+	// Description contains the description for this field
+	Description string `json:"description"`
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/models.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/models/models.go
@@ -18,7 +18,8 @@ type Model struct {
 	// DiscriminatedTypeValue contains the name of the model that implements a discriminated type
 	DiscriminatedTypeValue *string `json:"discriminatedTypeValue,omitempty"`
 
-	// TypeHintIn specifies the field which gives the type hint for the model that implements a discriminated type
+	// TypeHintIn specifies the field which contains the type hint for the model that implements
+	// a discriminated type
 	TypeHintIn *string `json:"typeHintIn,omitempty"`
 }
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_models.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_models.go
@@ -38,6 +38,10 @@ func codeForModel(modelName string, model importerModels.ModelDetails, parentMod
 		dataApiModel.DiscriminatedTypeValue = model.TypeHintValue
 	}
 
+	if model.TypeHintIn != nil {
+		dataApiModel.TypeHintIn = model.TypeHintIn
+	}
+
 	data, err := json.MarshalIndent(dataApiModel, "", " ")
 	if err != nil {
 		return nil, err
@@ -102,8 +106,9 @@ func mapField(fieldName string, fieldDetails importerModels.FieldDetails, isType
 		Name:                           fieldName,
 		ObjectDefinition:               *objectDefinition,
 		// TODO: support Optional being a distinct value in-time so we can have ReadOnly fields too
-		Optional: !fieldDetails.Required,
-		Required: fieldDetails.Required,
+		Optional:    !fieldDetails.Required,
+		Required:    fieldDetails.Required,
+		Description: fieldDetails.Description,
 	}, nil
 }
 


### PR DESCRIPTION
When loading and parsing the data we now just map everything from the data definitions over into the data api models 1:1, then do additional validation around discriminators when we validate object definitions etc.

This will also include various fixes to the data that's output in the data API. See individual commits.