### PR TITLE
Data API V2: set fields correctly back into model and various fixes/cleanup

### DIFF
--- a/tools/data-api/internal/endpoints/v1/schema_for_api_resource.go
+++ b/tools/data-api/internal/endpoints/v1/schema_for_api_resource.go
@@ -31,9 +31,10 @@ func (api Api) schemaForApiResource(w http.ResponseWriter, r *http.Request) {
 
 	for k, schemaModel := range resource.Schema.Models {
 		schemaModels[k] = models.ModelDetails{
-			Fields:        mapSchemaFields(schemaModel.Fields),
-			TypeHintIn:    schemaModel.TypeHintIn,
-			TypeHintValue: schemaModel.TypeHintValue,
+			Fields:         mapSchemaFields(schemaModel.Fields),
+			ParentTypeName: schemaModel.ParentTypeName,
+			TypeHintIn:     schemaModel.TypeHintIn,
+			TypeHintValue:  schemaModel.TypeHintValue,
 		}
 	}
 

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -368,6 +368,7 @@ func parseModelFromFilePath(filePath string) (*ModelDetails, error) {
 				Values: pointer.To([]interface{}{field.ObjectDefinition.MinItems, field.ObjectDefinition.MaxItems}),
 			}
 		}
+		fieldDetails[field.Name] = fieldDetail
 	}
 
 	return &ModelDetails{

--- a/tools/data-api/models/api_schema_details.go
+++ b/tools/data-api/models/api_schema_details.go
@@ -47,9 +47,6 @@ type ModelDetails struct {
 }
 
 type FieldDetails struct {
-	// Default is an optional value which should be used as the default for this field
-	Default *interface{} `json:"default"`
-
 	// DateFormat is the format which should be used for this field when Type is set to DateTime
 	DateFormat *DateFormat `json:"dateFormat"`
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -17,7 +17,7 @@ func codeForOperation(operationName string, input importerModels.OperationDetail
 	sort.Ints(expectedStatusCodes)
 	output := dataApiModels.Operation{
 		Name:                             operationName,
-		ContentType:                      input.ContentType,
+		ContentType:                      fmt.Sprintf("%s; charset=utf-8", input.ContentType),
 		ExpectedStatusCodes:              expectedStatusCodes,
 		FieldContainingPaginationDetails: input.FieldContainingPaginationDetails,
 		LongRunning:                      input.LongRunning,


### PR DESCRIPTION
The mapped fields from the data definitions weren't being set correctly.

Also exposing the `ParentTypeName` in the v1 endpoint and removed `Default` in the v1 endpoint since this is not used.