### PR TITLE
importer-rest-api-specs - Output Terraform Tests as HCL

### DIFF
--- a/tools/data-api/internal/repositories/helpers.go
+++ b/tools/data-api/internal/repositories/helpers.go
@@ -101,12 +101,12 @@ func getTerraformTestInfo(fileName string) (string, string, string, error) {
 
 }
 
-// getTerraformTestInfo transforms the file names in the Tests directory into a name, Terraform Definition type, Test Type  e.g.
-// LoadTest-Resource.json -> name = LoadTest and type = Resource
+// getTerraformOtherTestInfo transforms an otherTestType into `Other`, TestName, and a TestNum  e.g.
+// LoadTest-Resource-Other-Foo-2 -> testName = Foo and testNum = 2
 func getTerraformOtherTestInfo(otherTestType string) (string, int, error) {
 	splitName := strings.SplitN(otherTestType, "-", 4)
 	if len(splitName) != 4 {
-		return "", -1, fmt.Errorf("expected OtherTest to be split into format Other-Foo-1. Received: %+v", otherTestType)
+		return "", -1, fmt.Errorf("expected OtherTest to be split into format Other-Foo-2. Received: %+v", otherTestType)
 	}
 
 	testName := splitName[1]

--- a/tools/data-api/internal/repositories/helpers.go
+++ b/tools/data-api/internal/repositories/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -29,7 +30,6 @@ func loadJson(path string) (*[]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading %q: %+v", path, err)
 	}
-
 	defer contents.Close()
 
 	byteValue, err := io.ReadAll(contents)
@@ -38,6 +38,21 @@ func loadJson(path string) (*[]byte, error) {
 	}
 
 	return &byteValue, nil
+}
+
+func loadHcl(path string) (string, error) {
+	contents, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("loading %q: %+v", path, err)
+	}
+	defer contents.Close()
+
+	byteValue, err := io.ReadAll(contents)
+	if err != nil {
+		return "", fmt.Errorf("reading contents of %q: %+v", path, err)
+	}
+
+	return string(byteValue), nil
 }
 
 // getDefinitionInfo transforms the file names in the api definitions directory into a definition type and a name e.g.
@@ -67,5 +82,40 @@ func getTerraformDefinitionInfo(fileName string) (string, string, error) {
 	definitionType := strings.Split(splitName[1], ".")[0]
 
 	return definitionName, definitionType, nil
+
+}
+
+// getTerraformTestInfo transforms the file names in the Tests directory into a name, Terraform Definition type, Test Type  e.g.
+// LoadTest-Resource.json -> name = LoadTest and type = Resource
+func getTerraformTestInfo(fileName string) (string, string, string, error) {
+	if !strings.HasSuffix(fileName, ".hcl") {
+		return "", "", "", fmt.Errorf("file %q has an extensions not supported by the data api", fileName)
+	}
+	splitName := strings.SplitN(fileName, "-", 3)
+
+	definitionName := splitName[0]
+	definitionType := splitName[1]
+	testType := strings.Split(splitName[2], ".")[0]
+
+	return definitionName, definitionType, testType, nil
+
+}
+
+// getTerraformTestInfo transforms the file names in the Tests directory into a name, Terraform Definition type, Test Type  e.g.
+// LoadTest-Resource.json -> name = LoadTest and type = Resource
+func getTerraformOtherTestInfo(otherTestType string) (string, int, error) {
+	splitName := strings.SplitN(otherTestType, "-", 4)
+	if len(splitName) != 4 {
+		return "", -1, fmt.Errorf("expected OtherTest to be split into format Other-Foo-1. Received: %+v", otherTestType)
+	}
+
+	testName := splitName[1]
+
+	testNum, err := strconv.Atoi(splitName[2])
+	if err != nil {
+		return "", -1, fmt.Errorf("converting %s to int: %+v", splitName[2], err)
+	}
+
+	return testName, testNum, nil
 
 }

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -563,7 +563,7 @@ func (s *ServicesRepositoryImpl) ProcessTerraformDefinitions(serviceName string)
 			tests.TemplateConfiguration = &templateConfig
 
 		case strings.HasPrefix(lowerCaseTestType, "other"):
-			// we're assuming that tests are read in order
+			// todo we're assuming that tests are read in order and we should instead confirm that order
 			testName, _, err := getTerraformOtherTestInfo(testType)
 			if err != nil {
 				return nil, err
@@ -584,7 +584,6 @@ func (s *ServicesRepositoryImpl) ProcessTerraformDefinitions(serviceName string)
 				return nil, err
 			}
 
-			// todo we're assuming that we'll read the files in sequential order and should probably confirm that the ordering is correct
 			otherTest = append(otherTest, otherTestConfig)
 			otherTests[testName] = otherTest
 			tests.OtherTests = &otherTests

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_terraform.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_terraform.go
@@ -26,6 +26,9 @@ func (s Generator) generateTerraformDefinitions(apiVersion models.AzureApiDefini
 	if err := ensureDirectoryExists(s.workingDirectoryForTerraform, s.logger); err != nil {
 		return fmt.Errorf("ensuring the Terraform Directory at %q exists: %+v", s.workingDirectoryForTerraform, err)
 	}
+	if err := ensureDirectoryExists(s.workingDirectoryForTerraformTests, s.logger); err != nil {
+		return fmt.Errorf("ensuring the Terraform Tests Directory at %q exists: %+v", s.workingDirectoryForTerraformTests, err)
+	}
 
 	for resourceName, resource := range apiVersion.Resources {
 		if resource.Terraform == nil {

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_terraform_resource.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/generate_terraform_resource.go
@@ -49,15 +49,10 @@ func (s Generator) generateTerraformResourceDefinition(resourceLabel string, det
 	}
 
 	// output the Tests for this Terraform Resource
-	resourceTestsFileName := path.Join(s.workingDirectoryForTerraform, fmt.Sprintf("%s-Resource-Tests.json", details.ResourceName))
+	resourceTestsFileName := path.Join(s.workingDirectoryForTerraformTests, fmt.Sprintf("%s-Resource-Tests.hcl", details.ResourceName))
 	s.logger.Trace(fmt.Sprintf("Generating Tests for the Terraform Resource into %q", resourceTestsFileName))
 	resourceTestsCode := mapTerraformResourceTestDefinition(details.Tests)
-	s.logger.Trace("Marshalling Tests for the Terraform Resource..")
-	testsCode, err := json.MarshalIndent(resourceTestsCode, "", "\t")
-	if err != nil {
-		return fmt.Errorf("marshaling Tests for the Terraform Resource %q: %+v", resourceLabel, err)
-	}
-	if err := writeJsonToFile(resourceTestsFileName, testsCode); err != nil {
+	if err := writeTestsHclToFile(s.workingDirectoryForTerraformTests, details.ResourceName, resourceTestsCode); err != nil {
 		return fmt.Errorf("generating Tests for the Terraform Resource %q: %+v", resourceLabel, err)
 	}
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/helpers.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/helpers.go
@@ -2,11 +2,11 @@ package dataapigeneratorjson
 
 import (
 	"fmt"
-	dataApiModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigeneratorjson/models"
 	"os"
 	"path"
 
 	"github.com/hashicorp/go-hclog"
+	dataApiModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigeneratorjson/models"
 )
 
 func (s Generator) workingDirectoryForResource(resource string) string {
@@ -88,7 +88,7 @@ func writeTestsHclToFile(directory, resourceName string, tests dataApiModels.Ter
 	if tests.OtherTests != nil {
 		for otherTestName, v := range *tests.OtherTests {
 			for i, test := range v {
-				otherTestFileName := path.Join(directory, fmt.Sprintf("%s-Resource-%s-%d-Test.hcl", resourceName, otherTestName, i))
+				otherTestFileName := path.Join(directory, fmt.Sprintf("%s-Resource-Other-%s-%d-Test.hcl", resourceName, otherTestName, i))
 				if err := writeStringToFile(otherTestFileName, test); err != nil {
 					return fmt.Errorf("writing %s Test Config: %+v", otherTestName, err)
 				}

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/helpers.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/helpers.go
@@ -2,6 +2,7 @@ package dataapigeneratorjson
 
 import (
 	"fmt"
+	dataApiModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/dataapigeneratorjson/models"
 	"os"
 	"path"
 
@@ -52,6 +53,65 @@ func writeJsonToFile(fileName string, fileContents []byte) error {
 	}
 
 	file.Write(fileContents)
+	file.Close()
+	return nil
+}
+
+func writeTestsHclToFile(directory, resourceName string, tests dataApiModels.TerraformResourceTestConfig) error {
+	if !tests.Generate {
+		return nil
+	}
+	if tests.TemplateConfig != nil {
+		templateTestFileName := path.Join(directory, fmt.Sprintf("%s-Resource-Template-Test.hcl", resourceName))
+		if err := writeStringToFile(templateTestFileName, *tests.TemplateConfig); err != nil {
+			return fmt.Errorf("writing Template Test Config: %+v", err)
+		}
+	}
+
+	basicTestFileName := path.Join(directory, fmt.Sprintf("%s-Resource-Basic-Test.hcl", resourceName))
+	if err := writeStringToFile(basicTestFileName, tests.BasicConfig); err != nil {
+		return fmt.Errorf("writing Basic Test Config: %+v", err)
+	}
+
+	requiresImportTestFileName := path.Join(directory, fmt.Sprintf("%s-Resource-Requires-Import-Test.hcl", resourceName))
+	if err := writeStringToFile(requiresImportTestFileName, tests.RequiresImport); err != nil {
+		return fmt.Errorf("writing Requires Import Test Config: %+v", err)
+	}
+
+	if tests.CompleteConfig != nil {
+		completeTestFileName := path.Join(directory, fmt.Sprintf("%s-Resource-Complete-Test.hcl", resourceName))
+		if err := writeStringToFile(completeTestFileName, *tests.CompleteConfig); err != nil {
+			return fmt.Errorf("writing Complete Test Config: %+v", err)
+		}
+	}
+
+	if tests.OtherTests != nil {
+		for otherTestName, v := range *tests.OtherTests {
+			for i, test := range v {
+				otherTestFileName := path.Join(directory, fmt.Sprintf("%s-Resource-%s-%d-Test.hcl", resourceName, otherTestName, i))
+				if err := writeStringToFile(otherTestFileName, test); err != nil {
+					return fmt.Errorf("writing %s Test Config: %+v", otherTestName, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func writeStringToFile(fileName string, fileContents string) error {
+	existing, err := os.Open(fileName)
+	if os.IsExist(err) {
+		return fmt.Errorf("existing file exists at %q", fileName)
+	}
+	existing.Close()
+
+	file, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("creating %q: %+v", fileName, err)
+	}
+
+	file.WriteString(fileContents)
 	file.Close()
 	return nil
 }

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/interface.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/interface.go
@@ -5,13 +5,14 @@ import (
 )
 
 type Generator struct {
-	outputDirectory               string
-	resourceProvider              *string
-	serviceName                   string
-	terraformPackageName          *string
-	workingDirectoryForService    string
-	workingDirectoryForApiVersion string
-	workingDirectoryForTerraform  string
+	outputDirectory                   string
+	resourceProvider                  *string
+	serviceName                       string
+	terraformPackageName              *string
+	workingDirectoryForService        string
+	workingDirectoryForApiVersion     string
+	workingDirectoryForTerraform      string
+	workingDirectoryForTerraformTests string
 
 	// TODO: pass this into methods as needed, so that we can ensure the logger is always named as required?
 	logger hclog.Logger

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/service.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/service.go
@@ -13,15 +13,17 @@ func NewForService(serviceName, outputDirectory string, resourceProvider, terraf
 	normalisedServiceName := strings.ReplaceAll(serviceName, "-", "")
 	serviceWorkingDirectory := path.Join(outputDirectory, strings.Title(normalisedServiceName))
 	terraformWorkingDirectory := path.Join(serviceWorkingDirectory, "Terraform")
+	terraformTestsWorkingDirectory := path.Join(terraformWorkingDirectory, "Tests")
 
 	return &Generator{
-		logger:                       logger,
-		outputDirectory:              outputDirectory,
-		resourceProvider:             resourceProvider,
-		serviceName:                  serviceName,
-		terraformPackageName:         terraformPackageName,
-		workingDirectoryForService:   serviceWorkingDirectory,
-		workingDirectoryForTerraform: terraformWorkingDirectory,
+		logger:                            logger,
+		outputDirectory:                   outputDirectory,
+		resourceProvider:                  resourceProvider,
+		serviceName:                       serviceName,
+		terraformPackageName:              terraformPackageName,
+		workingDirectoryForService:        serviceWorkingDirectory,
+		workingDirectoryForTerraform:      terraformWorkingDirectory,
+		workingDirectoryForTerraformTests: terraformTestsWorkingDirectory,
 	}
 }
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_resource_tests.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_resource_tests.go
@@ -7,7 +7,6 @@ import (
 )
 
 func mapTerraformResourceTestDefinition(input resourcemanager.TerraformResourceTestsDefinition) dataApiModels.TerraformResourceTestConfig {
-	// TODO: looking at the data more and more, these probably want to become `*.hcl` files?
 	// Perhaps `Resource-Test-{Basic|Complete}.hcl` and  `Resource-Test-{Other}{1|2|3}.hcl`?
 	testConfig := dataApiModels.TerraformResourceTestConfig{
 		BasicConfig:    input.BasicConfiguration,

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_resource_tests.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_resource_tests.go
@@ -7,7 +7,6 @@ import (
 )
 
 func mapTerraformResourceTestDefinition(input resourcemanager.TerraformResourceTestsDefinition) dataApiModels.TerraformResourceTestConfig {
-	// Perhaps `Resource-Test-{Basic|Complete}.hcl` and  `Resource-Test-{Other}{1|2|3}.hcl`?
 	testConfig := dataApiModels.TerraformResourceTestConfig{
 		BasicConfig:    input.BasicConfiguration,
 		CompleteConfig: input.CompleteConfiguration,


### PR DESCRIPTION
This PR swaps how we output Terraform tests by outputting those tests as HCL rather than json