### PR TITLE
config: removing older versions of `redisenterprise`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -450,7 +450,7 @@ service "redis" {
 }
 service "redisenterprise" {
   name      = "RedisEnterprise"
-  available = ["2022-01-01", "2023-07-01", "2023-10-01-preview", "2023-11-01"]
+  available = ["2023-11-01"]
 }
 service "relay" {
   name      = "Relay"


### PR DESCRIPTION
These are no longer needed as of https://github.com/hashicorp/terraform-provider-azurerm/pull/23865