### PR TITLE
dataapiv2: More terraform v2 fixes

### DIFF
--- a/tools/data-api/internal/endpoints/v1/terraform_mappings.go
+++ b/tools/data-api/internal/endpoints/v1/terraform_mappings.go
@@ -43,6 +43,29 @@ func mapFields(input map[string]repositories.TerraformSchemaFieldDefinition) map
 	return output
 }
 
+var terraformSchemaObjectDefinitionToTerraformFieldSchemaTypes = map[repositories.TerraformSchemaFieldType]models.TerraformSchemaFieldType{
+	repositories.BooleanTerraformSchemaObjectDefinitionType:                       models.TerraformSchemaFieldTypeBoolean,
+	repositories.DateTimeTerraformSchemaObjectDefinitionType:                      models.TerraformSchemaFieldTypeDateTime,
+	repositories.DictionaryTerraformSchemaObjectDefinitionType:                    models.TerraformSchemaFieldTypeDictionary,
+	repositories.EdgeZoneTerraformSchemaObjectDefinitionType:                      models.TerraformSchemaFieldTypeEdgeZone,
+	repositories.SystemAssignedIdentityTerraformSchemaObjectDefinitionType:        models.TerraformSchemaFieldTypeIdentitySystemAssigned,
+	repositories.SystemAndUserAssignedIdentityTerraformSchemaObjectDefinitionType: models.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned,
+	repositories.SystemOrUserAssignedIdentityTerraformSchemaObjectDefinitionType:  models.TerraformSchemaFieldTypeIdentitySystemOrUserAssigned,
+	repositories.UserAssignedIdentityTerraformSchemaObjectDefinitionType:          models.TerraformSchemaFieldTypeIdentityUserAssigned,
+	repositories.LocationTerraformSchemaObjectDefinitionType:                      models.TerraformSchemaFieldTypeLocation,
+	repositories.FloatTerraformSchemaObjectDefinitionType:                         models.TerraformSchemaFieldTypeFloat,
+	repositories.IntegerTerraformSchemaObjectDefinitionType:                       models.TerraformSchemaFieldTypeInteger,
+	repositories.ListTerraformSchemaObjectDefinitionType:                          models.TerraformSchemaFieldTypeList,
+	repositories.ReferenceTerraformSchemaObjectDefinitionType:                     models.TerraformSchemaFieldTypeReference,
+	repositories.ResourceGroupTerraformSchemaObjectDefinitionType:                 models.TerraformSchemaFieldTypeResourceGroup,
+	repositories.SetTerraformSchemaObjectDefinitionType:                           models.TerraformSchemaFieldTypeSet,
+	repositories.StringTerraformSchemaFieldType:                                   models.TerraformSchemaFieldTypeString,
+	repositories.TagsTerraformSchemaObjectDefinitionType:                          models.TerraformSchemaFieldTypeTags,
+	repositories.SkuTerraformSchemaObjectDefinitionType:                           models.TerraformSchemaFieldTypeSku,
+	repositories.ZoneTerraformSchemaObjectDefinitionType:                          models.TerraformSchemaFieldTypeZone,
+	repositories.ZonesTerraformSchemaObjectDefinitionType:                         models.TerraformSchemaFieldTypeZones,
+}
+
 func mapTerraformObjectDefinition(input repositories.TerraformSchemaFieldObjectDefinition) models.TerraformSchemaFieldObjectDefinition {
 	output := models.TerraformSchemaFieldObjectDefinition{}
 
@@ -51,6 +74,12 @@ func mapTerraformObjectDefinition(input repositories.TerraformSchemaFieldObjectD
 	}
 	output.ReferenceName = input.ReferenceName
 	output.Type = models.TerraformSchemaFieldType(input.Type)
+
+	// Type could have been modified from the importer-rest-api-specs and will need to be mapped back to what it was originally.
+	// we'll overwrite what is in output.Type if the value exists in terraformSchemaObjectDefinitionToTerraformFieldSchemaTypes
+	if mapped, ok := terraformSchemaObjectDefinitionToTerraformFieldSchemaTypes[input.Type]; ok {
+		output.Type = mapped
+	}
 
 	return output
 }

--- a/tools/data-api/internal/repositories/helpers.go
+++ b/tools/data-api/internal/repositories/helpers.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -80,6 +81,13 @@ func getTerraformDefinitionInfo(fileName string) (string, string, error) {
 
 	definitionName := splitName[0]
 	definitionType := strings.Split(splitName[1], ".")[0]
+
+	// Resource-Schema Files can have multiple files with the model type appended to it (ie. KubernetesFleetManager-Resource-Schema-FleetHubProfile
+	// that final piece of the final name is not used and can be safely ignored
+	if strings.Contains(strings.ToLower(definitionType), "resource-schema") && len(strings.Split(definitionType, "-")) >= 3 {
+		log.Printf("FileName: %s", fileName)
+		definitionType = "Resource-Schema"
+	}
 
 	return definitionName, definitionType, nil
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_mappings.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_mappings.go
@@ -115,17 +115,17 @@ func mapTerraformSchemaMappings(input resourcemanager.MappingDefinition) (*dataa
 
 func mapTerraformSchemaResourceIdMappings(input []resourcemanager.ResourceIdMappingDefinition) []dataapimodels.TerraformResourceIdMappingDefinition {
 	// we need the ordering to be consistent else to avoid noisy regenerations, so let's order this on one of the keys
-	schemaFieldNames := make([]string, 0)
-	schemaFieldNamesToResourceIdMappings := make(map[string]resourcemanager.ResourceIdMappingDefinition)
+	segmentNames := make([]string, 0)
+	segmentNamesToResourceIdMappings := make(map[string]resourcemanager.ResourceIdMappingDefinition)
 	for _, item := range input {
-		schemaFieldNames = append(schemaFieldNames, item.SchemaFieldName)
-		schemaFieldNamesToResourceIdMappings[item.SchemaFieldName] = item
+		segmentNames = append(segmentNames, item.SegmentName)
+		segmentNamesToResourceIdMappings[item.SegmentName] = item
 	}
-	sort.Strings(schemaFieldNames)
+	sort.Strings(segmentNames)
 
 	output := make([]dataapimodels.TerraformResourceIdMappingDefinition, 0)
-	for _, schemaFieldName := range schemaFieldNames {
-		resourceIdMapping := schemaFieldNamesToResourceIdMappings[schemaFieldName]
+	for _, schemaFieldName := range segmentNames {
+		resourceIdMapping := segmentNamesToResourceIdMappings[schemaFieldName]
 		output = append(output, dataapimodels.TerraformResourceIdMappingDefinition{
 			SchemaFieldName:    resourceIdMapping.SchemaFieldName,
 			SegmentName:        resourceIdMapping.SegmentName,

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_schema.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_schema.go
@@ -3,6 +3,7 @@ package dataapigeneratorjson
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/sdk/dataapimodels"
@@ -30,7 +31,8 @@ func mapTerraformSchemaModelDefinition(modelName string, schemaModel resourceman
 
 	return &dataapimodels.TerraformSchemaModel{
 		Fields: schemaFields,
-		Name:   modelName,
+		// todo remove Schema when https://github.com/hashicorp/pandora/issues/3346 is addressed
+		Name: fmt.Sprintf("%sSchema", modelName),
 	}, nil
 }
 
@@ -111,6 +113,12 @@ func mapTerraformSchemaObjectDefinition(input resourcemanager.TerraformSchemaFie
 	objectDefinition := dataapimodels.TerraformSchemaObjectDefinition{
 		ReferenceName: input.ReferenceName,
 		Type:          mapped,
+	}
+
+	if input.ReferenceName != nil && !strings.HasSuffix(*input.ReferenceName, "Schema") {
+		// todo remove Schema when https://github.com/hashicorp/pandora/issues/3346 is addressed
+		referenceName := fmt.Sprintf("%sSchema", *input.ReferenceName)
+		objectDefinition.ReferenceName = &referenceName
 	}
 
 	if input.NestedObject != nil {


### PR DESCRIPTION
This PR should be the last of the Terraform fixes needed for the terraform generation to be 1-1. 

There is one issue in that the ordering of ModelToModel mappings does not match the old data api model. This will cause differences when running the generator but it should only happen once. I don't see a way to get the ordering to match but if we really want 1-1 then it will require another set of eyes to figure it out