### PR TITLE
`tools/data-api-differ`: shortening the list of changes when a new API Resource is detected

### DIFF
--- a/tools/data-api-differ/internal/commands/detect_breaking_changes.go
+++ b/tools/data-api-differ/internal/commands/detect_breaking_changes.go
@@ -59,7 +59,8 @@ func (c DetectBreakingChangesCommand) Run(args []string) int {
 	}
 
 	c.logger.Debug("Performing diff of the two data sources..")
-	result, err := differ.Diff(a.dataApiBinaryPath, a.initialApiDefinitionsPath, a.updatedApiDefinitionsPath)
+	includeNestedChangesWhenNew := false // not necessary since this is only tracking breaking changes
+	result, err := differ.Diff(a.dataApiBinaryPath, a.initialApiDefinitionsPath, a.updatedApiDefinitionsPath, includeNestedChangesWhenNew)
 	if err != nil {
 		c.logger.Error(fmt.Sprintf("performing diff: %+v", err))
 		return 1

--- a/tools/data-api-differ/internal/commands/detect_changes.go
+++ b/tools/data-api-differ/internal/commands/detect_changes.go
@@ -62,7 +62,8 @@ func (c DetectChangesCommand) Run(args []string) int {
 	}
 
 	c.logger.Debug("Performing diff of the two data sources..")
-	result, err := differ.Diff(a.dataApiBinaryPath, a.initialApiDefinitionsPath, a.updatedApiDefinitionsPath)
+	includeNestedChangesWhenNew := false // TODO: expose this as a `--full` flag
+	result, err := differ.Diff(a.dataApiBinaryPath, a.initialApiDefinitionsPath, a.updatedApiDefinitionsPath, includeNestedChangesWhenNew)
 	if err != nil {
 		c.logger.Error(fmt.Sprintf("performing diff: %+v", err))
 		return 1

--- a/tools/data-api-differ/internal/commands/output_resource_id_segments.go
+++ b/tools/data-api-differ/internal/commands/output_resource_id_segments.go
@@ -60,7 +60,8 @@ func (c OutputResourceIdSegmentsCommand) Run(args []string) int {
 	}
 
 	c.logger.Debug("Performing diff of the two data sources..")
-	result, err := differ.Diff(a.dataApiBinaryPath, a.initialApiDefinitionsPath, a.updatedApiDefinitionsPath)
+	includeNestedChangesWhenNew := true // needed to detect any Resource ID Segments containing Static Identifiers
+	result, err := differ.Diff(a.dataApiBinaryPath, a.initialApiDefinitionsPath, a.updatedApiDefinitionsPath, includeNestedChangesWhenNew)
 	if err != nil {
 		c.logger.Error(fmt.Sprintf("performing diff: %+v", err))
 		return 1

--- a/tools/data-api-differ/internal/differ/differ.go
+++ b/tools/data-api-differ/internal/differ/differ.go
@@ -11,13 +11,13 @@ import (
 type differ struct {
 }
 
-func performDiff(initial dataapi.Data, updated dataapi.Data) (*Result, error) {
+func performDiff(initial dataapi.Data, updated dataapi.Data, includeNestedChangesWhenNew bool) (*Result, error) {
 	diff := differ{}
 	output := make([]changes.Change, 0)
 
 	// TODO: support additional Data Sources when we're using the updated SDK
 	log.Logger.Trace("Detecting changes to the Resource Manager Services..")
-	resourceManagerChanges, err := diff.changesForServices(initial.ResourceManagerServices, updated.ResourceManagerServices)
+	resourceManagerChanges, err := diff.changesForServices(initial.ResourceManagerServices, updated.ResourceManagerServices, includeNestedChangesWhenNew)
 	if err != nil {
 		return nil, fmt.Errorf("determining changes for the Resource Manager Services: %+v", err)
 	}

--- a/tools/data-api-differ/internal/differ/differ_api_resource.go
+++ b/tools/data-api-differ/internal/differ/differ_api_resource.go
@@ -11,12 +11,12 @@ import (
 )
 
 // changesForApiResources determines the changes between the API Resources within the specified API Version.
-func (d differ) changesForApiResources(serviceName, apiVersion string, initial, updated map[string]dataapi.ApiResourceData) (*[]changes.Change, error) {
+func (d differ) changesForApiResources(serviceName, apiVersion string, initial, updated map[string]dataapi.ApiResourceData, includeNestedChangesWhenNew bool) (*[]changes.Change, error) {
 	output := make([]changes.Change, 0)
 	apiResources := d.uniqueApiResources(initial, updated)
 	for _, apiResource := range apiResources {
 		log.Logger.Trace(fmt.Sprintf("Detecting changes in API Resource %q..", apiResource))
-		changesForApiResource, err := d.changesForApiResource(serviceName, apiVersion, apiResource, initial, updated)
+		changesForApiResource, err := d.changesForApiResource(serviceName, apiVersion, apiResource, initial, updated, includeNestedChangesWhenNew)
 		if err != nil {
 			return nil, fmt.Errorf("detecting changes to the API Resource %q: %+v", apiResource, err)
 		}
@@ -26,7 +26,7 @@ func (d differ) changesForApiResources(serviceName, apiVersion string, initial, 
 }
 
 // changesForApiResource determines the changes between two versions of the specified API Resource.
-func (d differ) changesForApiResource(serviceName, apiVersion, apiResource string, initial, updated map[string]dataapi.ApiResourceData) (*[]changes.Change, error) {
+func (d differ) changesForApiResource(serviceName, apiVersion, apiResource string, initial, updated map[string]dataapi.ApiResourceData, includeNestedChangesWhenNew bool) (*[]changes.Change, error) {
 	output := make([]changes.Change, 0)
 
 	oldData, inOldData := initial[apiResource]
@@ -48,7 +48,11 @@ func (d differ) changesForApiResource(serviceName, apiVersion, apiResource strin
 			ApiVersion:   apiVersion,
 			ResourceName: apiResource,
 		})
-		// intentionally not returning here
+		if !includeNestedChangesWhenNew {
+			return &output, nil
+		}
+		// Otherwise we intentionally don't returning here to return the full output - needed to detect any new
+		// Static Identifiers found within the Resource ID Segments
 	}
 
 	// we then need to diff each of the individual components - however note that the old version may not exist

--- a/tools/data-api-differ/internal/differ/differ_api_resource.go
+++ b/tools/data-api-differ/internal/differ/differ_api_resource.go
@@ -51,8 +51,9 @@ func (d differ) changesForApiResource(serviceName, apiVersion, apiResource strin
 		if !includeNestedChangesWhenNew {
 			return &output, nil
 		}
-		// Otherwise we intentionally don't returning here to return the full output - needed to detect any new
-		// Static Identifiers found within the Resource ID Segments
+		// Otherwise we'll include the full list of nested changes (for example any new Constants, Models,
+		// Operations and Resource IDs contained within the [new] API Resource) - which will be a large
+		// number of changes - but is needed for certain kinds of diff's (e.g. detecting new Static Identifiers).
 	}
 
 	// we then need to diff each of the individual components - however note that the old version may not exist

--- a/tools/data-api-differ/internal/differ/differ_api_resource_test.go
+++ b/tools/data-api-differ/internal/differ/differ_api_resource_test.go
@@ -5,17 +5,27 @@ import (
 
 	"github.com/hashicorp/pandora/tools/data-api-differ/internal/changes"
 	"github.com/hashicorp/pandora/tools/data-api-differ/internal/dataapi"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func TestDiff_APIResourceAdded(t *testing.T) {
+func TestDiff_APIResourceAdded_WithNestedDetails(t *testing.T) {
 	initial := map[string]dataapi.ApiResourceData{
 		"First": {},
 	}
 	updated := map[string]dataapi.ApiResourceData{
-		"First":  {},
-		"Second": {},
+		"First": {},
+		"Second": {
+			Constants: map[string]resourcemanager.ConstantDetails{
+				"SomeConst": {
+					Type: resourcemanager.StringConstant,
+					Values: map[string]string{
+						"First": "first",
+					},
+				},
+			},
+		},
 	}
-	actual, err := differ{}.changesForApiResources("Computer", "2020-01-01", initial, updated)
+	actual, err := differ{}.changesForApiResources("Computer", "2020-01-01", initial, updated, true)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -25,20 +35,72 @@ func TestDiff_APIResourceAdded(t *testing.T) {
 			ApiVersion:   "2020-01-01",
 			ResourceName: "Second",
 		},
+		changes.ConstantAdded{
+			ServiceName:  "Computer",
+			ApiVersion:   "2020-01-01",
+			ResourceName: "Second",
+			ConstantName: "SomeConst",
+			ConstantType: string(resourcemanager.StringConstant),
+			KeysAndValues: map[string]string{
+				"First": "first",
+			},
+		},
 	}
 	assertChanges(t, expected, *actual)
 	assertContainsNoBreakingChanges(t, *actual)
 }
 
-func TestDiff_APIResourceRemoved(t *testing.T) {
+func TestDiff_APIResourceAdded_WithoutNestedDetails(t *testing.T) {
 	initial := map[string]dataapi.ApiResourceData{
-		"First":  {},
-		"Second": {},
+		"First": {},
+	}
+	updated := map[string]dataapi.ApiResourceData{
+		"First": {},
+		"Second": {
+			Constants: map[string]resourcemanager.ConstantDetails{
+				"SomeConst": {
+					Type: resourcemanager.StringConstant,
+					Values: map[string]string{
+						"First": "first",
+					},
+				},
+			},
+		},
+	}
+	actual, err := differ{}.changesForApiResources("Computer", "2020-01-01", initial, updated, false)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []changes.Change{
+		changes.ApiResourceAdded{
+			ServiceName:  "Computer",
+			ApiVersion:   "2020-01-01",
+			ResourceName: "Second",
+		},
+		// the Constant shouldn't be output since we're skipping the nested items
+	}
+	assertChanges(t, expected, *actual)
+	assertContainsNoBreakingChanges(t, *actual)
+}
+
+func TestDiff_APIResourceRemoved_WithNestedDetails(t *testing.T) {
+	initial := map[string]dataapi.ApiResourceData{
+		"First": {},
+		"Second": {
+			Constants: map[string]resourcemanager.ConstantDetails{
+				"SomeConst": {
+					Type: resourcemanager.StringConstant,
+					Values: map[string]string{
+						"First": "first",
+					},
+				},
+			},
+		},
 	}
 	updated := map[string]dataapi.ApiResourceData{
 		"First": {},
 	}
-	actual, err := differ{}.changesForApiResources("Computer", "2020-01-01", initial, updated)
+	actual, err := differ{}.changesForApiResources("Computer", "2020-01-01", initial, updated, true)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -48,6 +110,40 @@ func TestDiff_APIResourceRemoved(t *testing.T) {
 			ApiVersion:   "2020-01-01",
 			ResourceName: "Second",
 		},
+		// the constant isn't output since the entire API Resource is removed
+	}
+	assertChanges(t, expected, *actual)
+	assertContainsBreakingChanges(t, *actual)
+}
+
+func TestDiff_APIResourceRemoved_WithoutNestedDetails(t *testing.T) {
+	initial := map[string]dataapi.ApiResourceData{
+		"First": {},
+		"Second": {
+			Constants: map[string]resourcemanager.ConstantDetails{
+				"SomeConst": {
+					Type: resourcemanager.StringConstant,
+					Values: map[string]string{
+						"First": "first",
+					},
+				},
+			},
+		},
+	}
+	updated := map[string]dataapi.ApiResourceData{
+		"First": {},
+	}
+	actual, err := differ{}.changesForApiResources("Computer", "2020-01-01", initial, updated, false)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []changes.Change{
+		changes.ApiResourceRemoved{
+			ServiceName:  "Computer",
+			ApiVersion:   "2020-01-01",
+			ResourceName: "Second",
+		},
+		// the constant isn't output since the entire API Resource is removed
 	}
 	assertChanges(t, expected, *actual)
 	assertContainsBreakingChanges(t, *actual)

--- a/tools/data-api-differ/internal/differ/differ_api_versions.go
+++ b/tools/data-api-differ/internal/differ/differ_api_versions.go
@@ -10,12 +10,12 @@ import (
 )
 
 // changesForApiVersions determines the changes between the different API versions for the provided Service.
-func (d differ) changesForApiVersions(serviceName string, initial map[string]dataapi.ApiVersionData, updated map[string]dataapi.ApiVersionData) (*[]changes.Change, error) {
+func (d differ) changesForApiVersions(serviceName string, initial map[string]dataapi.ApiVersionData, updated map[string]dataapi.ApiVersionData, includeNestedChangesWhenNew bool) (*[]changes.Change, error) {
 	output := make([]changes.Change, 0)
 	apiVersions := d.uniqueApiVersions(initial, updated)
 	for _, apiVersion := range apiVersions {
 		log.Logger.Trace(fmt.Sprintf("Detecting changes in API Version %q..", apiVersion))
-		changesForApiVersion, err := d.changesForApiVersion(serviceName, apiVersion, initial, updated)
+		changesForApiVersion, err := d.changesForApiVersion(serviceName, apiVersion, initial, updated, includeNestedChangesWhenNew)
 		if err != nil {
 			return nil, fmt.Errorf("detecting changes to API Version %q: %+v", apiVersion, err)
 		}
@@ -25,7 +25,7 @@ func (d differ) changesForApiVersions(serviceName string, initial map[string]dat
 }
 
 // changesForApiVersion determines the changes between two different API Versions within a given Service.
-func (d differ) changesForApiVersion(serviceName, apiVersion string, initial, updated map[string]dataapi.ApiVersionData) (*[]changes.Change, error) {
+func (d differ) changesForApiVersion(serviceName, apiVersion string, initial, updated map[string]dataapi.ApiVersionData, includeNestedChangesWhenNew bool) (*[]changes.Change, error) {
 	output := make([]changes.Change, 0)
 
 	oldData, inOldData := initial[apiVersion]
@@ -55,7 +55,7 @@ func (d differ) changesForApiVersion(serviceName, apiVersion string, initial, up
 	if inOldData {
 		initialResources = oldData.Resources
 	}
-	changesInApiResources, err := d.changesForApiResources(serviceName, apiVersion, initialResources, updatedData.Resources)
+	changesInApiResources, err := d.changesForApiResources(serviceName, apiVersion, initialResources, updatedData.Resources, includeNestedChangesWhenNew)
 	if err != nil {
 		return nil, fmt.Errorf("detecting changes to the API Resources: %+v", err)
 	}

--- a/tools/data-api-differ/internal/differ/differ_api_versions_test.go
+++ b/tools/data-api-differ/internal/differ/differ_api_versions_test.go
@@ -5,17 +5,31 @@ import (
 
 	"github.com/hashicorp/pandora/tools/data-api-differ/internal/changes"
 	"github.com/hashicorp/pandora/tools/data-api-differ/internal/dataapi"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func TestDiff_APIVersionAdded(t *testing.T) {
+func TestDiff_APIVersionAdded_WithNestedDetails(t *testing.T) {
 	initial := map[string]dataapi.ApiVersionData{
 		"2020-01-01": {},
 	}
 	updated := map[string]dataapi.ApiVersionData{
 		"2020-01-01": {},
-		"2023-01-01": {},
+		"2023-01-01": {
+			Resources: map[string]dataapi.ApiResourceData{
+				"Example": {
+					Constants: map[string]resourcemanager.ConstantDetails{
+						"SomeConst": {
+							Type: resourcemanager.StringConstant,
+							Values: map[string]string{
+								"First": "first",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
-	actual, err := differ{}.changesForApiVersions("Computer", initial, updated)
+	actual, err := differ{}.changesForApiVersions("Computer", initial, updated, true)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -24,20 +38,126 @@ func TestDiff_APIVersionAdded(t *testing.T) {
 			ServiceName: "Computer",
 			ApiVersion:  "2023-01-01",
 		},
+		changes.ApiResourceAdded{
+			ServiceName:  "Computer",
+			ApiVersion:   "2023-01-01",
+			ResourceName: "Example",
+		},
+		changes.ConstantAdded{
+			ServiceName:  "Computer",
+			ApiVersion:   "2023-01-01",
+			ResourceName: "Example",
+			ConstantName: "SomeConst",
+			ConstantType: string(resourcemanager.StringConstant),
+			KeysAndValues: map[string]string{
+				"First": "first",
+			},
+		},
 	}
 	assertChanges(t, expected, *actual)
 	assertContainsNoBreakingChanges(t, *actual)
 }
 
-func TestDiff_APIVersionRemoved(t *testing.T) {
+func TestDiff_APIVersionAdded_WithoutNestedDetails(t *testing.T) {
 	initial := map[string]dataapi.ApiVersionData{
 		"2020-01-01": {},
-		"2023-01-01": {},
+	}
+	updated := map[string]dataapi.ApiVersionData{
+		"2020-01-01": {},
+		"2023-01-01": {
+			Resources: map[string]dataapi.ApiResourceData{
+				"Example": {
+					Constants: map[string]resourcemanager.ConstantDetails{
+						"SomeConst": {
+							Type: resourcemanager.StringConstant,
+							Values: map[string]string{
+								"First": "first",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	actual, err := differ{}.changesForApiVersions("Computer", initial, updated, false)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []changes.Change{
+		// we should get the API Version and API Resource but nothing under it
+		changes.ApiVersionAdded{
+			ServiceName: "Computer",
+			ApiVersion:  "2023-01-01",
+		},
+		changes.ApiResourceAdded{
+			ServiceName:  "Computer",
+			ApiVersion:   "2023-01-01",
+			ResourceName: "Example",
+		},
+	}
+	assertChanges(t, expected, *actual)
+	assertContainsNoBreakingChanges(t, *actual)
+}
+
+func TestDiff_APIVersionRemoved_WithNestedDetails(t *testing.T) {
+	initial := map[string]dataapi.ApiVersionData{
+		"2020-01-01": {},
+		"2023-01-01": {
+			Resources: map[string]dataapi.ApiResourceData{
+				"Example": {
+					// this won't be surfaced because the entire API Version has been removed
+					Constants: map[string]resourcemanager.ConstantDetails{
+						"SomeConst": {
+							Type: resourcemanager.StringConstant,
+							Values: map[string]string{
+								"First": "first",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	updated := map[string]dataapi.ApiVersionData{
 		"2020-01-01": {},
 	}
-	actual, err := differ{}.changesForApiVersions("Computer", initial, updated)
+	actual, err := differ{}.changesForApiVersions("Computer", initial, updated, true)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []changes.Change{
+		changes.ApiVersionRemoved{
+			ServiceName: "Computer",
+			ApiVersion:  "2023-01-01",
+		},
+	}
+	assertChanges(t, expected, *actual)
+	assertContainsBreakingChanges(t, *actual)
+}
+
+func TestDiff_APIVersionRemoved_WithoutNestedDetails(t *testing.T) {
+	initial := map[string]dataapi.ApiVersionData{
+		"2020-01-01": {},
+		"2023-01-01": {
+			Resources: map[string]dataapi.ApiResourceData{
+				"Example": {
+					// this won't be surfaced because the entire API Version has been removed
+					Constants: map[string]resourcemanager.ConstantDetails{
+						"SomeConst": {
+							Type: resourcemanager.StringConstant,
+							Values: map[string]string{
+								"First": "first",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	updated := map[string]dataapi.ApiVersionData{
+		"2020-01-01": {},
+	}
+	actual, err := differ{}.changesForApiVersions("Computer", initial, updated, false)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/tools/data-api-differ/internal/differ/differ_helpers_test.go
+++ b/tools/data-api-differ/internal/differ/differ_helpers_test.go
@@ -17,7 +17,7 @@ func init() {
 // determineAndValidateDiff runs a full diff of the two sets of data.
 // This is intended to be used by tests covering the entire `diff` code path, simulating a real-world usage.
 func determineAndValidateDiff(t *testing.T, initial, updated dataapi.Data, expected []changes.Change, breakingChanges bool) {
-	actual, err := performDiff(initial, updated)
+	actual, err := performDiff(initial, updated, true)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/tools/data-api-differ/internal/differ/differ_services.go
+++ b/tools/data-api-differ/internal/differ/differ_services.go
@@ -10,14 +10,14 @@ import (
 )
 
 // changesForServices determines the changes between the initial and updated set of Services.
-func (d differ) changesForServices(initial map[string]dataapi.ServiceData, updated map[string]dataapi.ServiceData) (*[]changes.Change, error) {
+func (d differ) changesForServices(initial map[string]dataapi.ServiceData, updated map[string]dataapi.ServiceData, includeNestedChangesWhenNew bool) (*[]changes.Change, error) {
 	output := make([]changes.Change, 0)
 	// first pull out a unique list of Service names
 	log.Logger.Info("Identifying a unique list of Service Names..")
 	serviceNames := d.uniqueServiceNames(initial, updated)
 	for _, serviceName := range serviceNames {
 		log.Logger.Info(fmt.Sprintf("Detecting changes in Service %q..", serviceName))
-		changesForService, err := d.changesForService(serviceName, initial, updated)
+		changesForService, err := d.changesForService(serviceName, initial, updated, includeNestedChangesWhenNew)
 		if err != nil {
 			return nil, fmt.Errorf("detecting changes to the Service %q: %+v", serviceName, err)
 		}
@@ -27,7 +27,7 @@ func (d differ) changesForServices(initial map[string]dataapi.ServiceData, updat
 }
 
 // changesForService determines the changes between two different Services.
-func (d differ) changesForService(serviceName string, initial map[string]dataapi.ServiceData, updated map[string]dataapi.ServiceData) (*[]changes.Change, error) {
+func (d differ) changesForService(serviceName string, initial map[string]dataapi.ServiceData, updated map[string]dataapi.ServiceData, includeNestedChangesWhenNew bool) (*[]changes.Change, error) {
 	output := make([]changes.Change, 0)
 	oldData, inOldData := initial[serviceName]
 	updatedData, inUpdatedData := updated[serviceName]
@@ -58,7 +58,7 @@ func (d differ) changesForService(serviceName string, initial map[string]dataapi
 	if inOldData {
 		oldApiVersions = oldData.ApiVersions
 	}
-	changesForApiVersions, err := d.changesForApiVersions(serviceName, oldApiVersions, updatedData.ApiVersions)
+	changesForApiVersions, err := d.changesForApiVersions(serviceName, oldApiVersions, updatedData.ApiVersions, includeNestedChangesWhenNew)
 	if err != nil {
 		return nil, fmt.Errorf("detecting changes to the API Versions: %+v", err)
 	}

--- a/tools/data-api-differ/internal/differ/interface.go
+++ b/tools/data-api-differ/internal/differ/interface.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Diff returns information about the changes between `initialPath` and `updatedPath`.
-func Diff(dataApiBinaryPath, initialPath, updatedPath string) (*Result, error) {
+func Diff(dataApiBinaryPath, initialPath, updatedPath string, includeNestedChangesWhenNew bool) (*Result, error) {
 	log.Logger.Trace(fmt.Sprintf("Parsing the Initial Data Set from %q..", initialPath))
 	initialData, err := dataapi.ParseDataFromPath(dataApiBinaryPath, initialPath)
 	if err != nil {
@@ -22,5 +22,5 @@ func Diff(dataApiBinaryPath, initialPath, updatedPath string) (*Result, error) {
 	}
 
 	log.Logger.Trace("Performing the diff..")
-	return performDiff(*initialData, *updatedData)
+	return performDiff(*initialData, *updatedData, includeNestedChangesWhenNew)
 }


### PR DESCRIPTION
When diffing the changes in https://github.com/hashicorp/pandora/pull/3570 the Data API Differ has correctly identified the changes however the list of changes is too long to render in a single Github comment, meaning that the Github Action currently fails for new Data PRs.

Whilst we're planning to change how this output is rendered which'll fix the issue in the medium-term - this PR updates the currently rendered output such that when a new API Resource is detected that we'll skip outputting the list of nested changes (e.g. the full set of Constants/Models/Resource IDs) in the structured output.

This means that the "Non Breaking Changes" present in #3570 gets reduced from 6420 lines to this:

```markdown
**185 Non-Breaking Changes** were detected:

* ✅ **New API Version:** `2023-12-01` in `DataProtection`.
* ✅ **New API Resource:** `AzureBackupJob` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `AzureBackupJobs` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `BackupInstances` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `BackupPolicies` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `BackupVaults` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `DeletedBackupInstances` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `DppFeatureSupport` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `DppJob` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `DppResourceGuardProxies` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `FetchSecondaryRecoveryPoints` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `FindRestorableTimeRanges` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `RecoveryPoint` in `DataProtection@2023-12-01`.
* ✅ **New API Resource:** `ResourceGuards` in `DataProtection@2023-12-01`.
* ✅ **New API Version:** `2023-09-01` in `Network`.
* ✅ **New API Resource:** `AdminRuleCollections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `AdminRules` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ApplicationGatewayPrivateEndpointConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ApplicationGatewayPrivateLinkResources` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ApplicationGatewayWafDynamicManifests` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ApplicationGateways` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ApplicationSecurityGroups` in `Network@2023-09-01`.
* ✅ **New API Resource:** `AvailableDelegations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `AvailableServiceAliases` in `Network@2023-09-01`.
* ✅ **New API Resource:** `AzureFirewalls` in `Network@2023-09-01`.
* ✅ **New API Resource:** `BastionHosts` in `Network@2023-09-01`.
* ✅ **New API Resource:** `BastionShareableLink` in `Network@2023-09-01`.
* ✅ **New API Resource:** `BgpServiceCommunities` in `Network@2023-09-01`.
* ✅ **New API Resource:** `CheckDnsAvailabilities` in `Network@2023-09-01`.
* ✅ **New API Resource:** `CloudServicePublicIPAddresses` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ConnectionMonitors` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ConnectivityConfigurations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `CustomIPPrefixes` in `Network@2023-09-01`.
* ✅ **New API Resource:** `DdosCustomPolicies` in `Network@2023-09-01`.
* ✅ **New API Resource:** `DdosProtectionPlans` in `Network@2023-09-01`.
* ✅ **New API Resource:** `DscpConfiguration` in `Network@2023-09-01`.
* ✅ **New API Resource:** `DscpConfigurations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `EndpointServices` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCircuitArpTable` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCircuitAuthorizations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCircuitConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCircuitPeerings` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCircuitRoutesTable` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCircuitRoutesTableSummary` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCircuitStats` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCircuits` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCrossConnectionArpTable` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCrossConnectionPeerings` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCrossConnectionRouteTable` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCrossConnectionRouteTableSummary` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteCrossConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteGateways` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteLinks` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRoutePortAuthorizations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRoutePorts` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRoutePortsLocations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteProviderPorts` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ExpressRouteServiceProviders` in `Network@2023-09-01`.
* ✅ **New API Resource:** `FirewallPolicies` in `Network@2023-09-01`.
* ✅ **New API Resource:** `FirewallPolicyRuleCollectionGroups` in `Network@2023-09-01`.
* ✅ **New API Resource:** `FlowLogs` in `Network@2023-09-01`.
* ✅ **New API Resource:** `IPAllocations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `IPGroups` in `Network@2023-09-01`.
* ✅ **New API Resource:** `LoadBalancers` in `Network@2023-09-01`.
* ✅ **New API Resource:** `LocalNetworkGateways` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NatGateways` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkGroups` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkInterfaces` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkManagerActiveConfigurations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkManagerActiveConnectivityConfigurations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkManagerConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkManagerEffectiveConnectivityConfiguration` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkManagerEffectiveSecurityAdminRules` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkManagers` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkProfiles` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkSecurityGroups` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkVirtualAppliances` in `Network@2023-09-01`.
* ✅ **New API Resource:** `NetworkWatchers` in `Network@2023-09-01`.
* ✅ **New API Resource:** `P2sVpnGateways` in `Network@2023-09-01`.
* ✅ **New API Resource:** `PacketCaptures` in `Network@2023-09-01`.
* ✅ **New API Resource:** `PeerExpressRouteCircuitConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `PrivateDnsZoneGroups` in `Network@2023-09-01`.
* ✅ **New API Resource:** `PrivateEndpoints` in `Network@2023-09-01`.
* ✅ **New API Resource:** `PrivateLinkService` in `Network@2023-09-01`.
* ✅ **New API Resource:** `PrivateLinkServices` in `Network@2023-09-01`.
* ✅ **New API Resource:** `PublicIPAddresses` in `Network@2023-09-01`.
* ✅ **New API Resource:** `PublicIPPrefixes` in `Network@2023-09-01`.
* ✅ **New API Resource:** `RouteFilterRules` in `Network@2023-09-01`.
* ✅ **New API Resource:** `RouteFilters` in `Network@2023-09-01`.
* ✅ **New API Resource:** `RouteTables` in `Network@2023-09-01`.
* ✅ **New API Resource:** `Routes` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ScopeConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `SecurityAdminConfigurations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `SecurityPartnerProviders` in `Network@2023-09-01`.
* ✅ **New API Resource:** `SecurityRules` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ServiceEndpointPolicies` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ServiceEndpointPolicyDefinitions` in `Network@2023-09-01`.
* ✅ **New API Resource:** `ServiceTags` in `Network@2023-09-01`.
* ✅ **New API Resource:** `StaticMembers` in `Network@2023-09-01`.
* ✅ **New API Resource:** `Subnets` in `Network@2023-09-01`.
* ✅ **New API Resource:** `TrafficAnalytics` in `Network@2023-09-01`.
* ✅ **New API Resource:** `Usages` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VMSSPublicIPAddresses` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VipSwap` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualApplianceSites` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualApplianceSkus` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualNetworkGatewayConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualNetworkGateways` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualNetworkPeerings` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualNetworkTap` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualNetworkTaps` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualNetworks` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualRouterPeerings` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualRouters` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VirtualWANs` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VpnGateways` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VpnLinkConnections` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VpnServerConfigurations` in `Network@2023-09-01`.
* ✅ **New API Resource:** `VpnSites` in `Network@2023-09-01`.
* ✅ **New API Resource:** `WebApplicationFirewallPolicies` in `Network@2023-09-01`.
* ✅ **New API Resource:** `WebCategories` in `Network@2023-09-01`.
* ✅ **New API Version:** `2023-08-01` in `RecoveryServicesBackup`.
* ✅ **New API Resource:** `BackupEngines` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupJobs` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupPolicies` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupProtectableItems` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupProtectedItems` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupProtectionContainers` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupProtectionIntent` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupResourceEncryptionConfigs` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupResourceStorageConfigsNonCRR` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupResourceVaultConfigs` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupStatus` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupUsageSummaries` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `BackupWorkloadItems` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `Backups` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `DataMove` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `FeatureSupport` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `FetchTieringCost` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ItemLevelRecoveryConnections` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `JobCancellations` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `JobDetails` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `Jobs` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `Operation` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `PrivateEndpointConnection` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ProtectableContainers` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ProtectedItems` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ProtectionContainers` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ProtectionIntent` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ProtectionPolicies` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `RecoveryPoint` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `RecoveryPoints` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `RecoveryPointsRecommendedForMove` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ResourceGuardProxies` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ResourceGuardProxy` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `Restores` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `SecurityPINs` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `SoftDeletedContainers` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Resource:** `ValidateOperation` in `RecoveryServicesBackup@2023-08-01`.
* ✅ **New API Version:** `2023-11-01` in `SecurityInsights`.
* ✅ **New API Resource:** `Actions` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `AlertRuleTemplates` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `AlertRules` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `AutomationRules` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `Bookmarks` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `ContentPackages` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `ContentProductPackages` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `ContentProductTemplates` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `ContentTemplates` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `DataConnectors` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `IncidentAlerts` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `IncidentBookmarks` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `IncidentComments` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `IncidentEntities` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `IncidentRelations` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `Incidents` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `Metadata` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `Repositories` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `SecurityMLAnalyticsSettings` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `SentinelOnboardingStates` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `SourceControls` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `ThreatIntelligence` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `WatchlistItems` in `SecurityInsights@2023-11-01`.
* ✅ **New API Resource:** `Watchlists` in `SecurityInsights@2023-11-01`.
```

Which unblocks the Data API Differ for the moment - and then allows us to rework the UI without having actions failures in the interim.