### PR TITLE
automation: fixing the checkout path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ vendor/
 
 # Temp directories
 outputs/
+pandora-from-main/
 
 # .net binaries
 [Dd]ebug/

--- a/scripts/automation-determine-changes-to-api-definitions.sh
+++ b/scripts/automation-determine-changes-to-api-definitions.sh
@@ -80,7 +80,7 @@ function runStaticIdentifierDetector {
 }
 
 function main {
-  local tempDirectory="${TMPDIR}/pandora-from-main"
+  local tempDirectory="./pandora-from-main"
   local initialApiDefinitionsDirectory="${DIR}/api-definitions"
   local updatedApiDefinitionsDirectory="${tempDirectory}/api-definitions"
   local outputDirectory="$1"


### PR DESCRIPTION
The Github Actions agents aren't setting `$TMPPATH` so let's just output this into `./pandora-from-main` for now