### PR TITLE
tools/importer-rest-api-specs: adding a workaround for HDInsight 26838

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
@@ -2,10 +2,10 @@ package dataworkarounds
 
 import (
 	"fmt"
+	
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
-
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 var _ workaround = workaroundHDInsight26838{}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
@@ -1,0 +1,78 @@
+package dataworkarounds
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundHDInsight26838{}
+
+// Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/26838
+type workaroundHDInsight26838 struct{}
+
+func (workaroundHDInsight26838) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	// The field `kind` is a constant within the API but isn't documented as such - whilst
+	// we've previously been using this as a String - since we need to recase the value as
+	// the API returns this inconsistently - and there's a fixed list of possible values
+	// PR https://github.com/Azure/azure-rest-api-specs/pull/26838 updates the field within
+	// the API Definition to be an Enum - so that we can transform this into a Constant.
+	//
+	// NOTE: the fix for this currently spans multiple API Versions
+	supportedApiVersions := map[string]struct{}{
+		"2018-06-01-preview": {},
+		"2021-06-01":         {},
+		"2023-04-15-preview": {},
+		"2023-08-15-preview": {},
+	}
+
+	serviceMatches := apiDefinition.ServiceName == "HDInsight"
+	_, apiVersionMatches := supportedApiVersions[apiDefinition.ApiVersion]
+	return serviceMatches && apiVersionMatches
+}
+
+func (workaroundHDInsight26838) Name() string {
+	return "HDInsight / 26838"
+}
+
+func (workaroundHDInsight26838) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resource, ok := apiDefinition.Resources["Clusters"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `Clusters`")
+	}
+
+	model, ok := resource.Models["ClusterDefinition"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Model named `ClusterDefinition`")
+	}
+	field, ok := model.Fields["Kind"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Field named `Kind`")
+	}
+	field.ObjectDefinition = &models.ObjectDefinition{
+		Type:          models.ObjectDefinitionReference,
+		ReferenceName: pointer.To("ClusterKind"),
+	}
+	model.Fields["Kind"] = field
+	resource.Models["ClusterDefinition"] = model
+
+	// then add the backing constant
+	if v, ok := resource.Constants["ClusterKind"]; ok {
+		return nil, fmt.Errorf("an existing Constant exists with the name `ClusterKind`: %+v", v)
+	}
+	resource.Constants["ClusterKind"] = resourcemanager.ConstantDetails{
+		Type: resourcemanager.StringConstant,
+		Values: map[string]string{
+			"Hadoop":          "HADOOP",
+			"HBase":           "HBASE",
+			"Kafka":           "KAFKA",
+			"InteractiveHive": "INTERACTIVEHIVE",
+			"Spark":           "SPARK",
+		},
+	}
+
+	apiDefinition.Resources["Clusters"] = resource
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -16,6 +16,7 @@ var workarounds = []workaround{
 	workaroundContainerService21394{},
 	workaroundDataFactory23013{},
 	workaroundDevCenter26189{},
+	workaroundHDInsight26838{},
 	workaroundLoadTest20961{},
 	workaroundRedis22407{},
 	workaroundMachineLearning25142{},


### PR DESCRIPTION
Works around https://github.com/Azure/azure-rest-api-specs/pull/26838