### PR TITLE
config: adding AlertsManagement @ `2019-05-05-preview` and `2019-06-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -8,7 +8,7 @@ service "advisor" {
 }
 service "alertsmanagement" {
   name      = "AlertsManagement"
-  available = ["2021-08-08", "2023-03-01"]
+  available = ["2019-05-05-preview", "2019-06-01", "2021-08-08", "2023-03-01"]
 }
 service "analysisservices" {
   name      = "AnalysisServices"


### PR DESCRIPTION
These are used [here](https://github.com/hashicorp/terraform-provider-azurerm/tree/bf4b436d9bd36ee253c4947f4812846528a47345/vendor/github.com/Azure/azure-sdk-for-go/services/preview/alertsmanagement/mgmt/2019-06-01-preview/alertsmanagement).