### PR TITLE
automation: updating the Terraform Generator to use Data API V2

### DIFF
--- a/.github/workflows/automation-regenerate-go-sdk.yaml
+++ b/.github/workflows/automation-regenerate-go-sdk.yaml
@@ -24,16 +24,6 @@ jobs:
         with:
           go-version: '1.21.3'
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
-        with:
-          dotnet-version: 7.0.x
-
-      - name: "Build Data API (V1)"
-        run: |
-          cd ./data
-          make build
-
       - name: "Launch SSH Agent"
         run: |
           # launch an ssh agent and export it's env vars

--- a/.github/workflows/automation-regenerate-go-sdk.yaml
+++ b/.github/workflows/automation-regenerate-go-sdk.yaml
@@ -29,11 +29,9 @@ jobs:
         with:
           dotnet-version: 7.0.x
 
-      - name: "Build Data API"
+      - name: "Build Data API (V1)"
         run: |
           cd ./data
-          make build
-          cd ../tools/data-api
           make build
 
       - name: "Launch SSH Agent"

--- a/.github/workflows/unit-test-end-to-end-resource-manager.yaml
+++ b/.github/workflows/unit-test-end-to-end-resource-manager.yaml
@@ -17,19 +17,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
-        with:
-          dotnet-version: 7.0.x
-
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: '1.21.3'
-
-      - name: "Build Data API"
-        run: |
-          cd ./data
-          make build
 
       - name: "Build and Run importer-rest-api-specs"
         id: import-data

--- a/scripts/automation-generate-and-commit-go-sdk.sh
+++ b/scripts/automation-generate-and-commit-go-sdk.sh
@@ -31,7 +31,7 @@ function runWrapper {
   echo "Running Wrapper.."
   cd "${DIR}/tools/wrapper-automation"
   ./wrapper-automation go-sdk \
-    --api-definitions-directory="../../$apiDefinitionsDirectory"\
+    --api-definitions-dir="../../$apiDefinitionsDirectory"\
     --output-dir="../../$outputDirectory"
 
   cd "${DIR}"

--- a/scripts/automation-generate-and-commit-go-sdk.sh
+++ b/scripts/automation-generate-and-commit-go-sdk.sh
@@ -5,33 +5,34 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)/.."
 
 function buildAndInstallDependencies {
-    echo "Installing the Data API V2 onto the GOBIN.."
-    cd "${DIR}/tools/data-api"
-    go install .
-    cd "${DIR}"
+  echo "Outputting Go Version.."
+  go version
 
-    echo "Installing the Go SDK Generator into the GOBIN.."
-    cd "${DIR}/tools/generator-go-sdk"
-    go install .
-    cd "${DIR}"
+  echo "Installing the Data API V2 onto the GOBIN.."
+  cd "${DIR}/tools/data-api"
+  go install .
+  cd "${DIR}"
 
-    echo "Building Wrapper.."
-    cd "${DIR}/tools/wrapper-automation"
-    go build -o wrapper-automation
-    cd "${DIR}"
+  echo "Installing the Go SDK Generator into the GOBIN.."
+  cd "${DIR}/tools/generator-go-sdk"
+  go install .
+  cd "${DIR}"
+
+  echo "Building Wrapper.."
+  cd "${DIR}/tools/wrapper-automation"
+  go build -o wrapper-automation
+  cd "${DIR}"
 }
 
 function runWrapper {
-  local dataApiAssemblyPath=$1
+  local apiDefinitionsDirectory=$1
   local outputDirectory=$2
-  local useV2Generator=$4
 
   echo "Running Wrapper.."
   cd "${DIR}/tools/wrapper-automation"
   ./wrapper-automation go-sdk \
-    -data-api-assembly-path="../../$dataApiAssemblyPath"\
-    -output-dir="../../$outputDirectory"\
-    -use-v2-generator="$useV2Generator"
+    --api-definitions-directory="../../$apiDefinitionsDirectory"\
+    --output-dir="../../$outputDirectory"
 
   cd "${DIR}"
 
@@ -114,17 +115,16 @@ function cleanup {
 }
 
 function main {
-  local dataApiAssemblyPath="data/Pandora.Api/bin/Debug/net7.0/Pandora.Api.dll"
+  local apiDefinitionsDirectory="./api-definitions"
   local swaggerSubmodule="./submodules/rest-api-specs"
   local outputDirectory="tmp/go-azure-sdk"
   local sdkRepo="git@github.com:hashicorp/go-azure-sdk.git"
   local sha
-  local useV2Generator=true
 
   buildAndInstallDependencies
   sha=$(getSwaggerSubmoduleSha "$swaggerSubmodule")
   prepareGoSdk "$outputDirectory" "$sdkRepo"
-  runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
+  runWrapper "$apiDefinitionsDirectory" "$outputDirectory"
   conditionallyCommitAndPushGoSdk "$outputDirectory" "$sha"
   cleanup "$outputDirectory"
 }

--- a/scripts/automation-generate-and-commit-go-sdk.sh
+++ b/scripts/automation-generate-and-commit-go-sdk.sh
@@ -5,6 +5,11 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)/.."
 
 function buildAndInstallDependencies {
+    echo "Installing the Data API V2 onto the GOBIN.."
+    cd "${DIR}/tools/data-api"
+    go install .
+    cd "${DIR}"
+
     echo "Installing the Go SDK Generator into the GOBIN.."
     cd "${DIR}/tools/generator-go-sdk"
     go install .
@@ -110,7 +115,6 @@ function cleanup {
 
 function main {
   local dataApiAssemblyPath="data/Pandora.Api/bin/Debug/net7.0/Pandora.Api.dll"
-  local dataApiV2Path="tools/data-api/data-api"
   local swaggerSubmodule="./submodules/rest-api-specs"
   local outputDirectory="tmp/go-azure-sdk"
   local sdkRepo="git@github.com:hashicorp/go-azure-sdk.git"
@@ -120,12 +124,7 @@ function main {
   buildAndInstallDependencies
   sha=$(getSwaggerSubmoduleSha "$swaggerSubmodule")
   prepareGoSdk "$outputDirectory" "$sdkRepo"
-  if [ "$useV2Generator" = true ]
-  then
-    runWrapper "$dataApiV2Path" "$outputDirectory" "$sha" "$useV2Generator"
-  else
-    runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
-  fi
+  runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
   conditionallyCommitAndPushGoSdk "$outputDirectory" "$sha"
   cleanup "$outputDirectory"
 }

--- a/scripts/automation-generate-and-commit-terraform.sh
+++ b/scripts/automation-generate-and-commit-terraform.sh
@@ -31,7 +31,7 @@ function runWrapper {
   echo "Running Wrapper.."
   cd "${DIR}/tools/wrapper-automation"
   ./wrapper-automation terraform \
-    --api-definitions-directory="../../$apiDefinitionsDirectory"\
+    --api-definitions-dir="../../$apiDefinitionsDirectory"\
     --output-dir="../../$outputDirectory"
 
   cd "${DIR}"

--- a/scripts/automation-generate-and-commit-terraform.sh
+++ b/scripts/automation-generate-and-commit-terraform.sh
@@ -11,6 +11,11 @@ function buildAndInstallDependencies {
     echo "Outputting .net Version.."
     dotnet --version
 
+    echo "Installing the Data API into the GOBIN.."
+    cd "${DIR}/tools/data-api"
+    go install .
+    cd "${DIR}"
+
     echo "Installing the Terraform Generator into the GOBIN.."
     cd "${DIR}/tools/generator-terraform"
     go install .
@@ -142,7 +147,6 @@ function cleanup {
 
 function main {
   local dataApiAssemblyPath="data/Pandora.Api/bin/Debug/net7.0/Pandora.Api.dll"
-  local dataApiV2Path="tools/data-api/data-api"
   local swaggerSubmodule="./submodules/rest-api-specs"
   local outputDirectory="tmp/terraform-provider-azurerm"
   local providerRepo="git@github.com:hashicorp/terraform-provider-azurerm.git"
@@ -152,12 +156,7 @@ function main {
   buildAndInstallDependencies
   sha=$(getSwaggerSubmoduleSha "$swaggerSubmodule")
   prepareTerraformProvider "$outputDirectory" "$providerRepo"
-  if [ "$useV2Generator" = true ]
-  then
-    runWrapper "$dataApiV2Path" "$outputDirectory" "$sha" "$useV2Generator"
-  else
-    runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
-  fi
+  runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
   runFmtImportsAndGenerate "$outputDirectory"
   conditionallyCommitAndPushTerraformProvider "$outputDirectory" "$sha"
   cleanup "$outputDirectory"

--- a/scripts/automation-generate-and-commit-terraform.sh
+++ b/scripts/automation-generate-and-commit-terraform.sh
@@ -5,39 +5,34 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)/.."
 
 function buildAndInstallDependencies {
-    echo "Outputting Go Version.."
-    go version
+  echo "Outputting Go Version.."
+  go version
 
-    echo "Outputting .net Version.."
-    dotnet --version
+  echo "Installing the Data API into the GOBIN.."
+  cd "${DIR}/tools/data-api"
+  go install .
+  cd "${DIR}"
 
-    echo "Installing the Data API into the GOBIN.."
-    cd "${DIR}/tools/data-api"
-    go install .
-    cd "${DIR}"
+  echo "Installing the Terraform Generator into the GOBIN.."
+  cd "${DIR}/tools/generator-terraform"
+  go install .
+  cd "${DIR}"
 
-    echo "Installing the Terraform Generator into the GOBIN.."
-    cd "${DIR}/tools/generator-terraform"
-    go install .
-    cd "${DIR}"
-
-    echo "Building Wrapper.."
-    cd "${DIR}/tools/wrapper-automation"
-    go build -o wrapper-automation
-    cd "${DIR}"
+  echo "Building Wrapper.."
+  cd "${DIR}/tools/wrapper-automation"
+  go build -o wrapper-automation
+  cd "${DIR}"
 }
 
 function runWrapper {
-  local dataApiAssemblyPath=$1
+  local apiDefinitionsDirectory=$1
   local outputDirectory=$2
-  local useV2Generator=$4
 
   echo "Running Wrapper.."
   cd "${DIR}/tools/wrapper-automation"
   ./wrapper-automation terraform \
-    -data-api-assembly-path="../../$dataApiAssemblyPath"\
-    -output-dir="../../$outputDirectory"\
-    -use-v2-generator="$useV2Generator"
+    --api-definitions-directory="../../$apiDefinitionsDirectory"\
+    --output-dir="../../$outputDirectory"
 
   cd "${DIR}"
 
@@ -146,17 +141,16 @@ function cleanup {
 }
 
 function main {
-  local dataApiAssemblyPath="data/Pandora.Api/bin/Debug/net7.0/Pandora.Api.dll"
+  local apiDefinitionsDirectory="./api-definitions"
   local swaggerSubmodule="./submodules/rest-api-specs"
   local outputDirectory="tmp/terraform-provider-azurerm"
   local providerRepo="git@github.com:hashicorp/terraform-provider-azurerm.git"
   local sha
-  local useV2Generator=false
 
   buildAndInstallDependencies
   sha=$(getSwaggerSubmoduleSha "$swaggerSubmodule")
   prepareTerraformProvider "$outputDirectory" "$providerRepo"
-  runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
+  runWrapper "$apiDefinitionsDirectory" "$outputDirectory"
   runFmtImportsAndGenerate "$outputDirectory"
   conditionallyCommitAndPushTerraformProvider "$outputDirectory" "$sha"
   cleanup "$outputDirectory"

--- a/scripts/automation-generate-go-sdk.sh
+++ b/scripts/automation-generate-go-sdk.sh
@@ -31,7 +31,7 @@ function runWrapper {
   echo "Running Wrapper.."
   cd "${DIR}/tools/wrapper-automation"
   ./wrapper-automation go-sdk \
-    --api-definitions-directory="../../$apiDefinitionsDirectory"\
+    --api-definitions-dir="../../$apiDefinitionsDirectory"\
     --output-dir="../../$outputDirectory"
 
   cd "${DIR}"

--- a/scripts/automation-generate-go-sdk.sh
+++ b/scripts/automation-generate-go-sdk.sh
@@ -5,33 +5,34 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)/.."
 
 function buildAndInstallDependencies {
-    echo "Installing the Data API V2 onto the GOBIN.."
-    cd "${DIR}/tools/data-api"
-    go install .
-    cd "${DIR}"
+  echo "Outputting Go Version.."
+  go version
 
-    echo "Installing the Go SDK Generator into the GOBIN.."
-    cd "${DIR}/tools/generator-go-sdk"
-    go install .
-    cd "${DIR}"
+  echo "Installing the Data API V2 onto the GOBIN.."
+  cd "${DIR}/tools/data-api"
+  go install .
+  cd "${DIR}"
 
-    echo "Building Wrapper.."
-    cd "${DIR}/tools/wrapper-automation"
-    go build -o wrapper-automation
-    cd "${DIR}"
+  echo "Installing the Go SDK Generator into the GOBIN.."
+  cd "${DIR}/tools/generator-go-sdk"
+  go install .
+  cd "${DIR}"
+
+  echo "Building Wrapper.."
+  cd "${DIR}/tools/wrapper-automation"
+  go build -o wrapper-automation
+  cd "${DIR}"
 }
 
 function runWrapper {
-  local dataApiAssemblyPath=$1
+  local apiDefinitionsDirectory=$1
   local outputDirectory=$2
-  local useV2Generator=$4
 
   echo "Running Wrapper.."
   cd "${DIR}/tools/wrapper-automation"
   ./wrapper-automation go-sdk \
-    -data-api-assembly-path="../../$dataApiAssemblyPath"\
-    -output-dir="../../$outputDirectory"\
-    -use-v2-generator="$useV2Generator"
+    --api-definitions-directory="../../$apiDefinitionsDirectory"\
+    --output-dir="../../$outputDirectory"
 
   cd "${DIR}"
 
@@ -94,17 +95,16 @@ function cleanup {
 }
 
 function main {
-  local dataApiAssemblyPath="data/Pandora.Api/bin/Debug/net7.0/Pandora.Api.dll"
+  local apiDefinitionsDirectory="./api-definitions"
   local swaggerSubmodule="./submodules/rest-api-specs"
   local outputDirectory="tmp/go-azure-sdk"
   local sdkRepo="https://github.com/hashicorp/go-azure-sdk.git"
   local sha
-  local useV2Generator=true
 
   buildAndInstallDependencies
   sha=$(getSwaggerSubmoduleSha "$swaggerSubmodule")
   prepareGoSdk "$outputDirectory" "$sdkRepo"
-  runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
+  runWrapper "$apiDefinitionsDirectory" "$outputDirectory"
   runGoSDKUnitTests "$outputDirectory"
   cleanup "$outputDirectory"
 }

--- a/scripts/automation-generate-go-sdk.sh
+++ b/scripts/automation-generate-go-sdk.sh
@@ -5,6 +5,11 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)/.."
 
 function buildAndInstallDependencies {
+    echo "Installing the Data API V2 onto the GOBIN.."
+    cd "${DIR}/tools/data-api"
+    go install .
+    cd "${DIR}"
+
     echo "Installing the Go SDK Generator into the GOBIN.."
     cd "${DIR}/tools/generator-go-sdk"
     go install .
@@ -90,22 +95,16 @@ function cleanup {
 
 function main {
   local dataApiAssemblyPath="data/Pandora.Api/bin/Debug/net7.0/Pandora.Api.dll"
-  local dataApiV2Path="tools/data-api/data-api"
   local swaggerSubmodule="./submodules/rest-api-specs"
   local outputDirectory="tmp/go-azure-sdk"
   local sdkRepo="https://github.com/hashicorp/go-azure-sdk.git"
   local sha
-  local useV2Generator=false
+  local useV2Generator=true
 
   buildAndInstallDependencies
   sha=$(getSwaggerSubmoduleSha "$swaggerSubmodule")
   prepareGoSdk "$outputDirectory" "$sdkRepo"
-  if [ "$useV2Generator" = true ]
-  then
-    runWrapper "$dataApiV2Path" "$outputDirectory" "$sha" "$useV2Generator"
-  else
-    runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
-  fi
+  runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$sha" "$useV2Generator"
   runGoSDKUnitTests "$outputDirectory"
   cleanup "$outputDirectory"
 }

--- a/scripts/automation-generate-terraform.sh
+++ b/scripts/automation-generate-terraform.sh
@@ -31,7 +31,7 @@ function runWrapper {
   echo "Running Wrapper.."
   cd "${DIR}/tools/wrapper-automation"
   ./wrapper-automation terraform \
-    --api-definitions-directory="../../$apiDefinitionsDirectory"\
+    --api-definitions-dir="../../$apiDefinitionsDirectory"\
     --output-dir="../../$outputDirectory"
 
   cd "${DIR}"

--- a/scripts/automation-generate-terraform.sh
+++ b/scripts/automation-generate-terraform.sh
@@ -11,6 +11,11 @@ function buildAndInstallDependencies {
     echo "Outputting .net Version.."
     dotnet --version
 
+    echo "Installing the Data API V2 onto the GOBIN.."
+    cd "${DIR}/tools/data-api"
+    go install .
+    cd "${DIR}"
+
     echo "Installing the Terraform Generator into the GOBIN.."
     cd "${DIR}/tools/generator-terraform"
     go install .
@@ -111,19 +116,13 @@ function cleanup {
 
 function main {
   local dataApiAssemblyPath="data/Pandora.Api/bin/Debug/net7.0/Pandora.Api.dll"
-  local dataApiV2Path="tools/data-api/data-api"
   local outputDirectory="tmp/provider-azurerm"
   local providerRepo="git@github.com:hashicorp/terraform-provider-azurerm.git"
   local useV2Generator=false
 
   buildAndInstallDependencies
   prepareTerraformProvider "$outputDirectory" "$providerRepo"
-  if [ "$useV2Generator" = true ]
-  then
-    runWrapper "$dataApiV2Path" "$outputDirectory" "$useV2Generator"
-  else
-    runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$useV2Generator"
-  fi
+  runWrapper "$dataApiAssemblyPath" "$outputDirectory" "$useV2Generator"
   runFmtImportsAndGenerate "$outputDirectory"
   runTerraformProviderUnitTests "$outputDirectory"
   cleanup "$outputDirectory"

--- a/tools/wrapper-automation/go_sdk_generator.go
+++ b/tools/wrapper-automation/go_sdk_generator.go
@@ -23,7 +23,7 @@ func (c GoSdkGeneratorCmd) Run(args []string) int {
 	}
 
 	f := flag.NewFlagSet("wrapper-automation", flag.ExitOnError)
-	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-directory", "", "--api-definitions-directory=./api-definitions")
+	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-dir", "", "--api-definitions-dir=./api-definitions")
 	f.StringVar(&arguments.DataApiAssemblyPath, "data-api-assembly-path", "", "--data-api-assembly-path=../data/Pandora.Api.dll")
 	f.StringVar(&arguments.OutputDirectory, "output-dir", "", "--output-dir=../output")
 

--- a/tools/wrapper-automation/go_sdk_generator.go
+++ b/tools/wrapper-automation/go_sdk_generator.go
@@ -23,9 +23,9 @@ func (c GoSdkGeneratorCmd) Run(args []string) int {
 	}
 
 	f := flag.NewFlagSet("wrapper-automation", flag.ExitOnError)
-	f.StringVar(&arguments.DataApiAssemblyPath, "data-api-assembly-path", "", "-data-api-assembly-path=../data/Pandora.Api.dll")
-	f.StringVar(&arguments.OutputDirectory, "output-dir", "", "-output-dir=../output")
-	f.BoolVar(&arguments.UseV2Generator, "use-v2-generator", false, "-use-v2-generator=true")
+	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-directory", "", "--api-definitions-directory=./api-definitions")
+	f.StringVar(&arguments.DataApiAssemblyPath, "data-api-assembly-path", "", "--data-api-assembly-path=../data/Pandora.Api.dll")
+	f.StringVar(&arguments.OutputDirectory, "output-dir", "", "--output-dir=../output")
 
 	if err := f.Parse(args); err != nil {
 		log.Fatalf("parsing arguments: %+v", err)

--- a/tools/wrapper-automation/models.go
+++ b/tools/wrapper-automation/models.go
@@ -16,16 +16,18 @@ type Arguments struct {
 }
 
 func (a Arguments) Validate() error {
-	if a.DataApiAssemblyPath == "" {
-		return fmt.Errorf("missing 'data-api-assembly-path'")
-	}
-
-	if _, err := os.Stat(a.DataApiAssemblyPath); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("the Data API Assembly doesn't exist at %q", a.DataApiAssemblyPath)
+	if !a.UseV2Generator {
+		if a.DataApiAssemblyPath == "" {
+			return fmt.Errorf("missing 'data-api-assembly-path'")
 		}
 
-		return fmt.Errorf("validating Data API Assembly exists: %+v", err)
+		if _, err := os.Stat(a.DataApiAssemblyPath); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("the Data API Assembly doesn't exist at %q", a.DataApiAssemblyPath)
+			}
+
+			return fmt.Errorf("validating Data API Assembly exists: %+v", err)
+		}
 	}
 
 	return nil

--- a/tools/wrapper-automation/models.go
+++ b/tools/wrapper-automation/models.go
@@ -43,7 +43,7 @@ func (a Arguments) Validate() error {
 	}
 
 	if a.ApiDefinitionsDirectory == "" && a.DataApiAssemblyPath == "" {
-		return fmt.Errorf("one of either 'api-definitions-directory' or 'data-api-assembly-path' must be specified")
+		return fmt.Errorf("one of either 'api-definitions-dir' or 'data-api-assembly-path' must be specified")
 	}
 
 	return nil

--- a/tools/wrapper-automation/rest_api_specs_importer.go
+++ b/tools/wrapper-automation/rest_api_specs_importer.go
@@ -23,7 +23,7 @@ func (c RestApiSpecsImporterCmd) Run(args []string) int {
 	}
 
 	f := flag.NewFlagSet("wrapper-automation", flag.ExitOnError)
-	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-directory", "", "--api-definitions-directory=./api-definitions")
+	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-dir", "", "--api-definitions-dir=./api-definitions")
 	f.StringVar(&arguments.DataApiAssemblyPath, "data-api-assembly-path", "", "-data-api-assembly-path=../data/Pandora.Api.dll")
 	f.StringVar(&arguments.OutputDirectory, "output-dir", "", "-output-dir=../output")
 

--- a/tools/wrapper-automation/rest_api_specs_importer.go
+++ b/tools/wrapper-automation/rest_api_specs_importer.go
@@ -23,6 +23,7 @@ func (c RestApiSpecsImporterCmd) Run(args []string) int {
 	}
 
 	f := flag.NewFlagSet("wrapper-automation", flag.ExitOnError)
+	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-directory", "", "--api-definitions-directory=./api-definitions")
 	f.StringVar(&arguments.DataApiAssemblyPath, "data-api-assembly-path", "", "-data-api-assembly-path=../data/Pandora.Api.dll")
 	f.StringVar(&arguments.OutputDirectory, "output-dir", "", "-output-dir=../output")
 

--- a/tools/wrapper-automation/run.go
+++ b/tools/wrapper-automation/run.go
@@ -17,7 +17,7 @@ func run(args Arguments) error {
 	// 1: Launch the Data API
 	var dataApi *exec.Cmd
 	if args.UseV2Generator {
-		dataApi = exec.Command(args.DataApiAssemblyPath, "serve")
+		dataApi = exec.Command("data-api", "serve")
 	} else {
 		dataApi = exec.Command("dotnet", args.DataApiAssemblyPath)
 	}

--- a/tools/wrapper-automation/run.go
+++ b/tools/wrapper-automation/run.go
@@ -15,10 +15,9 @@ func run(args Arguments) error {
 	}
 
 	// 1: Launch the Data API
-	var dataApi *exec.Cmd
-	if args.UseV2Generator {
-		dataApi = exec.Command("data-api", "serve")
-	} else {
+	dataApi := exec.Command("data-api", "serve", fmt.Sprintf("--data-directory=%s", args.ApiDefinitionsDirectory))
+	if args.DataApiAssemblyPath != "" {
+		// Data API v1
 		dataApi = exec.Command("dotnet", args.DataApiAssemblyPath)
 	}
 	env := os.Environ()

--- a/tools/wrapper-automation/terraform_generator.go
+++ b/tools/wrapper-automation/terraform_generator.go
@@ -23,9 +23,9 @@ func (c TerraformCmd) Run(args []string) int {
 	}
 
 	f := flag.NewFlagSet("wrapper-automation", flag.ExitOnError)
-	f.StringVar(&arguments.DataApiAssemblyPath, "data-api-assembly-path", "", "-data-api-assembly-path=../data/Pandora.Api.dll")
-	f.StringVar(&arguments.OutputDirectory, "output-dir", "", "-output-dir=../output")
-	f.BoolVar(&arguments.UseV2Generator, "use-v2-generator", false, "-use-v2-generator=true")
+	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-directory", "", "--api-definitions-directory=./api-definitions")
+	f.StringVar(&arguments.DataApiAssemblyPath, "data-api-assembly-path", "", "--data-api-assembly-path=../data/Pandora.Api.dll")
+	f.StringVar(&arguments.OutputDirectory, "output-dir", "", "--output-dir=../output")
 
 	if err := f.Parse(args); err != nil {
 		log.Fatalf("parsing arguments: %+v", err)

--- a/tools/wrapper-automation/terraform_generator.go
+++ b/tools/wrapper-automation/terraform_generator.go
@@ -23,7 +23,7 @@ func (c TerraformCmd) Run(args []string) int {
 	}
 
 	f := flag.NewFlagSet("wrapper-automation", flag.ExitOnError)
-	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-directory", "", "--api-definitions-directory=./api-definitions")
+	f.StringVar(&arguments.ApiDefinitionsDirectory, "api-definitions-dir", "", "--api-definitions-dir=./api-definitions")
 	f.StringVar(&arguments.DataApiAssemblyPath, "data-api-assembly-path", "", "--data-api-assembly-path=../data/Pandora.Api.dll")
 	f.StringVar(&arguments.OutputDirectory, "output-dir", "", "--output-dir=../output")
 


### PR DESCRIPTION
This PR also updates the way the `data-api` tool is built and launched to match the way the `generator-go-sdk` and `generator-terraform` tools are built/launched (that is, installing them onto the `$GOPATH`) - meaning that the shell scripts contain all of the dependencies needed to launch the Data API v2. This means that the process is now fully reproducible with a fresh checkout, which makes debugging issues simpler.

Notably as a part of doing this the `wrapper-automation` tool now takes the path to the API Definitions directory, matching the behaviour of Data API V2.

Finally this PR cleans up the Github Action for the Go SDK Generator, so that we no longer build V1 of the Data API (since this is no longer using it).