### PR TITLE
Data API V2: fixing various data issues in the parser and exposing missing attributes in the service and version definitions

### DIFF
--- a/tools/data-api/internal/repositories/mappings.go
+++ b/tools/data-api/internal/repositories/mappings.go
@@ -153,3 +153,16 @@ func mapResourceIdSegmentType(input dataapimodels.ResourceIdSegmentType) (*Resou
 
 	return nil, fmt.Errorf("unmapped Resource Id Segment Type %q", string(input))
 }
+
+func mapApiDefinitionSourceType(input dataapimodels.ApiDefinitionsSource) (*ApiDefinitionSourceType, error) {
+	mappings := map[dataapimodels.ApiDefinitionsSource]ApiDefinitionSourceType{
+		dataapimodels.HandWrittenApiDefinitionsSource:                      HandWrittenApiDefinitionsSource,
+		dataapimodels.AzureRestApiSpecsRepositoryApiDefinitionsSource:      ResourceManagerRestApiSpecsApiDefinitionsSource,
+		dataapimodels.MicrosoftGraphMetaDataRepositoryApiDefinitionsSource: MicrosoftGraphMetadataApiDefinitionsSource,
+	}
+	if v, ok := mappings[input]; ok {
+		return &v, nil
+	}
+
+	return nil, fmt.Errorf("unmapped Data Source Type %q", string(input))
+}

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -232,6 +232,7 @@ func (s *ServicesRepositoryImpl) ProcessServiceDefinitions(serviceName string) (
 
 	serviceDetails := &ServiceDetails{
 		Name:             serviceName,
+		Generate:         serviceDefinition.Generate,
 		ResourceProvider: serviceDefinition.ResourceProvider,
 		ApiVersions:      versionDefinitions,
 	}

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -250,6 +250,23 @@ func (s *ServicesRepositoryImpl) ProcessVersionDefinitions(serviceName string, v
 		Generate: true,
 	}
 
+	var apiVersionDefinition dataapimodels.ApiVersionDefinition
+
+	contents, err := loadJson(path.Join((*s.serviceNamesToDirectory)[serviceName], version, "ApiVersionDefinition.json"))
+	if err != nil {
+		return nil, fmt.Errorf("processing service definition for %q: %+v", serviceName, err)
+	}
+
+	if err = json.Unmarshal(*contents, &apiVersionDefinition); err != nil {
+		return nil, fmt.Errorf("unmarshaling service definition for %q: %+v", serviceName, err)
+	}
+
+	source, err := mapApiDefinitionSourceType(apiVersionDefinition.Source)
+	if err != nil {
+		return nil, err
+	}
+	versionDefinition.Source = *source
+
 	resourceDefinitions := make(map[string]*ServiceApiVersionResourceDetails, 0)
 
 	for _, resource := range resources {

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_api_version_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_api_version_definition.go
@@ -12,6 +12,7 @@ func buildApiVersionDefinition(apiVersion string, isPreview bool, resources map[
 		ApiVersion: apiVersion,
 		IsPreview:  isPreview,
 		Generate:   true,
+		Source:     dataapimodels.AzureRestApiSpecsRepositoryApiDefinitionsSource,
 	}
 
 	names := make([]string, 0)

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_operations.go
@@ -40,16 +40,11 @@ func codeForOperation(operationName string, input importerModels.OperationDetail
 	}
 
 	if input.ResponseObject != nil {
-		// we disregard the response object if it's either a long running operation or not a list operation
-		// since that is the behaviour in the current data api and to prevent diffs in the generated sdk
-		// this can be removed once #3364 has been fixed
-		if !input.LongRunning || input.FieldContainingPaginationDetails != nil {
-			responseObject, err := mapObjectDefinition(input.ResponseObject, knownConstants, knownModels)
-			if err != nil {
-				return nil, fmt.Errorf("mapping the response object definition: %+v", err)
-			}
-			output.ResponseObject = responseObject
+		responseObject, err := mapObjectDefinition(input.ResponseObject, knownConstants, knownModels)
+		if err != nil {
+			return nil, fmt.Errorf("mapping the response object definition: %+v", err)
 		}
+		output.ResponseObject = responseObject
 	}
 
 	if len(input.Options) > 0 {

--- a/tools/importer-rest-api-specs/components/parser/load_and_parse.go
+++ b/tools/importer-rest-api-specs/components/parser/load_and_parse.go
@@ -86,6 +86,18 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 	if err != nil {
 		return nil, fmt.Errorf("applying Swagger overrides: %+v", err)
 	}
+
+	// the response object is removed for long-running operations (see #2828) as well as for operations that are not
+	// list operations for parity with the former data api definitions in C# (see #3364).
+	// this can only be done here, since there are data workarounds that manipulate the operation information that
+	// we need to determine if the response object should be stripped or not e.g. workaround_automation_25435.go
+	for _, service := range *output {
+		for _, resource := range service.Resources {
+			operations := removeResponseObjectForSpecificOperations(&resource.Operations)
+			resource.Operations = *operations
+		}
+	}
+
 	out = *output
 
 	if len(out) > 1 {
@@ -97,6 +109,17 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 	}
 
 	return nil, nil
+}
+
+func removeResponseObjectForSpecificOperations(operations *map[string]models.OperationDetails) *map[string]models.OperationDetails {
+	for name, details := range *operations {
+		if details.LongRunning && !details.IsListOperation {
+			details.ResponseObject = nil
+		}
+		(*operations)[name] = details
+	}
+
+	return operations
 }
 
 func serviceShouldBeIgnored(name string) bool {

--- a/tools/sdk/dataapimodels/api_version_definition.go
+++ b/tools/sdk/dataapimodels/api_version_definition.go
@@ -14,4 +14,7 @@ type ApiVersionDefinition struct {
 
 	// Resources specifies a list of Api Resource names that exist within this API version.
 	Resources []string `json:"resources"`
+
+	// Source specifies where the definitions originated from
+	Source ApiDefinitionsSource `json:"source"`
 }


### PR DESCRIPTION
This PR fixes the following:

- fixes #3364
- fixes #3363
- maps the value for generate over in the service details (for the `generate-go-sdk` tool)
- loads the `ApiVersionDefinition.json` in `data-api` so that we can expose the source information (also for the `generate-go-sdk` tool)


Everything has been tested and generated locally:
- the `go-azure-sdk` generates successfully with these changes and without any diffs
- this PR will trigger a regen of the api-definitions, but the only changes should be the addition of the `Source` field to all of the `ApiVersionDefinitions.json` in the `api-definitions` folder