### PR TITLE
tools/importer-rest-api-specs: HDInsight Cluster is now a Common ID

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hdinsight_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hdinsight_cluster.go
@@ -1,0 +1,28 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdHDInsightCluster{}
+
+type commonIdHDInsightCluster struct{}
+
+func (c commonIdHDInsightCluster) id() models.ParsedResourceId {
+	name := "HDInsightCluster"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			models.StaticResourceIDSegment("providers", "providers"),
+			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.HDInsight"),
+			models.StaticResourceIDSegment("clusters", "clusters"),
+			models.UserSpecifiedResourceIDSegment("clusterName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -49,6 +49,9 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdAutomationCompilationJob{}, // (@stephybun) CompilationJobId segment is defined in three different ways `jobId`, `compilationJobId` and `compilationJobName`
 	commonIdProvisioningService{},      // (@jackofallops): Inconsistent user specified fields in the swagger - `provisioningServices/{resourceName}` vs `provisioningServices/{provisioningServiceName}`
 
+	// HDInsight
+	commonIdHDInsightCluster{},
+
 	// Key Vault
 	commonIdKeyVault{},
 	commonIdKeyVaultKey{},


### PR DESCRIPTION
Dependent on https://github.com/hashicorp/go-azure-helpers/pull/198