### PR TITLE
`tools/importer-rest-api-specs`: adding a data workaround for `Azure/azure-rest-api-specs#27351` / importing `BotService` @ `2022-09-15`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -71,6 +71,10 @@ service "blueprint" {
   name      = "Blueprints"
   available = ["2018-11-01-preview"]
 }
+service "botservice" {
+  name      = "BotService"
+  available = ["2022-09-15"]
+}
 service "chaos" {
   name      = "ChaosStudio"
   available = ["2023-04-15-preview", "2023-11-01", "2024-01-01"]

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
@@ -1,0 +1,72 @@
+package dataworkarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundBotService27351{}
+
+type workaroundBotService27351 struct {
+}
+
+func (workaroundBotService27351) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	// This workaround fixes an issue where the BotService Channel URI is defined using two subtly different Resource IDs.
+	// Fix: https://github.com/Azure/azure-rest-api-specs/pull/27351
+	//
+	// The DELETE and GET define the Uri Parameter `channelName` as a String - whereas the PATCH and POST define it as
+	// a Constant.
+	// The result of this is that whilst we switch out the Resource ID for a Common ID, this inconsistency means we end up
+	// with 2 different Resource IDs in the output, the Common ID (`BotServiceChannelId`) using a Constant Segment and another
+	// Resource ID (`ChannelId`) using a String segment.
+	//
+	// As such this workaround fixes this issue by normalizing the resulting output - since these are the same endpoint/should
+	// support the same values for this URI Segment.
+	serviceMatches := apiDefinition.ServiceName == "BotService"
+	apiVersions := map[string]struct{}{
+		"2021-05-01-preview": {},
+		"2022-06-15-preview": {},
+		"2023-09-15-preview": {},
+		"2020-06-02":         {},
+		"2021-03-01":         {},
+		"2022-09-15":         {},
+	}
+	_, apiVersionMatches := apiVersions[apiDefinition.ApiVersion]
+	return serviceMatches && apiVersionMatches
+}
+
+func (workaroundBotService27351) Name() string {
+	return "BotService / 27351"
+}
+
+func (workaroundBotService27351) Process(input models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	output := input
+
+	resource, ok := output.Resources["Channel"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `Channel` but didn't get one")
+	}
+	// ensure we've got the Resource ID we're going to switch over to
+	if _, ok := resource.ResourceIds["BotServiceChannelId"]; !ok {
+		return nil, fmt.Errorf("expected a Resource ID named `BotServiceChannelId` but didn't get one")
+	}
+
+	// ensure we've got the mismatched Resource ID in order to remove it
+	if _, ok := resource.ResourceIds["ChannelId"]; !ok {
+		return nil, fmt.Errorf("expected a Resource ID named `ChannelId` but didn't get one")
+	}
+	delete(resource.ResourceIds, "ChannelId")
+
+	for operationName, operation := range resource.Operations {
+		if operation.ResourceIdName != nil && *operation.ResourceIdName == "ChannelId" {
+			operation.ResourceIdName = pointer.To("BotServiceChannelId")
+		}
+		resource.Operations[operationName] = operation
+	}
+
+	output.Resources["Channel"] = resource
+
+	return &output, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -13,6 +13,7 @@ var workarounds = []workaround{
 	workaroundAutomation25108{},
 	workaroundAutomation25435{},
 	workaroundBatch21291{},
+	workaroundBotService27351{},
 	workaroundContainerService21394{},
 	workaroundDataFactory23013{},
 	workaroundDevCenter26189{},
@@ -20,7 +21,6 @@ var workarounds = []workaround{
 	workaroundLoadTest20961{},
 	workaroundRedis22407{},
 	workaroundMachineLearning25142{},
-
 	workaroundRecoveryServicesSiteRecovery26680{},
 
 	// @tombuildsstuff: this is an odd place for this however this allows working around inconsistencies in the Swagger

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service_channel.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service_channel.go
@@ -13,7 +13,33 @@ func (commonIdBotServiceChannel) id() models.ParsedResourceId {
 	name := "BotServiceChannel"
 	return models.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]resourcemanager.ConstantDetails{
+			"BotServiceChannelType": {
+				CaseInsensitive: false,
+				Type:            resourcemanager.StringConstant,
+				Values: map[string]string{
+					"AcsChatChannel":          "AcsChatChannel",
+					"AlexaChannel":            "AlexaChannel",
+					"DirectLineChannel":       "DirectLineChannel",
+					"DirectLineSpeechChannel": "DirectLineSpeechChannel",
+					"EmailChannel":            "EmailChannel",
+					"KikChannel":              "KikChannel",
+					"FacebookChannel":         "FacebookChannel",
+					"LineChannel":             "LineChannel",
+					"M365Extensions":          "M365Extensions",
+					"MsTeamsChannel":          "MsTeamsChannel",
+					"Omnichannel":             "Omnichannel",
+					"OutlookChannel":          "OutlookChannel",
+					"SearchAssistant":         "SearchAssistant",
+					"SkypeChannel":            "SkypeChannel",
+					"SlackChannel":            "SlackChannel",
+					"SmsChannel":              "SmsChannel",
+					"TelegramChannel":         "TelegramChannel",
+					"TelephonyChannel":        "TelephonyChannel",
+					"WebChatChannel":          "WebChatChannel",
+				},
+			},
+		},
 		Segments: []resourcemanager.ResourceIdSegment{
 			models.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
 			models.SubscriptionIDResourceIDSegment("subscriptionId"),


### PR DESCRIPTION
This PR adds a data workaround for https://github.com/Azure/azure-rest-api-specs/pull/27351 which enables importing `BotService` @ `2022-09-15`.

The Swagger defines the same Path with different types of segments depending on the HTTP Method, where the DELETE and GET operations use a String segment - but the PATCH and POST operations use a Constant segment - meaning that whilst we detect the Common ID (using the Constant segments) it's inconsistent).

Related: https://github.com/hashicorp/go-azure-helpers/pull/203