### PR TITLE
nit: `tools/importer-rest-api-specs` - fixing the workaround for 26678 from #3478

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_26678.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_26678.go
@@ -29,6 +29,6 @@ func (workaroundOperationalinsights26678) Process(apiDefinition models.AzureApiD
 	}
 	operation.ExpectedStatusCodes = append(operation.ExpectedStatusCodes, 202)
 	resource.Operations["Update"] = operation
-	apiDefinition.Resources["Cluster"] = resource
+	apiDefinition.Resources["Clusters"] = resource
 	return &apiDefinition, nil
 }


### PR DESCRIPTION
This should be set back into `Clusters` and not `Cluster`.