### PR TITLE
config - remove `dataprotection` `2023-08-01` since this was pulled in the Rest API Specs repo

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -158,7 +158,7 @@ service "datamigration" {
 }
 service "dataprotection" {
   name      = "DataProtection"
-  available = ["2022-04-01", "2023-05-01", "2023-08-01", "2023-11-01"]
+  available = ["2022-04-01", "2023-05-01", "2023-11-01"]
 }
 service "datashare" {
   name      = "DataShare"


### PR DESCRIPTION
This version was pulled https://github.com/Azure/azure-rest-api-specs/commit/60679ee3db06e93eb73faa0587fed93ed843d6dc
And is causing https://github.com/hashicorp/pandora/pull/3465 to fail.