### PR TITLE
`tools/importer-rest-api-specs`: normalizing `runAsAccount` to remove an eventual consistency issue

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
+++ b/tools/importer-rest-api-specs/components/parser/cleanup/cleanup.go
@@ -178,6 +178,7 @@ func NormalizeSegment(input string, camelCase bool) string {
 		"role":                                    "role",   // handles Role
 		"routes":                                  "routes", // handles Routes
 		"rulesengines":                            "rulesEngines",
+		"runasaccounts":                           "runAsAccounts",
 		"saasresources":                           "saasResources",
 		"schemagroups":                            "schemaGroups",
 		"scripts":                                 "scripts", // handles Scripts


### PR DESCRIPTION
Fixes https://github.com/hashicorp/pandora/issues/3050