### PR TITLE
config: removing an older/unused version of `kusto`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -53,7 +53,7 @@ service "automation" {
 }
 service "azure-kusto" {
   name      = "Kusto"
-  available = ["2023-05-02", "2023-08-15"]
+  available = ["2023-08-15"]
 }
 service "azureactivedirectory" {
   name      = "AzureActiveDirectory"


### PR DESCRIPTION
Spotted this was unused when implementing https://github.com/hashicorp/terraform-provider-azurerm/pull/24477