### PR TITLE
`tools/importer-rest-api-specs`: support for pulling the Display Name for an Integer Constant if defined

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/constants_test.go
+++ b/tools/importer-rest-api-specs/components/parser/constants_test.go
@@ -108,6 +108,101 @@ func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 	}
 }
 
+func TestParseConstantsIntegersTopLevelAsIntsWithDisplayName(t *testing.T) {
+	// This is an Integer Enum where there's a (Display) Name listed for the integer
+	// so we should be using `Name (string): Value (integer`)
+	result, err := ParseSwaggerFileForTesting(t, "constants_integers_with_names.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	resource, ok := result.Resources["Discriminator"]
+	if !ok {
+		t.Fatal("the Resource 'Discriminator' was not found")
+	}
+
+	// sanity checking
+	if len(resource.Constants) != 1 {
+		t.Fatalf("expected 1 constant but got %d", len(resource.Constants))
+	}
+	if len(resource.Models) != 2 {
+		t.Fatalf("expected 2 models but got %d", len(resource.Models))
+	}
+	if len(resource.Operations) != 1 {
+		t.Fatalf("expected 1 operation but got %d", len(resource.Operations))
+	}
+	if len(resource.ResourceIds) != 1 {
+		t.Fatalf("expected 1 Resource ID but got %d", len(resource.ResourceIds))
+	}
+
+	wrapper, ok := resource.Models["ExampleWrapper"]
+	if !ok {
+		t.Fatalf("the Model `ExampleWrapper` was not found")
+	}
+	if len(wrapper.Fields) != 2 {
+		t.Fatalf("expected wrapper.Fields to have 2 fields but got %d", len(wrapper.Fields))
+	}
+
+	person, ok := resource.Models["Person"]
+	if !ok {
+		t.Fatalf("the Model `Person` was not found")
+	}
+	if len(person.Fields) != 1 {
+		t.Fatalf("expected person.Fields to have 1 field but got %d", len(person.Fields))
+	}
+	favouriteTableField, ok := person.Fields["FavouriteTable"]
+	if !ok {
+		t.Fatal("animal.Fields['FavouriteTable'] did not exist")
+	}
+	if favouriteTableField.ObjectDefinition == nil {
+		t.Fatal("animal.Fields['FavouriteTable'] had a nil ObjectDefinition")
+	}
+	if favouriteTableField.ObjectDefinition.Type != models.ObjectDefinitionReference {
+		t.Fatalf("animal.Fields['FavouriteTable'] should be a Reference but got %q", string(favouriteTableField.ObjectDefinition.Type))
+	}
+	if *favouriteTableField.ObjectDefinition.ReferenceName != "TableNumber" {
+		t.Fatalf("animal.Fields['FavouriteTable'] should be 'FavouriteTable' but was %q", *favouriteTableField.ObjectDefinition.ReferenceName)
+	}
+
+	favouriteTable, ok := resource.Constants["TableNumber"]
+	if !ok {
+		t.Fatalf("resource.Constants['TableNumber'] was not found")
+	}
+	if favouriteTable.Type != resourcemanager.IntegerConstant {
+		t.Fatalf("expected resource.Constants['TableNumber'].Type to be 'Integer' but got %q", favouriteTable.Type)
+	}
+	if len(favouriteTable.Values) != 3 {
+		t.Fatalf("expected resource.Constants['TableNumber'] to have 3 values but got %d", len(favouriteTable.Values))
+	}
+	v, ok := favouriteTable.Values["First"]
+	if !ok {
+		t.Fatalf("resource.Constants['TableNumber'] didn't contain the key 'First'")
+	}
+	if v != "1" {
+		t.Fatalf("expected the value for resource.Constants['TableNumber'].Values['First'] to be '1' but got %q", v)
+	}
+	v, ok = favouriteTable.Values["Second"]
+	if !ok {
+		t.Fatalf("resource.Constants['TableNumber'] didn't contain the key 'Second'")
+	}
+	if v != "2" {
+		t.Fatalf("expected the value for resource.Constants['TableNumber'].Values['Second'] to be '2' but got %q", v)
+	}
+	v, ok = favouriteTable.Values["Third"]
+	if !ok {
+		t.Fatalf("resource.Constants['TableNumber'] didn't contain the key 'Third'")
+	}
+	if v != "3" {
+		t.Fatalf("expected the value for resource.Constants['TableNumber'].Values['Third'] to be '3' but got %q", v)
+	}
+}
+
 func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 	// Tests an Integer Constant with modelAsString, which is bad data / should be ignored
 	result, err := ParseSwaggerFileForTesting(t, "constants_integers_as_strings.json")
@@ -293,6 +388,101 @@ func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 	}
 	if v != "3" {
 		t.Fatalf("expected the value for resource.Constants['TableNumber'].Values['Three'] to be '3' but got %q", v)
+	}
+}
+
+func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
+	// This is an Integer Enum where there's a (Display) Name listed for the integer
+	// so we should be using `Name (string): Value (integer`)
+	result, err := ParseSwaggerFileForTesting(t, "constants_integers_with_names_inlined.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	resource, ok := result.Resources["Discriminator"]
+	if !ok {
+		t.Fatal("the Resource 'Discriminator' was not found")
+	}
+
+	// sanity checking
+	if len(resource.Constants) != 1 {
+		t.Fatalf("expected 1 constant but got %d", len(resource.Constants))
+	}
+	if len(resource.Models) != 2 {
+		t.Fatalf("expected 2 models but got %d", len(resource.Models))
+	}
+	if len(resource.Operations) != 1 {
+		t.Fatalf("expected 1 operation but got %d", len(resource.Operations))
+	}
+	if len(resource.ResourceIds) != 1 {
+		t.Fatalf("expected 1 Resource ID but got %d", len(resource.ResourceIds))
+	}
+
+	wrapper, ok := resource.Models["ExampleWrapper"]
+	if !ok {
+		t.Fatalf("the Model `ExampleWrapper` was not found")
+	}
+	if len(wrapper.Fields) != 2 {
+		t.Fatalf("expected wrapper.Fields to have 2 fields but got %d", len(wrapper.Fields))
+	}
+
+	person, ok := resource.Models["Person"]
+	if !ok {
+		t.Fatalf("the Model `Person` was not found")
+	}
+	if len(person.Fields) != 1 {
+		t.Fatalf("expected person.Fields to have 1 field but got %d", len(person.Fields))
+	}
+	favouriteTableField, ok := person.Fields["FavouriteTable"]
+	if !ok {
+		t.Fatal("animal.Fields['FavouriteTable'] did not exist")
+	}
+	if favouriteTableField.ObjectDefinition == nil {
+		t.Fatal("animal.Fields['FavouriteTable'] had a nil ObjectDefinition")
+	}
+	if favouriteTableField.ObjectDefinition.Type != models.ObjectDefinitionReference {
+		t.Fatalf("animal.Fields['FavouriteTable'] should be a Reference but got %q", string(favouriteTableField.ObjectDefinition.Type))
+	}
+	if *favouriteTableField.ObjectDefinition.ReferenceName != "TableNumber" {
+		t.Fatalf("animal.Fields['FavouriteTable'] should be 'FavouriteTable' but was %q", *favouriteTableField.ObjectDefinition.ReferenceName)
+	}
+
+	favouriteTable, ok := resource.Constants["TableNumber"]
+	if !ok {
+		t.Fatalf("resource.Constants['TableNumber'] was not found")
+	}
+	if favouriteTable.Type != resourcemanager.IntegerConstant {
+		t.Fatalf("expected resource.Constants['TableNumber'].Type to be 'Integer' but got %q", favouriteTable.Type)
+	}
+	if len(favouriteTable.Values) != 3 {
+		t.Fatalf("expected resource.Constants['TableNumber'] to have 3 values but got %d", len(favouriteTable.Values))
+	}
+	v, ok := favouriteTable.Values["First"]
+	if !ok {
+		t.Fatalf("resource.Constants['TableNumber'] didn't contain the key 'First'")
+	}
+	if v != "1" {
+		t.Fatalf("expected the value for resource.Constants['TableNumber'].Values['First'] to be '1' but got %q", v)
+	}
+	v, ok = favouriteTable.Values["Second"]
+	if !ok {
+		t.Fatalf("resource.Constants['TableNumber'] didn't contain the key 'Second'")
+	}
+	if v != "2" {
+		t.Fatalf("expected the value for resource.Constants['TableNumber'].Values['Second'] to be '2' but got %q", v)
+	}
+	v, ok = favouriteTable.Values["Third"]
+	if !ok {
+		t.Fatalf("resource.Constants['TableNumber'] didn't contain the key 'Third'")
+	}
+	if v != "3" {
+		t.Fatalf("expected the value for resource.Constants['TableNumber'].Values['Third'] to be '3' but got %q", v)
 	}
 }
 

--- a/tools/importer-rest-api-specs/components/parser/testdata/constants_integers_with_names.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/constants_integers_with_names.json
@@ -1,0 +1,149 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}": {
+      "put": {
+        "tags": [
+          "Discriminator"
+        ],
+        "operationId": "Discriminator_Test",
+        "description": "Tests parsing of a model containing a Constant",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExampleWrapper"
+            },
+            "description": "Wrapper class containing a Constant."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/ExampleWrapper"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ExampleWrapper": {
+      "description": "The Resource definition.",
+      "properties": {
+        "multiple": {
+          "description": "List of people.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "single": {
+          "$ref": "#/definitions/Person"
+        }
+      },
+      "required": [
+        "single"
+      ],
+      "title": "ExampleWrapper",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "Person": {
+      "properties": {
+        "favouriteTable": {
+          "description": "Preferred Table number.",
+          "$ref": "#/definitions/TableNumber"
+        }
+      },
+      "required": [
+        "favouriteTable"
+      ],
+      "title": "Person",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "TableNumber": {
+      "enum": [
+        1,
+        2,
+        3
+      ],
+      "type": "integer",
+      "x-ms-enum": {
+        "name": "TableNumber",
+        "modelAsString": false,
+        "values": [
+          {
+            "value": 1,
+            "name": "First",
+            "description": "First item."
+          },
+          {
+            "value": 2,
+            "name": "Second",
+            "description": "Second item."
+          },
+          {
+            "value": 3,
+            "name": "Third",
+            "description": "Third item."
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The API version to be used with the HTTP request."
+    },
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription ID."
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "The name of the resource group that contains the resource."
+    }
+  }
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/constants_integers_with_names_inlined.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/constants_integers_with_names_inlined.json
@@ -1,0 +1,146 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}": {
+      "put": {
+        "tags": [
+          "Discriminator"
+        ],
+        "operationId": "Discriminator_Test",
+        "description": "Tests parsing of a model containing a Constant",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExampleWrapper"
+            },
+            "description": "Wrapper class containing a Constant."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/ExampleWrapper"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ExampleWrapper": {
+      "description": "The Resource definition.",
+      "properties": {
+        "multiple": {
+          "description": "List of people.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "single": {
+          "$ref": "#/definitions/Person"
+        }
+      },
+      "required": [
+        "single"
+      ],
+      "title": "ExampleWrapper",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "Person": {
+      "properties": {
+        "favouriteTable": {
+          "description": "Preferred Table number.",
+          "enum": [
+            1,
+            2,
+            3
+          ],
+          "type": "integer",
+          "x-ms-enum": {
+            "name": "TableNumber",
+            "modelAsString": false,
+            "values": [
+              {
+                "value": 1,
+                "name": "First",
+                "description": "First item."
+              },
+              {
+                "value": 2,
+                "name": "Second",
+                "description": "Second item."
+              },
+              {
+                "value": 3,
+                "name": "Third",
+                "description": "Third item."
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "favouriteTable"
+      ],
+      "title": "Person",
+      "type": "object",
+      "x-ms-azure-resource": true
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The API version to be used with the HTTP request."
+    },
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription ID."
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "The name of the resource group that contains the resource."
+    }
+  }
+}


### PR DESCRIPTION
This commit fixes https://github.com/hashicorp/pandora/issues/3010 by checking for a Display Name within the `x-ms-enum` block and pulling from that if a (Display) Name is defined for an Integer constant.

Whilst I considered doing this for Float and String constants too, I've intentionally omitted those since Float constants are rare (so we can apply this same fix if needed down the line) - and for String constants there's little benefit to changing at this point, since we normalize a key from the value for the constant.

Ultimately this should ensure that when we import the constant `EmailChannelAuthMethod` for `BotService` that we output this as:

> `Password`: `0`
> `Graph`: `1`

Which is far more descriptive than:

> `Zero`: `0`
> `One`: `1`

---

There's a couple of changes to the existing data, but it's nothing major:

```diff
diff --git a/api-definitions/resource-manager/CosmosDB/2022-11-15/Mongorbacs/Constant-MongoRoleDefinitionType.json b/api-definitions/resource-manager/CosmosDB/2022-11-15/Mongorbacs/Constant-MongoRoleDefinitionType.json
index 6283a51ce7..0c3a0f9cf9 100644
--- a/api-definitions/resource-manager/CosmosDB/2022-11-15/Mongorbacs/Constant-MongoRoleDefinitionType.json
+++ b/api-definitions/resource-manager/CosmosDB/2022-11-15/Mongorbacs/Constant-MongoRoleDefinitionType.json
@@ -3,12 +3,12 @@
        "type": "Integer",
        "values": [
                {
-                       "key": "One",
-                       "value": "1"
+                       "key": "BuiltInRole",
+                       "value": "0"
                },
                {
-                       "key": "Zero",
-                       "value": "0"
+                       "key": "CustomRole",
+                       "value": "1"
                }
        ]
 }
\ No newline at end of file
diff --git a/api-definitions/resource-manager/MixedReality/2021-01-01/Key/Constant-Serial.json b/api-definitions/resource-manager/MixedReality/2021-01-01/Key/Constant-Serial.json
index f21186275a..1e385dd515 100644
--- a/api-definitions/resource-manager/MixedReality/2021-01-01/Key/Constant-Serial.json
+++ b/api-definitions/resource-manager/MixedReality/2021-01-01/Key/Constant-Serial.json
@@ -3,11 +3,11 @@
        "type": "Integer",
        "values": [
                {
-                       "key": "One",
+                       "key": "Primary",
                        "value": "1"
                },
                {
-                       "key": "Two",
+                       "key": "Secondary",
                        "value": "2"
                }
        ]
```