### PR TITLE
tools/data-api: using a go mod replace to find the sdk

### DIFF
--- a/tools/data-api/go.mod
+++ b/tools/data-api/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-chi/render v1.0.2
 	github.com/hashicorp/go-azure-helpers v0.57.0
 	github.com/hashicorp/go-hclog v1.5.0
-	github.com/hashicorp/pandora/tools/sdk v0.0.0-20231120114556-5d946e565a56
+	github.com/hashicorp/pandora/tools/sdk v0.0.0-00010101000000-000000000000
 	github.com/mitchellh/cli v1.1.5
 )
 
@@ -34,3 +34,5 @@ require (
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 )
+
+replace github.com/hashicorp/pandora/tools/sdk => ../sdk

--- a/tools/data-api/go.sum
+++ b/tools/data-api/go.sum
@@ -33,8 +33,6 @@ github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/pandora/tools/sdk v0.0.0-20231120114556-5d946e565a56 h1:VrkzuMTvE2dGTefdbP6cNnQVxffCmYeLTAZg16aH7ow=
-github.com/hashicorp/pandora/tools/sdk v0.0.0-20231120114556-5d946e565a56/go.mod h1:zsGM7mjOiRjhGHJcPluwi8FkVpg4K1AAv2QqaQ71ty4=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=


### PR DESCRIPTION
This ensures that these are sourced from the local disk rather than an untagged revision - to match the other tooling.

ctx: https://github.com/hashicorp/pandora/pull/3382/files#diff-cc49cf4a51c8b072add49b7bf868102dfa5d7601027382d31522f4bdf33ca59aR10