### PR TITLE
`importer-rest-api-specs` - support resource generation for resources with a scoped ID segment

### DIFF
--- a/config/resources/chaosstudio.hcl
+++ b/config/resources/chaosstudio.hcl
@@ -1,0 +1,1 @@
+package resources

--- a/config/resources/chaosstudio.hcl
+++ b/config/resources/chaosstudio.hcl
@@ -1,1 +1,0 @@
-package resources

--- a/config/resources/containerservice.hcl
+++ b/config/resources/containerservice.hcl
@@ -10,11 +10,7 @@ service "ContainerService" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}"
         display_name = "Kubernetes Fleet Manager"
         website_subcategory = "Container"
-        description = <<HERE
-Manages a Kubernetes Fleet Manager
-
-~> **Note:** This Resource is in **Preview** to use this you must be opted into the Preview. You can do this by running `az feature register --namespace Microsoft.ContainerService --name FleetResourcePreview` and then `az provider register -n Microsoft.ContainerService`
-HERE
+        description = "Manages a Kubernetes Fleet Manager"
       }
     }
   }

--- a/tools/importer-rest-api-specs/components/resources/identification.go
+++ b/tools/importer-rest-api-specs/components/resources/identification.go
@@ -20,17 +20,18 @@ func FindCandidates(input services.Resource, resourceDefinitions map[string]defi
 	}
 
 	for resourceIdName, resourceId := range input.Schema.ResourceIds {
-		// no point
-		if resourceId.Segments[0].Type == resourcemanager.ScopeSegment {
-			continue
-		}
-
 		hasList := false
 
 		var createMethod *resourcemanager.MethodDefinition
 		var updateMethod *resourcemanager.MethodDefinition
 		var deleteMethod *resourcemanager.MethodDefinition
 		var getMethod *resourcemanager.MethodDefinition
+
+		resourceLabel, resourceMetaData := findResourceName(resourceDefinitions, resourceId.Id)
+		if resourceLabel == nil || resourceMetaData == nil {
+			logger.Debug(fmt.Sprintf("Identified Resource %q but not defined - skipping", resourceId.Id))
+			continue
+		}
 
 		for operationName, operation := range input.Operations.Operations {
 			// if it's an operation on just a suffix we're not interested
@@ -109,12 +110,6 @@ func FindCandidates(input services.Resource, resourceDefinitions map[string]defi
 					TimeoutInMinutes: 30,
 				}
 			}
-		}
-
-		resourceLabel, resourceMetaData := findResourceName(resourceDefinitions, resourceId.Id)
-		if resourceLabel == nil || resourceMetaData == nil {
-			logger.Debug(fmt.Sprintf("Identified Resource %q but not defined - skipping", resourceId.Id))
-			continue
 		}
 
 		var dataSourceDefinition *resourcemanager.TerraformDataSourceDetails

--- a/tools/importer-rest-api-specs/components/schema/builder.go
+++ b/tools/importer-rest-api-specs/components/schema/builder.go
@@ -378,11 +378,10 @@ func (b Builder) findCreateUpdateReadPayloads(input resourcemanager.TerraformRes
 	out.createModelName = *createOperation.RequestObject.ReferenceName
 	out.createPayload = createModel
 	createPropsModelName, createPropsModel := out.getPropertiesModelWithinModel(out.createPayload, b.models)
-	if createPropsModelName == nil || createPropsModel == nil {
-		return nil, fmt.Errorf("couldn't find `Properties` model for Create Payload")
+	if createPropsModelName != nil || createPropsModel != nil {
+		out.createPropertiesPayload = *createPropsModel
+		out.createPropertiesModelName = *createPropsModelName
 	}
-	out.createPropertiesPayload = *createPropsModel
-	out.createPropertiesModelName = *createPropsModelName
 
 	// Read has to exist
 	readOperation, ok := b.operations[input.ReadMethod.MethodName]
@@ -401,11 +400,10 @@ func (b Builder) findCreateUpdateReadPayloads(input resourcemanager.TerraformRes
 	out.readPayload = readModel
 	// then find the `Properties` model within this
 	readPropsModelName, readPropsModel := out.getPropertiesModelWithinModel(out.readPayload, b.models)
-	if readPropsModelName == nil || readPropsModel == nil {
-		return nil, fmt.Errorf("couldn't find `Properties` model for Read Payload")
+	if readPropsModelName != nil || readPropsModel != nil {
+		out.readPropertiesModelName = *readPropsModelName
+		out.readPropertiesPayload = *readPropsModel
 	}
-	out.readPropertiesModelName = *readPropsModelName
-	out.readPropertiesPayload = *readPropsModel
 
 	// Update doesn't have to exist
 	if updateMethod := input.UpdateMethod; updateMethod != nil {
@@ -426,11 +424,10 @@ func (b Builder) findCreateUpdateReadPayloads(input resourcemanager.TerraformRes
 
 		// then find the `Properties` model within this
 		updatePropsModelName, updatePropsModel := out.getPropertiesModelWithinModel(*out.updatePayload, b.models)
-		if updatePropsModelName == nil || updatePropsModel == nil {
-			return nil, fmt.Errorf("couldn't find `Properties` model for Update Payload")
+		if updatePropsModelName != nil || updatePropsModel != nil {
+			out.updatePropertiesModelName = updatePropsModelName
+			out.updatePropertiesPayload = updatePropsModel
 		}
-		out.updatePropertiesModelName = updatePropsModelName
-		out.updatePropertiesPayload = updatePropsModel
 	}
 
 	// NOTE: intentionally not including Delete since the payload shouldn't be applicable to users

--- a/tools/importer-rest-api-specs/components/schema/internal.go
+++ b/tools/importer-rest-api-specs/components/schema/internal.go
@@ -5,13 +5,15 @@ import (
 )
 
 type operationPayloads struct {
-	createModelName           string
-	createPayload             resourcemanager.ModelDetails
+	createModelName string
+	createPayload   resourcemanager.ModelDetails
+	// TODO once #3588 has been resolved these should become pointers
 	createPropertiesModelName string
 	createPropertiesPayload   resourcemanager.ModelDetails
 
-	readModelName           string
-	readPayload             resourcemanager.ModelDetails
+	readModelName string
+	readPayload   resourcemanager.ModelDetails
+	// TODO once #3588 has been resolved these should become pointers
 	readPropertiesModelName string
 	readPropertiesPayload   resourcemanager.ModelDetails
 


### PR DESCRIPTION
Currently we skip resource generation if a candidate resource has a scoped resource ID segment. This PR removes that check and flips the logic for setting the Create/Read/Update Property payload instead of erroring.

These changes are required to be able to generate the resource Chaos Studio Targets. This shouldn't result in changes to the existing Data API definitions.