### PR TITLE
automation: running the automation when `./api-definitions` changes

### DIFF
--- a/.github/workflows/automation-extract-tf-resource-ids.yaml
+++ b/.github/workflows/automation-extract-tf-resource-ids.yaml
@@ -3,6 +3,7 @@ name: Extract TF resource IDs
 on:
   pull_request_target:
     paths:
+      - 'api-definitions/**' # needed until https://github.com/hashicorp/pandora/issues/3315 is implemented
       - 'data/**'
     types: ['opened', 'edited']
 

--- a/.github/workflows/automation-regenerate-go-sdk.yaml
+++ b/.github/workflows/automation-regenerate-go-sdk.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - 'api-definitions/**'
       - 'data/**'
       - 'tools/generator-go-sdk/**'
   workflow_dispatch: # for manual invocations

--- a/.github/workflows/automation-regenerate-terraform.yaml
+++ b/.github/workflows/automation-regenerate-terraform.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - 'api-definitions/**'
       - 'data/**'
       - 'tools/generator-terraform/**'
   workflow_dispatch: # for manual invocations


### PR DESCRIPTION
This works around a limitation where GHA only triggers based on the first 3000 files in a given changeset, which may or may not contain `./data`. Since API Definitions are temporarily output to both `./api-definitions` and `./data` - this PR means we trigger on both regardless, working around this issue for the moment.