### PR TITLE
automation: `data-api-differ` should run against PRs and not the target branch

### DIFF
--- a/.github/workflows/automation-data-api-differ.yaml
+++ b/.github/workflows/automation-data-api-differ.yaml
@@ -1,13 +1,13 @@
 ---
 name: Detect changes to the API Definitions
 on:
-  pull_request_target:
+  pull_request:
+    types: ['opened', 'synchronize']
     paths:
       - 'api-definitions/**' # to detect changes when the API Definitions are updated
       - 'tools/data-api/**' # to detect changes when the Data API is updated
       - 'tools/data-api-differ/**' # to detect changes when the Data API Differ is updated
       - 'tools/importer-rest-api-specs/**' # to detect changes when the Importer is updated
-    types: ['opened', 'synchronize']
 
 jobs:
   detect-changes-to-the-api-definitions:

--- a/.github/workflows/automation-data-api-differ.yaml
+++ b/.github/workflows/automation-data-api-differ.yaml
@@ -5,6 +5,7 @@ on:
     types: ['opened', 'synchronize']
     paths:
       - 'api-definitions/**' # to detect changes when the API Definitions are updated
+      - 'scripts/automation-determine-changes-to-api-definitions.sh' # to handle changes to the script
       - 'tools/data-api/**' # to detect changes when the Data API is updated
       - 'tools/data-api-differ/**' # to detect changes when the Data API Differ is updated
       - 'tools/importer-rest-api-specs/**' # to detect changes when the Importer is updated

--- a/scripts/automation-determine-changes-to-api-definitions.sh
+++ b/scripts/automation-determine-changes-to-api-definitions.sh
@@ -24,6 +24,12 @@ function checkoutAPIDefinitionsFromMainInto {
 
   cd "${DIR}"
 
+  echo "Outputting the available branches.."
+  git branch
+
+  echo "Outputting git status.."
+  git status
+
   echo "Removing any existing directory at ${workingDirectory}.."
   rm -rf "$workingDirectory"
 
@@ -33,10 +39,6 @@ function checkoutAPIDefinitionsFromMainInto {
 
   echo "Resetting the secondary working directory"
   git reset --hard
-  git clean -xdf
-
-  echo "Checking out the 'main' branch in the copy"
-  git checkout main
 
   echo "Returning to the original working directory.."
   cd "${DIR}"


### PR DESCRIPTION
Copied this from the wrong GHA - right now this runs from `main` against `main` which means [no changes are output](https://github.com/hashicorp/pandora/pull/3500#issuecomment-1857602479) - this fixes that.