### PR TITLE
documentation: documenting the current architecture/workflow and summarising the proposed changes to the Data API going forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ These tools are:
 
 At the current time only Resource Manager Services are supported - although we're looking to support Microsoft Graph and (potentially) the Data Plane APIs in the future.
 
+Additional documentation can be found [in the `./docs` folder](docs/README.md).
+
 ## Getting Started
 
 The following dependencies are required:
 
-* [Golang 1.20.x](https://go.dev/dl/)
+* [Golang 1.21.x](https://go.dev/dl/)
 * [.NET 7.x](https://dotnet.microsoft.com/download/dotnet/7.0)
 
 At first checkout you'll need to both initialize and then update the Git submodule:
@@ -32,31 +34,10 @@ The Swagger Git Submodule is updated every weekday (via Dependabot) - once updat
 $ git submodule update
 ```
 
-## How does this work?
-
-Pandora's primarily intended to be run in automation (using both Github Actions and Dependabot) - which gets run once a Pull Request is merged.
-
-* Once a Pull Request is merged that updates one of the following paths, the Rest API Specs Importer is run.
-  * The Resource Manager Config (`./config/resource-manager.hcl`).
-  * The Resource Manager Swagger Git Submodule (`./submodules/rest-api-specs`).
-  * Any of the tooling within `./tools`.
-* If the Rest API Specs Importer outputs any changes to the Imported API Definitions, those are committed and a Pull Request is opened.
-* Once that PR is merged, if there's any changes then the `hashicorp/go-azure-sdk` repository is updated in the same fashion via the Go SDK Generator (outputting any new/changes to the Go SDK).
-* At the same time, if there's any changes then the `hashicorp/terraform-provider-azurerm` repository is also updated via the Terraform Generator (outputting any new/changes to the Terraform Generator).
-
-To show the workflow with examples:
-
-1. A Pull Request is opened to add a new Service/API version to the config ([example](https://github.com/hashicorp/pandora/pull/939)).
-2. Once that Pull Request is merged that generates a Data API PR ([example](https://github.com/hashicorp/pandora/pull/941)).
-3. Once that Pull Request is merged that generates a Go SDK PR ([example](https://github.com/hashicorp/go-azure-sdk/pull/20)).
-4. Once that Pull Request is merged the SDK is automatically released (e.g. we add a new git tag).
-
-More information on [how to import a new Resource Manager Service/API Version for an existing Service](./docs/resource-manager-service-import) can be found in the `./docs` folder.
-
 ## Project Structure
 
-- `./config/resource-manager.hcl` - contains the list of Resource Manager Services and API Versions which should be imported.
-- `./data` - contains the Data API, containing the transformed Azure API Definitions in the intermediate C# format.
+- `./config` - contains the configuration for which Services should be imported from both Resource Manager and Microsoft Graph, and (for Resource Manager) the list of Terraform Resources which should be generated.
+- `./data` - contains V1 of the Data API - and the transformed Azure API Definitions in the intermediate C# format.
 - `./docs` - contains documentation.
 - `./submodules/msgraph-metadata` - contains the Git Submodule to [the `microsoftgraph/msgraph-metadata` repository](https://github.com/microsoftgraph/msgraph-metadata) - containing the OpenAPI/Swagger definitions for Microsoft Graph.
 - `./submodules/rest-api-specs` - contains the Git Submodule to [the `Azure/azure-rest-api-specs` repository](https://github.com/Azure/azure-rest-api-specs) - containing the OpenAPI/Swagger definitions for Azure Resource Manager.
@@ -65,6 +46,11 @@ More information on [how to import a new Resource Manager Service/API Version fo
 - `./tools/importer-msgraph-metadata` - contains the Importer for the Microsoft Graph API Definitions.
 - `./tools/importer-rest-api-specs` - contains the Importer for the Azure Resource Manager OpenAPI/Swagger definitions.
 - `./tools/version-bumper` - contains a small tool to add new Services and new API Versions for existing Services to the config.
+
+The following directories are under active development, but aren't used in production at this time:
+
+- `./api-definitions` - contains V2 of the API Definitions - output as JSON rather than C# (as in V1).
+- `./tools/data-api` - contains V2 of the Data API - which will replace V1 of the Data API in time.
 
 There's also few helper tools (for example, for use in automation):
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@ graph LR
   TerraformGenerator--->github.com/hashicorp/terraform-provider-azurerm
 ```
 
+A more detailed diagram explaining the workflow [can be found in the `Architecture Diagrams` document](internals-architecture-diagrams.md). 
+
 More details can be found [in the main README under "how does this work"](https://github.com/hashicorp/pandora#how-does-this-work).
 
 ## Overview
@@ -31,9 +33,17 @@ Specific information on each tool can be found in the README for each tool, [for
 
 ## Guides
 
+The following guides cover how to import a new Service/API Version - or to generate a new Terraform Resource:
+
 * [How to add a new Common ID](common-ids.md).
 * [Resource Manager: How to import a new API Version or Service into Pandora](resource-manager-service-import.md).
 * [Resource Manager: Generating a new Resource](resource-manager-generate-new-resource.md).
+
+The following guides are internal/technical documentation - documenting the overall architecture and requiring additional context:
+
+* [Internals: Architecture Diagrams](internals-architecture-diagrams.md)
+* [Internals: How the Automation Works](internals-how-automation-works.md)
+* [Internals: Future - changes to the Data API/Architecture](internals-architectural-changes-data-api.md)
 
 ### Resource ID's as a primary concept
 

--- a/docs/internals-architectural-changes-data-api.md
+++ b/docs/internals-architectural-changes-data-api.md
@@ -1,0 +1,218 @@
+# Internals: Future changes to the Architecture/Data API
+
+This document covers changes required to the Data API to support the presence of multiple Importers.
+
+> NOTE: This work is dependent on both `importer-msgraph-metadata` and `importer-rest-api-specs` being updated to use Data API v2.
+
+Originally we intended to have a single Importer that support multiple Sources of Data (e.g. Microsoft Graph and Resource
+Manager, with Data Plane support possible in the future) - however this has since been implemented as individual importers
+for both Microsoft Graph (`importer-msgraph-metadata`) and Resource Manager (`importer-rest-api-specs`) which currently
+necessitates duplicating both the models backing the API Definitions (today) and the Terraform Generation logic (in the
+future).
+
+This means that the system design currently looks similar to below:
+
+```
+┌─Current Implementation────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                       │
+│                                                                                                                       │
+│   ┌─Importers────────────────────────┐                                                                                │
+│   │                                  │                   .───────.                                                    │
+│   │  ┌────────────────────────────┐  │                ,─'         '─.                                                 │
+│   │  │                            │  │               ╱               ╲                                                │
+│   │  │  Rest API Specs Importer   │  │              ╱                 ╲                 ┌──────────────────────┐      │
+│   │  │                            │  │             ;        API        :                │                      │      │
+│   │  └────────────────────────────┘  │             │    Definitions    │                │       Data API       │      │
+│   │  ┌────────────────────────────┐  │────────────▶│                   │◀───────────────│       V1 or V2       │      │
+│   │  │                            │  │  Publishes  :   (C# or JSON)    ;    Consumes    │                      │      │
+│   │  │  Microsoft Graph Importer  │  │              ╲                 ╱                 └──────────────────────┘      │
+│   │  │                            │  │               ╲               ╱                                                │
+│   │  └────────────────────────────┘  │                ╲             ╱                                                 │
+│   │                                  │                 '─.       ,─'                                                  │
+│   └──────────────────────────────────┘                    `─────'                                                     │
+│                                                                                                                       │
+│                                                                                                                       │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Whilst it was possible to coordinate changes to both Importers and the Data API for the API Definitions, given that we
+may need to support additional Importers in the future (e.g. Data Plane) and that in order for each Importer to support
+Identifying and Building Terraform Resources in the future - it's likely that divergences would emerge over time and that
+there's value in having a greater separation of concerns here.
+
+As such there's a number of improvements we can make to the system design which'll make life easier going forwards,
+namely having the Data API owning the API Definitions - and splitting out a dedicated tool for identifying and building
+the Terraform Data Sources and Resources from the API Definitions.
+
+This approach allows each tool to have a single focus - becoming far simpler and thus easier to reason with - which will
+enable reducing the complexity of the `importer-rest-api-specs` tool in particular.
+
+To do this we'll want to make two changes to the current system design:
+
+1. Have the Data API become the sole maintainer of the API Definitions.
+2. Split out the Terraform Identification/Builder logic from the `importer-rest-api-specs` tool.
+
+### Step 1: Update the Data API to become the sole maintainer of the API Definitions
+
+To have the Data API become the sole maintainer, we'll need to change how these files are persisted.
+
+At present each Importer writes the API Definitions to a known folder in a known format - instead we'll need to change
+this such that each Importer publishes the API Definitions to the Data API (via new API Endpoints) - which then in turn
+write the API Definitions to disk as needed.
+
+This necessitates:
+
+1. The Data API needs a new set of endpoints, _presumably_ supporting:
+  * `DELETE {serviceType}/services/{serviceName}` - to support deleting an existing Service.
+  * `DELETE {serviceType}/services/{serviceName}/{apiVersion}` - to support deleting an existing API Version.
+  * `GET {serviceType}/services/{serviceName}` - to support retrieving an existing Service.
+  * `GET {serviceType}/services/{serviceName}/{apiVersion}` - to support retrieving an existing API Version.
+  * `PUT {serviceType}/services/{serviceName}` - to support creating a new (or replacing an existing) Service.
+  * `PUT {serviceType}/services/{serviceName}/{apiVersion}` - to support creating a new (or replacing an existing) API Version within a Service.
+2. The SDK for the Data API needs to be updated to support these new endpoints.
+3. Updating each Importer to use the new endpoints, rather than writing the files to disk.
+
+This allows the Data API to become the sole maintainer of the API Definitions - making any changes easier going
+forwards and means the system design would look similar to below:
+
+```
+┌─Future Implementation─────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                       │
+│                                                                                                                       │
+│   ┌─Importers────────────────────────┐                                                                                │
+│   │                                  │  Retrieves                                              .───────.              │
+│   │  ┌────────────────────────────┐  │   Current   ┌──────────────────────┐                 ,─'         '─.           │
+│   │  │                            │  │    State    │                      │                ╱               ╲          │
+│   │  │  Rest API Specs Importer   │  │────────────▶│                      │               ╱                 ╲         │
+│   │  │                            │  │             │                      │              ;        API        :        │
+│   │  └────────────────────────────┘  │             │       Data API       │              │    Definitions    │        │
+│   │  ┌────────────────────────────┐  │             │                      │─────────────▶│                   │        │
+│   │  │                            │  │             │         (V2)         │  Publishes   :      (JSON)       ;        │
+│   │  │  Microsoft Graph Importer  │  │────────────▶│                      │               ╲                 ╱         │
+│   │  │                            │  │  Publishes  │                      │                ╲               ╱          │
+│   │  └────────────────────────────┘  │             │                      │                 ╲             ╱           │
+│   │                                  │             └──────────────────────┘                  '─.       ,─'            │
+│   └──────────────────────────────────┘                                                          `─────'               │
+│                                                                                                                       │
+│                                                                                                                       │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+This change is necessary to support Step 2, splitting out the Terraform Resource Builder logic from the
+`importer-rest-api-specs` tool - which is necessary to be able to generate Data Sources and Resources for Microsoft
+Graph in the future.
+
+Whilst the files used for the API Definitions are in sync, we can gradually migrate from the current setup to publishing
+the API Definitions to the Data API.
+
+This means that we'll need to have a Data API instance available in order to run  each Importer, which whilst might
+sound not ideal - means that we could extend the Data API to better support local development in the future.
+For example, supporting launching the Data API with a feature-flag where the API Definitions are stored in-memory
+only - meaning that these don't need to be persisted to disk, speeding up local development - or other changes which
+may seem helpful in the future.
+
+In order to run this in automation, we'll need to add a couple of new modes to the `wrapper-automation` tool, to support
+launching the Data API prior to running each Importer, but that should be mostly reusable from the existing logic / a
+previous implementation as can be found [in this pull request](https://github.com/hashicorp/pandora/pull/1637).
+
+### Step 2: Split out the Terraform Resource Builder logic from the `importer-rest-api-specs` tool.
+
+Today Terraform Resources are identified and then built-up (that is, the Terraform Schema, Mappings and Tests for that
+Terraform Resource) within `importer-rest-api-specs` - which means that in order to support generating Resources (and
+Data Sources, in the future) - we would need to duplicate this logic into `importer-msgraph-metadata` and keep this
+relatively in-sync - which is a similar problem to the API Definitions.
+
+Rather than doing this we should introduce a separate tool, working name `Terraform Resource Builder` - which focuses
+solely on Building Terraform Resources (that is, the Terraform Schema, any Mappings and the Acceptance Tests) based
+on the data within the Data API.
+
+This allows each Importer (that is, `importer-rest-api-specs` and `importer-msgraph-metadata`) to remain focused on
+Importing the API Definitions - where the API Definitions are then pushed into the Data API - with the Terraform Resource
+Builder pulling information from the Data API - and subsequently pushing any changes back to it.
+
+Whilst spreading these tools out does introduce a little more overhead, it makes the process boundaries clearer - since
+the inputs and outputs for each tool are more clearly defined. For example, this should make supporting Data Sources in
+the future simpler - since we can first add support the Terraform Resource Builder, push that data into the Data API,
+then validate the data looks good - and finally work on outputting the Data Sources in `generator-terraform`.
+
+> Note that it could also make sense for this tool to support Identifying new candidate Terraform Resources and Data Sources
+in the future - sending a PR which updates the `./config/resources/{serviceName}.hcl` files.
+
+At a high level this looks like:
+
+```
+┌─Future Implementation: Step 2─────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                       │
+│                                                                                                                       │
+│                                                    ┌──────────────────────┐                                           │
+│                                                    │  Terraform Resource  │                                           │
+│                                                    │       Builder        │                                           │
+│                                                    └──────────────────────┘                                           │
+│                                                       ▲               │                                               │
+│                                                       │Retrieves      │                                               │
+│                                                       │ Current       │Publishes                                      │
+│                                                       │  State        │                                               │
+│   ┌─Importers────────────────────────┐                │               │                                               │
+│   │                                  │  Retrieves     ▽               ▼                        .───────.              │
+│   │  ┌────────────────────────────┐  │   Current   ┌──────────────────────┐                 ,─'         '─.           │
+│   │  │                            │  │    State    │                      │                ╱               ╲          │
+│   │  │  Rest API Specs Importer   │  │────────────▶│                      │               ╱                 ╲         │
+│   │  │                            │  │             │                      │              ;        API        :        │
+│   │  └────────────────────────────┘  │             │       Data API       │              │    Definitions    │        │
+│   │  ┌────────────────────────────┐  │             │                      │─────────────▶│                   │        │
+│   │  │                            │  │             │         (V2)         │  Read/Write  :      (JSON)       ;        │
+│   │  │  Microsoft Graph Importer  │  │────────────▶│                      │               ╲                 ╱         │
+│   │  │                            │  │  Publishes  │                      │                ╲               ╱          │
+│   │  └────────────────────────────┘  │             │                      │                 ╲             ╱           │
+│   │                                  │             └──────────────────────┘                  '─.       ,─'            │
+│   └──────────────────────────────────┘                                                          `─────'               │
+│                                                                                                                       │
+│                                                                                                                       │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### End Result
+
+With these changes all together, this means that the overall System Design will look similar to below:
+
+```
+┌─Future Implementation: End Goal───────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                       │
+│                                                    ┌──────────────────────┐                                           │
+│                                                    │  Terraform Resource  │                                           │
+│                                                    │       Builder        │                                           │
+│                                                    └──────────────────────┘                                           │
+│                                                       ▲               │                                               │
+│                                                       │Retrieves      │                                               │
+│                                                       │ Current       │Publishes                                      │
+│                                                       │  State        │                                               │
+│   ┌─Importers────────────────────────┐                │               │                                               │
+│   │                                  │  Retrieves     ▽               ▼                        .───────.              │
+│   │  ┌────────────────────────────┐  │   Current   ┌──────────────────────┐                 ,─'         '─.           │
+│   │  │                            │  │    State    │                      │                ╱               ╲          │
+│   │  │  Rest API Specs Importer   │  │────────────▶│                      │               ╱                 ╲         │
+│   │  │                            │  │             │                      │              ;        API        :        │
+│   │  └────────────────────────────┘  │             │       Data API       │              │    Definitions    │        │
+│   │  ┌────────────────────────────┐  │             │                      │─────────────▶│                   │        │
+│   │  │                            │  │             │         (V2)         │  Read/Write  :      (JSON)       ;        │
+│   │  │  Microsoft Graph Importer  │  │────────────▶│                      │               ╲                 ╱         │
+│   │  │                            │  │  Publishes  │                      │                ╲               ╱          │
+│   │  └────────────────────────────┘  │             │                      │                 ╲             ╱           │
+│   │                                  │             └──────────────────────┘                  '─.       ,─'            │
+│   └──────────────────────────────────┘                         ▲                                `─────'               │
+│                                                                │ Retrieves                                            │
+│                                                                │  Current                                             │
+│                                                                │   State                                              │
+│                                                                │                                                      │
+│                                   ┌─Generators──────────────────────────────────────────────┐                         │
+│                                   │                                                         │                         │
+│                                   │    ┌────────────────────┐  ┌───────────────────────┐    │                         │
+│                                   │    │                    │  │                       │    │                         │
+│                                   │    │  Go SDK Generator  │  │  Terraform Generator  │    │                         │
+│                                   │    │                    │  │                       │    │                         │
+│                                   │    └────────────────────┘  └───────────────────────┘    │                         │
+│                                   │                                                         │                         │
+│                                   └─────────────────────────────────────────────────────────┘                         │
+│                                                                                                                       │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```

--- a/docs/internals-architecture-diagrams.md
+++ b/docs/internals-architecture-diagrams.md
@@ -1,0 +1,88 @@
+## Internals: Architecture Diagrams
+
+Pandora is a series of different tools, the following diagram highlights how they all fit together:
+
+```
+┌─System Overview────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                                                            │
+│  ┌─Data Sources (Repositories)──────────────┐   ┌─Configs───────────────────────────────────────────────────────────────┐  │
+│  │                                          │   │ ┌────────────────────────────────┐ ┌────────────────────────────────┐ │  │
+│  │  ┌────────────────────────────────────┐  │   │ │  Resource Manager (Services)   │ │   Microsoft Graph (Services)   │ │  │
+│  │  │     Azure/azure-rest-api-specs     │  │   │ └────────────────────────────────┘ └────────────────────────────────┘ │  │
+│  │  └────────────────────────────────────┘  │   │ ┌────────────────────────────────┐                                    │  │
+│  │  ┌────────────────────────────────────┐  │   │ │  Resource Manager (Terraform)  │                                    │  │
+│  │  │  microsoftgraph/msgraph-metadata   │  │   │ └────────────────────────────────┘                                    │  │
+│  │  └────────────────────────────────────┘  │   │                                                                       │  │
+│  │                                          │   │  The list of Services (and API Versions) for Resource Manager is      │  │
+│  │  These are updated Daily via Dependabot  │   │  updated by the `version-bumper` tool - which runs once the Submodule │  │
+│  │                                          │   │  has been updated.                                                    │  │
+│  └──────────────────────────────────────────┘   └───────────────────────────────────────────────────────────────────────┘  │
+│                        ▲                                                            ▲                                      │
+│                        │                                                            │                                      │
+│                        │                     Loads data from                        │                                      │
+│                        └────────────────────────────┬───────────────────────────────┘                                      │
+│                                                     │                                                                      │
+│                                                     │                                                                      │
+│                                                     │                                                                      │
+│                  ┌──────Importers─────────────────────────────────────────────────────┐                                    │
+│                  │     ┌───────────────────────────┐  ┌───────────────────────────┐   │                                    │
+│                  │     │  Rest API Specs Importer  │  │ Microsoft Graph Importer  │   │                                    │
+│                  │     └───────────────────────────┘  └───────────────────────────┘   │                                    │
+│                  │                                                                    │                                    │
+│                  │ Each importer loads it's Config and then the associated data for   │                                    │
+│                  │ each Service from the Data Source.                                 │                                    │
+│                  │                                                                    │                                    │
+│                  │ This data is then parsed and transformed as required to give a     │        Publishes                   │
+│                  │ consistent set of API Definitions for each Service.                │─────────────────┐                  │
+│                  │                                                                    │                 │                  │
+│                  │ The Rest API Specs Importer also generates any Terraform Resources │                 ▼                  │
+│                  │ that are defined in the associated Config.                         │            .─────────.             │
+│                  │                                                                    │         ,─'           '─.          │
+│                  │ Finally the processed data is output as API Definitions which the  │        ╱                 ╲         │
+│                  │ Data API can then consume (and serve).                             │       ;  API Definitions  :        │
+│                  │                                                                    │       :    (C# / JSON)    ;        │
+│                  └────────────────────────────────────────────────────────────────────┘        ╲                 ╱         │
+│                                                                                                 ╲               ╱          │
+│                                                                                                  '─.         ,─'           │
+│                                                                                                     `───────'              │
+│                  ┌─Data API───────────────────────────────────────────────────────────┐                 ▲                  │
+│                  │                  ┌──────────────────────────────┐                  │                 │                  │
+│                  │                  │      Data API (V1 / V2)      │                  │                 │                  │
+│                  │                  └──────────────────────────────┘                  │  Loads data from│                  │
+│                  │                                                                    │─────────────────┘                  │
+│                  │ The Data API exposes the API Definitions over a known set of       │                                    │
+│                  │ HTTP endpoints.                                                    │                                    │
+│                  └────────────────────────────────────────────────────────────────────┘                                    │
+│                                                     ▲                                                                      │
+│                                                     │                                                                      │
+│                                                     │ Retrieves API                                                        │
+│                                                     │  Definitions                                                         │
+│                                                     │                                                                      │
+│                  ┌───────Generators───────────────────────────────────────────────────┐                                    │
+│                  │          ┌──────────────────────┐ ┌──────────────────────┐         │                                    │
+│                  │          │   Go SDK Generator   │ │ Terraform Generator  │         │                                    │
+│                  │          └──────────────────────┘ └──────────────────────┘         │                                    │
+│                  │                                                                    │                                    │
+│                  │ Each generator retrieves the API Definitions from the Data API and │                                    │
+│                  │ then generates either the Go SDK or Terraform Resources as needed. │                                    │
+│                  │                                                                    │                                    │
+│                  │ The associated unit tests are then run on the updated generated    │                                    │
+│                  │ output to ensure that it compiles, before a branch is pushed to    │                                    │
+│                  │ the relevant downstream repository.                                │                                    │
+│                  └────────────────────────────────────────────────────────────────────┘                                    │
+│                                                     │                                                                      │
+│                                                     │  Updates                                                             │
+│                                                     │                                                                      │
+│                                                     ▼                                                                      │
+│                 ┌─Outputs──────────────────────────────────────────────────────────────┐                                   │
+│                 │  ┌─────────────────────────┐ ┌────────────────────────────────────┐  │                                   │
+│                 │  │ hashicorp/go-azure-sdk  │ │hashicorp/terraform-provider-azurerm│  │                                   │
+│                 │  └─────────────────────────┘ └────────────────────────────────────┘  │                                   │
+│                 │                                                                      │                                   │
+│                 │  Automation within each repository will open a Pull Request when a   │                                   │
+│                 │  branch is opened.                                                   │                                   │
+│                 │                                                                      │                                   │
+│                 └──────────────────────────────────────────────────────────────────────┘                                   │
+│                                                                                                                            │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```

--- a/docs/internals-how-automation-works.md
+++ b/docs/internals-how-automation-works.md
@@ -1,0 +1,24 @@
+## Internals: How the Automation Works
+
+> NOTE: This has been lifted from the README and needs to be extended in a follow-up PR.
+
+Pandora's primarily intended to be run in automation (using both GitHub Actions and Dependabot) - with each of the different tools running once a Pull Request is merged.
+
+## Overview
+
+* Once a Pull Request is merged that updates one of the following paths, the Rest API Specs Importer is run.
+    * The Resource Manager Config (`./config/resource-manager.hcl`).
+    * The Resource Manager Swagger Git Submodule (`./submodules/rest-api-specs`).
+    * Any of the tooling within `./tools`.
+* If the Rest API Specs Importer outputs any changes to the Imported API Definitions, those are committed and a Pull Request is opened.
+* Once that PR is merged, if there's any changes then the `hashicorp/go-azure-sdk` repository is updated in the same fashion via the Go SDK Generator (outputting any new/changes to the Go SDK).
+* At the same time, if there's any changes then the `hashicorp/terraform-provider-azurerm` repository is also updated via the Terraform Generator (outputting any new/changes to the Terraform Generator).
+
+To show the workflow with examples:
+
+1. A Pull Request is opened to add a new Service/API version to the config ([example](https://github.com/hashicorp/pandora/pull/939)).
+2. Once that Pull Request is merged that generates a Data API PR ([example](https://github.com/hashicorp/pandora/pull/941)).
+3. Once that Pull Request is merged that generates a Go SDK PR ([example](https://github.com/hashicorp/go-azure-sdk/pull/20)).
+4. Once that Pull Request is merged the SDK is automatically released (e.g. we add a new git tag).
+
+See also: [how to import a new Resource Manager Service/API Version for an existing Service](resource-manager-service-import.md).


### PR DESCRIPTION
This PR documents the current architecture/workflow - but also documents/discusses the proposed changes for Data API v2 (around having the Data API become the sole owner of the API as we've previously discussed).

I've also split the `how automation works` section of the README out into the docs folder, for easier grouping