### PR TITLE
`tools/generator-go-sdk`: updating `LoadTestService` and `ManagedIdentity` to use the new base layer

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -33,8 +33,6 @@ func main() {
 		// with services already used in `terraform-provider-azurerm`. These services will be gradually removed
 		// from this list to ensure they're migrated across to using `hashicorp/go-azure-sdk`s base layer.
 
-		// NOTE: also see the list in ./tools/generator-terraform/generator/definitions/template_service_client.go
-		// for services/resources which are auto-generated
 		"ContainerApps",
 		"ContainerInstance",
 		"CosmosDB",
@@ -58,9 +56,9 @@ func main() {
 		"Automation@2021-06-22",
 
 		// @tombuildsstuff: there's generated resources associated with these three - please check before removing these
+		// NOTE: also see the list in ./tools/generator-terraform/generator/definitions/template_service_client.go
+		// for services/resources which are auto-generated
 		"ContainerService",
-		"LoadTestService",
-		"ManagedIdentity",
 
 		// @tombuildsstuff: KeyVault requires that the exact casing retrieved from the API is re-sent back to the API
 		// as such will require custom work in the Provider (potentially a custom unmarshaller from the HTTP Body) to support this

--- a/tools/generator-terraform/generator/definitions/template_service_client.go
+++ b/tools/generator-terraform/generator/definitions/template_service_client.go
@@ -12,8 +12,6 @@ import (
 var servicesUsingOldBaseLayer = map[string]struct{}{
 	// these should be lower-cased
 	"containerservice": {},
-	"loadtestservice":  {},
-	"managedidentity":  {},
 }
 
 func templateForServiceClient(input models.ServiceInput) string {

--- a/tools/generator-terraform/generator/definitions/template_service_client.go
+++ b/tools/generator-terraform/generator/definitions/template_service_client.go
@@ -12,6 +12,9 @@ import (
 var servicesUsingOldBaseLayer = map[string]struct{}{
 	// these should be lower-cased
 	"containerservice": {},
+
+	// purely for testing purposes
+	"examplelegacypackage": {},
 }
 
 func templateForServiceClient(input models.ServiceInput) string {

--- a/tools/generator-terraform/generator/definitions/template_service_client_test.go
+++ b/tools/generator-terraform/generator/definitions/template_service_client_test.go
@@ -139,7 +139,7 @@ func TestTemplateForServiceClient_GoAutoRest(t *testing.T) {
 		ResourceToApiVersion: map[string]string{
 			"load_test_service_resource": "2015-11-01-preview",
 		},
-		SdkServiceName:     "loadtestservice",
+		SdkServiceName:     "examplelegacypackage",
 		ServicePackageName: "mypackage",
 	}
 	actual := templateForServiceClient(input)
@@ -148,16 +148,16 @@ package client
 
 import (
 	"github.com/Azure/go-autorest/autorest"
-	loadtestserviceV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2015-11-01-preview"
+	examplelegacypackageV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/examplelegacypackage/2015-11-01-preview"
 	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
 )
 
 type AutoClient struct {
-	V20151101Preview loadtestserviceV20151101Preview.Client
-	}
+	V20151101Preview examplelegacypackageV20151101Preview.Client
+}
 
 func NewClient(o *common.ClientOptions) (*AutoClient, error) {
-	v20151101PreviewClient := loadtestserviceV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
+	v20151101PreviewClient := examplelegacypackageV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
 		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 	return &AutoClient{
@@ -175,7 +175,7 @@ func TestTemplateForServiceClient_GoAutoRest_WithMultipleApiVersions(t *testing.
 			"load_test_service_one_resource": "2015-11-01-preview",
 			"load_test_service_two_resource": "2021-10-10",
 		},
-		SdkServiceName:     "loadtestservice",
+		SdkServiceName:     "examplelegacypackage",
 		ServicePackageName: "mypackage",
 	}
 	actual := templateForServiceClient(input)
@@ -184,21 +184,21 @@ package client
 
 import (
 	"github.com/Azure/go-autorest/autorest"
-	loadtestserviceV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2015-11-01-preview"
-	loadtestserviceV20211010 "github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2021-10-10"
+	examplelegacypackageV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/examplelegacypackage/2015-11-01-preview"
+	examplelegacypackageV20211010 "github.com/hashicorp/go-azure-sdk/resource-manager/examplelegacypackage/2021-10-10"
 	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
 )
 
 type AutoClient struct {
-	V20151101Preview loadtestserviceV20151101Preview.Client
-	V20211010 loadtestserviceV20211010.Client
-	}
+	V20151101Preview examplelegacypackageV20151101Preview.Client
+	V20211010 examplelegacypackageV20211010.Client
+}
 
 func NewClient(o *common.ClientOptions) (*AutoClient, error) {
-	v20151101PreviewClient := loadtestserviceV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
+	v20151101PreviewClient := examplelegacypackageV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
 		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
-	v20211010Client := loadtestserviceV20211010.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
+	v20211010Client := examplelegacypackageV20211010.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
 		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 	return &AutoClient{
@@ -217,7 +217,7 @@ func TestTemplateForServiceClient_GoAutoRest_WithMultipleResourcesAndOneApiVersi
 			"load_test_service_one_resource": "2015-11-01-preview",
 			"load_test_service_two_resource": "2015-11-01-preview",
 		},
-		SdkServiceName:     "loadtestservice",
+		SdkServiceName:     "examplelegacypackage",
 		ServicePackageName: "mypackage",
 	}
 	actual := templateForServiceClient(input)
@@ -226,16 +226,16 @@ package client
 
 import (
 	"github.com/Azure/go-autorest/autorest"
-	loadtestserviceV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2015-11-01-preview"
+	examplelegacypackageV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/examplelegacypackage/2015-11-01-preview"
 	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
 )
 
 type AutoClient struct {
-	V20151101Preview loadtestserviceV20151101Preview.Client
-	}
+	V20151101Preview examplelegacypackageV20151101Preview.Client
+}
 
 func NewClient(o *common.ClientOptions) (*AutoClient, error) {
-	v20151101PreviewClient := loadtestserviceV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
+	v20151101PreviewClient := examplelegacypackageV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
 		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 	return &AutoClient{


### PR DESCRIPTION
This also requires updating `generator-terraform` to account to account for that.

However - given these updates need to be coordinated - merging this change will (temporarily) break the `generator-terraform` automation, as the resulting code won't compile. This is because the SDK version vendored into `hashicorp/terraform-provider-azurerm` still uses the old base layer, as such the Go SDK will need to be released and then updated in `hashicorp/terraform-provider-azurerm` by hand - at which point the automation will work as usual.

Whilst it's possible to stagger the updates such that we released the Go SDK switching these two services over to the new base layer, and then did the same for the Terraform Provider - the end result is the same insofar as we'd end up needing to manually reconcile these - so I think the "least bad" thing to do for now is to keep this in a single PR and then roll this out.

---

I've intentionally opted to _not_ move `ContainerService` in this PR due to the size of the surface area/other open PR's - but we'll want to coordinate that one in time.