### PR TITLE
Data API V2: use data api v2 to generate `go-azure-sdk`

### DIFF
--- a/.github/workflows/automation-regenerate-go-sdk.yaml
+++ b/.github/workflows/automation-regenerate-go-sdk.yaml
@@ -33,6 +33,8 @@ jobs:
         run: |
           cd ./data
           make build
+          cd ../tools/data-api
+          make build
 
       - name: "Launch SSH Agent"
         run: |

--- a/scripts/automation-generate-and-commit-go-sdk.sh
+++ b/scripts/automation-generate-and-commit-go-sdk.sh
@@ -115,7 +115,7 @@ function main {
   local outputDirectory="tmp/go-azure-sdk"
   local sdkRepo="git@github.com:hashicorp/go-azure-sdk.git"
   local sha
-  local useV2Generator=false
+  local useV2Generator=true
 
   buildAndInstallDependencies
   sha=$(getSwaggerSubmoduleSha "$swaggerSubmodule")


### PR DESCRIPTION
This PR flips the flag from `false` to `true` for the go sdk generation.

The script `automation-generate-and-commit-go-sdk.sh` was executed locally and ran successfully with no diffs.