### PR TITLE
add authorization_2018-01-01-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -41,7 +41,7 @@ service "attestation" {
 }
 service "authorization" {
   name      = "Authorization"
-  available = ["2020-04-01-preview", "2020-10-01", "2022-04-01", "2022-05-01-preview"]
+  available = ["2018-01-01-preview", "2020-04-01-preview", "2020-10-01", "2022-04-01", "2022-05-01-preview"]
 }
 service "automanage" {
   name      = "AutoManage"


### PR DESCRIPTION
missed by https://github.com/hashicorp/pandora/pull/3477
authorization@2020-04-01-preview in `azure-sdk-go` is using `2018-01-01-preview` for `roleDefinitions`...

```
input-file:
- Microsoft.Authorization/preview/2015-06-01/authorization-ClassicAdminCalls.json
- Microsoft.Authorization/stable/2015-07-01/authorization-ElevateAccessCalls.json
- Microsoft.Authorization/preview/2018-01-01-preview/authorization-ProviderOperationsCalls.json
- Microsoft.Authorization/preview/2018-01-01-preview/authorization-RoleDefinitionsCalls.json
- Microsoft.Authorization/preview/2018-07-01-preview/authorization-DenyAssignmentGetCalls.json
- Microsoft.Authorization/preview/2019-08-01-preview/authorization-UsageMetricsCalls.json
- Microsoft.Authorization/preview/2020-04-01-preview/authorization-RoleAssignmentsCalls.json
```