### PR TITLE
`tools/importer-rest-api-specs`: adding a workaround for Azure/azure-rest-api-specs PR 26680

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_recoveryservicessiterecovery_26680.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_recoveryservicessiterecovery_26680.go
@@ -1,0 +1,87 @@
+package dataworkarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundRecoveryServicesSiteRecovery26680{}
+
+// workaroundRecoveryServicesSiteRecovery26680 works around the model `CreateCertificateOptions` being
+// present within the API but not being documented in the API Definitions - as such this adds the missing
+// model/fields to make this useful.
+//
+// Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/26680
+type workaroundRecoveryServicesSiteRecovery26680 struct {
+}
+
+func (w workaroundRecoveryServicesSiteRecovery26680) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	if apiDefinition.ServiceName != "RecoveryServicesSiteRecovery" {
+		return false
+	}
+
+	apiVersions := map[string]struct{}{
+		"2022-10-01": {},
+		"2023-01-01": {},
+		"2023-02-01": {},
+		"2023-04-01": {},
+		"2023-06-01": {},
+	}
+	if _, apiVersionMatches := apiVersions[apiDefinition.ApiVersion]; !apiVersionMatches {
+		return false
+	}
+
+	if _, resourceExists := apiVersions["VaultCertificates"]; !resourceExists {
+		return false
+	}
+
+	return true
+}
+
+func (w workaroundRecoveryServicesSiteRecovery26680) Name() string {
+	return "RecoveryServicesSiteRecovery / 26680"
+}
+
+func (w workaroundRecoveryServicesSiteRecovery26680) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resource, ok := apiDefinition.Resources["VaultCertificates"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `VaultCertificates` but didn't get one")
+	}
+
+	// 1. Add the missing model
+	resource.Models["CertificateCreateOptions"] = models.ModelDetails{
+		Fields: map[string]models.FieldDetails{
+			"ValidityInHours": {
+				Required: false,
+				JsonName: "validityInHours",
+				ObjectDefinition: &models.ObjectDefinition{
+					Type: models.ObjectDefinitionInteger,
+				},
+			},
+		},
+	}
+
+	// 2. Add the field referencing the missing model
+	model, ok := resource.Models["CertificateRequest"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Model named `CertificateRequest` but didn't get one")
+	}
+	model.Fields["CertificateCreateOptions"] = models.FieldDetails{
+		Required:        false,
+		ReadOnly:        false,
+		Sensitive:       false,
+		JsonName:        "certificateCreateOptions",
+		Description:     "",
+		CustomFieldType: nil,
+		ObjectDefinition: &models.ObjectDefinition{
+			ReferenceName: pointer.To("CertificateCreateOptions"),
+			Type:          models.ObjectDefinitionReference,
+		},
+	}
+	resource.Models["CertificateRequest"] = model
+
+	apiDefinition.Resources["VaultCertificates"] = resource
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -20,6 +20,8 @@ var workarounds = []workaround{
 	workaroundRedis22407{},
 	workaroundMachineLearning25142{},
 
+	workaroundRecoveryServicesSiteRecovery26680{},
+
 	// @tombuildsstuff: this is an odd place for this however this allows working around inconsistencies in the Swagger
 	// we should look at moving this into the `resourceids` package when time allows.
 	workaroundInconsistentlyDefinedSegments{},


### PR DESCRIPTION
This is currently hand-defined in the Provider https://github.com/hashicorp/terraform-provider-azurerm/blob/bf4b436d9bd36ee253c4947f4812846528a47345/internal/services/recoveryservices/azuresdkhacks/model_certificaterequest.go#L12-L19 and should instead be added to the API Definition

x-link: https://github.com/Azure/azure-rest-api-specs/pull/26680