### PR TITLE
automation: disabling `Detect changes to the API Definitions` when `importer-rest-api-specs` changes

### DIFF
--- a/.github/workflows/automation-data-api-differ.yaml
+++ b/.github/workflows/automation-data-api-differ.yaml
@@ -8,7 +8,6 @@ on:
       - 'scripts/automation-determine-changes-to-api-definitions.sh' # to handle changes to the script
       - 'tools/data-api/**' # to detect changes when the Data API is updated
       - 'tools/data-api-differ/**' # to detect changes when the Data API Differ is updated
-      - 'tools/importer-rest-api-specs/**' # to detect changes when the Importer is updated
 
 jobs:
   detect-changes-to-the-api-definitions:


### PR DESCRIPTION
The API definitions aren't changed at this point (but might make sense for us to handle in the end-to-end test) as such I'm disabling this for now since this fails for forked PRs.