### PR TITLE
add workaround for #26678

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_26678.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_26678.go
@@ -1,0 +1,34 @@
+package dataworkarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundOperationalinsights26678{}
+
+type workaroundOperationalinsights26678 struct{}
+
+func (workaroundOperationalinsights26678) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	return apiDefinition.ServiceName == "OperationalInsights" && apiDefinition.ApiVersion == "2021-06-01"
+}
+
+func (workaroundOperationalinsights26678) Name() string {
+	return "OperationalInsights / 26678"
+}
+
+func (workaroundOperationalinsights26678) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resource, ok := apiDefinition.Resources["Cluster"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `Cluster` but didn't get one")
+	}
+	operation, ok := resource.Operations["Update"]
+	if !ok {
+		return nil, fmt.Errorf("expected an Operation named `Update` but didn't get one")
+	}
+	operation.ExpectedStatusCodes = append(operation.ExpectedStatusCodes, 202)
+	resource.Operations["Update"] = operation
+	apiDefinition.Resources["Cluster"] = resource
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_26678.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_26678.go
@@ -19,7 +19,7 @@ func (workaroundOperationalinsights26678) Name() string {
 }
 
 func (workaroundOperationalinsights26678) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
-	resource, ok := apiDefinition.Resources["Cluster"]
+	resource, ok := apiDefinition.Resources["Clusters"]
 	if !ok {
 		return nil, fmt.Errorf("expected a Resource named `Cluster` but didn't get one")
 	}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -29,6 +29,8 @@ var workarounds = []workaround{
 
 	// @tombuildsstuff: we also have to account for package names which aren't valid in Go:
 	workaroundInvalidGoPackageNames{},
+
+	workaroundOperationalinsights26678{},
 }
 
 func ApplyWorkarounds(input []models.AzureApiDefinition, logger hclog.Logger) (*[]models.AzureApiDefinition, error) {


### PR DESCRIPTION
adding workaround for https://github.com/hashicorp/go-azure-sdk/issues/735 ( https://github.com/Azure/azure-rest-api-specs/issues/26678 )
will convert to ready to review once the test pipeline pass