### PR TITLE
`tools/generator-go-sdk`: outputting the latest HTTP Response as a part of the `ListComplete` object

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods.go
+++ b/tools/generator-go-sdk/generator/templater_methods.go
@@ -349,6 +349,7 @@ func (c %[1]s) %[2]sCompleteMatchingPredicate(ctx context.Context%[4]s, predicat
 	}
 
 	result = %[2]sCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
 		Items: items,
 	}
 	return
@@ -372,7 +373,8 @@ func (c %[1]s) %[2]sComplete(ctx context.Context%[3]s) (result %[2]sCompleteResu
 	}
 
 	result = %[2]sCompleteResult{
-		Items: items,
+		LatestHttpResponse: resp.Response,
+		Items:		  items,
 	}
 	return
 }
@@ -621,6 +623,7 @@ func (c methodsPandoraTemplater) responseStructTemplate(data ServiceGeneratorDat
 		// whilst these looks like they could crash it's guaranteed above
 		paginationCode = fmt.Sprintf(`
 type %[2]sCompleteResult struct {
+	LatestHttpResponse *http.Response
 	Items []%[1]s
 }
 `, typeName, c.operationName)

--- a/tools/generator-go-sdk/generator/templater_methods_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_test.go
@@ -365,6 +365,7 @@ type ListOperationResponse struct {
 }
 
 type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
 	Items []LingLing
 }
 
@@ -430,6 +431,7 @@ func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, id Panda
 	}
 
 	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
 		Items: items,
 	}
 	return


### PR DESCRIPTION
Fixes https://github.com/hashicorp/go-azure-sdk/issues/716