### PR TITLE
tools/data-api: fixing the mapping of Terraform specific objects

### DIFF
--- a/tools/data-api/internal/endpoints/v1/terraform_mappings.go
+++ b/tools/data-api/internal/endpoints/v1/terraform_mappings.go
@@ -2,59 +2,55 @@ package v1
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/data-api/internal/repositories"
 	"github.com/hashicorp/pandora/tools/data-api/models"
 )
 
-func mapSchemaModels(input *map[string]repositories.TerraformSchemaModelDefinition) (map[string]models.TerraformSchemaModelDefinition, error) {
-	if input == nil {
-		return nil, nil
-	}
+func mapSchemaModels(input map[string]repositories.TerraformSchemaModelDefinition) (*map[string]models.TerraformSchemaModelDefinition, error) {
+	output := make(map[string]models.TerraformSchemaModelDefinition)
 
-	output := make(map[string]models.TerraformSchemaModelDefinition, 0)
-
-	for name, model := range *input {
-		var modelDefinition models.TerraformSchemaModelDefinition
-
+	for name, model := range input {
 		fields, err := mapFields(model.Fields)
 		if err != nil {
 			return nil, fmt.Errorf("mapping fields for %s: %+v", name, err)
 		}
-		modelDefinition.Fields = fields
 
-		output[name] = modelDefinition
+		output[name] = models.TerraformSchemaModelDefinition{
+			Fields: *fields,
+		}
 	}
 
-	return output, nil
+	return &output, nil
 }
 
-func mapFields(input map[string]repositories.TerraformSchemaFieldDefinition) (map[string]models.TerraformSchemaFieldDefinition, error) {
-	output := make(map[string]models.TerraformSchemaFieldDefinition, 0)
+func mapFields(input map[string]repositories.TerraformSchemaFieldDefinition) (*map[string]models.TerraformSchemaFieldDefinition, error) {
+	output := make(map[string]models.TerraformSchemaFieldDefinition)
 
 	for name, field := range input {
-		fieldDefinition := models.TerraformSchemaFieldDefinition{
-			Computed: field.Computed,
-			ForceNew: field.ForceNew,
-			HclName:  field.HclName,
-			Optional: field.Optional,
-			Required: field.Required,
+		objectDefinition, err := mapTerraformObjectDefinition(field.ObjectDefinition)
+		if err != nil {
+			return nil, fmt.Errorf("mapping object definition for %q: %+v", name, err)
+		}
+		validation, err := mapValidation(field.Validation)
+		if err != nil {
+			return nil, fmt.Errorf("mapping validation for %q: %+v", name, err)
+		}
+
+		output[name] = models.TerraformSchemaFieldDefinition{
+			Computed:         field.Computed,
+			ForceNew:         field.ForceNew,
+			HclName:          field.HclName,
+			Optional:         field.Optional,
+			ObjectDefinition: *objectDefinition,
+			Required:         field.Required,
 			Documentation: models.TerraformSchemaDocumentationDefinition{
 				Markdown: field.Documentation.Markdown,
 			},
-			Validation: mapValidation(field.Validation),
+			Validation: validation,
 		}
-
-		objectDefinition, err := mapTerraformObjectDefinition(field.ObjectDefinition)
-		if err != nil {
-			return output, fmt.Errorf("mapping object definition for %s: %+v", name, err)
-		}
-		fieldDefinition.ObjectDefinition = objectDefinition
-
-		output[name] = fieldDefinition
 	}
 
-	return output, nil
+	return &output, nil
 }
 
 var terraformSchemaObjectDefinitionToTerraformFieldSchemaTypes = map[repositories.TerraformSchemaFieldType]models.TerraformSchemaFieldType{
@@ -62,85 +58,114 @@ var terraformSchemaObjectDefinitionToTerraformFieldSchemaTypes = map[repositorie
 	repositories.DateTimeTerraformSchemaObjectDefinitionType:                      models.TerraformSchemaFieldTypeDateTime,
 	repositories.DictionaryTerraformSchemaObjectDefinitionType:                    models.TerraformSchemaFieldTypeDictionary,
 	repositories.EdgeZoneTerraformSchemaObjectDefinitionType:                      models.TerraformSchemaFieldTypeEdgeZone,
-	repositories.SystemAssignedIdentityTerraformSchemaObjectDefinitionType:        models.TerraformSchemaFieldTypeIdentitySystemAssigned,
-	repositories.SystemAndUserAssignedIdentityTerraformSchemaObjectDefinitionType: models.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned,
-	repositories.SystemOrUserAssignedIdentityTerraformSchemaObjectDefinitionType:  models.TerraformSchemaFieldTypeIdentitySystemOrUserAssigned,
-	repositories.UserAssignedIdentityTerraformSchemaObjectDefinitionType:          models.TerraformSchemaFieldTypeIdentityUserAssigned,
-	repositories.LocationTerraformSchemaObjectDefinitionType:                      models.TerraformSchemaFieldTypeLocation,
 	repositories.FloatTerraformSchemaObjectDefinitionType:                         models.TerraformSchemaFieldTypeFloat,
 	repositories.IntegerTerraformSchemaObjectDefinitionType:                       models.TerraformSchemaFieldTypeInteger,
 	repositories.ListTerraformSchemaObjectDefinitionType:                          models.TerraformSchemaFieldTypeList,
+	repositories.LocationTerraformSchemaObjectDefinitionType:                      models.TerraformSchemaFieldTypeLocation,
 	repositories.ReferenceTerraformSchemaObjectDefinitionType:                     models.TerraformSchemaFieldTypeReference,
 	repositories.ResourceGroupTerraformSchemaObjectDefinitionType:                 models.TerraformSchemaFieldTypeResourceGroup,
 	repositories.SetTerraformSchemaObjectDefinitionType:                           models.TerraformSchemaFieldTypeSet,
-	repositories.StringTerraformSchemaFieldType:                                   models.TerraformSchemaFieldTypeString,
-	repositories.TagsTerraformSchemaObjectDefinitionType:                          models.TerraformSchemaFieldTypeTags,
 	repositories.SkuTerraformSchemaObjectDefinitionType:                           models.TerraformSchemaFieldTypeSku,
+	repositories.StringTerraformSchemaObjectDefinitionType:                        models.TerraformSchemaFieldTypeString,
+	repositories.SystemAssignedIdentityTerraformSchemaObjectDefinitionType:        models.TerraformSchemaFieldTypeIdentitySystemAssigned,
+	repositories.SystemAndUserAssignedIdentityTerraformSchemaObjectDefinitionType: models.TerraformSchemaFieldTypeIdentitySystemAndUserAssigned,
+	repositories.SystemOrUserAssignedIdentityTerraformSchemaObjectDefinitionType:  models.TerraformSchemaFieldTypeIdentitySystemOrUserAssigned,
+	repositories.TagsTerraformSchemaObjectDefinitionType:                          models.TerraformSchemaFieldTypeTags,
+	repositories.UserAssignedIdentityTerraformSchemaObjectDefinitionType:          models.TerraformSchemaFieldTypeIdentityUserAssigned,
 	repositories.ZoneTerraformSchemaObjectDefinitionType:                          models.TerraformSchemaFieldTypeZone,
 	repositories.ZonesTerraformSchemaObjectDefinitionType:                         models.TerraformSchemaFieldTypeZones,
 }
 
-func mapTerraformObjectDefinition(input repositories.TerraformSchemaFieldObjectDefinition) (models.TerraformSchemaFieldObjectDefinition, error) {
+func mapTerraformObjectDefinition(input repositories.TerraformSchemaFieldObjectDefinition) (*models.TerraformSchemaFieldObjectDefinition, error) {
 	output := models.TerraformSchemaFieldObjectDefinition{}
 
 	if input.NestedObject != nil {
 		nestedObject, err := mapTerraformObjectDefinition(*input.NestedObject)
 		if err != nil {
-			return output, err
+			return nil, err
 		}
-		output.NestedObject = pointer.To(nestedObject)
+		output.NestedObject = nestedObject
 	}
 	output.ReferenceName = input.ReferenceName
-	output.Type = models.TerraformSchemaFieldType(input.Type)
 
 	mapped, ok := terraformSchemaObjectDefinitionToTerraformFieldSchemaTypes[input.Type]
 	if !ok {
-		return output, fmt.Errorf("internal-error: missing mapping for Terraform Schema Field Type %q", string(input.Type))
+		return nil, fmt.Errorf("internal-error: missing mapping for Terraform Schema Field Type %q", string(input.Type))
 	}
 	output.Type = mapped
 
-	return output, nil
+	return &output, nil
 }
 
-func mapUpdateMethod(input *repositories.MethodDefinition) *models.MethodDefinition {
-	if input == nil {
-		return nil
-	}
-
-	return &models.MethodDefinition{
+func mapMethodDefinition(input repositories.MethodDefinition) models.MethodDefinition {
+	return models.MethodDefinition{
 		Generate:         input.Generate,
 		MethodName:       input.MethodName,
 		TimeoutInMinutes: input.TimeoutInMinutes,
 	}
 }
 
-func mapValidation(input *repositories.TerraformSchemaValidationDefinition) *models.TerraformSchemaValidationDefinition {
+var repositoryToApiResponseTerraformSchemaValidationType = map[repositories.TerraformSchemaValidationType]models.TerraformSchemaValidationType{
+	repositories.PossibleValuesTerraformSchemaValidationType: models.TerraformSchemaValidationTypePossibleValues,
+}
+
+var repositoryToApiResponseTerraformSchemaValidationPossibleValueType = map[repositories.TerraformSchemaValidationPossibleValueType]models.TerraformSchemaValidationPossibleValueType{
+	repositories.TerraformSchemaValidationPossibleValueTypeInt:    models.TerraformSchemaValidationPossibleValueTypeInt,
+	repositories.TerraformSchemaValidationPossibleValueTypeFloat:  models.TerraformSchemaValidationPossibleValueTypeFloat,
+	repositories.TerraformSchemaValidationPossibleValueTypeString: models.TerraformSchemaValidationPossibleValueTypeString,
+}
+
+func mapValidation(input *repositories.TerraformSchemaValidationDefinition) (*models.TerraformSchemaValidationDefinition, error) {
 	if input == nil {
-		return nil
+		return nil, nil
+	}
+
+	typeVal, ok := repositoryToApiResponseTerraformSchemaValidationType[input.Type]
+	if !ok {
+		return nil, fmt.Errorf("internal-error: missing mapping for `TerraformSchemaValidationType` %q", string(input.Type))
 	}
 
 	output := models.TerraformSchemaValidationDefinition{
-		Type:           models.TerraformSchemaValidationType(input.Type),
+		Type:           typeVal,
 		PossibleValues: nil,
 	}
 
-	possibleValues := models.TerraformSchemaValidationPossibleValuesDefinition{}
-
 	if input.PossibleValues != nil {
-		possibleValues.Type = models.TerraformSchemaValidationPossibleValueType(input.PossibleValues.Type)
-		possibleValues.Values = input.PossibleValues.Values
+		possibleTypesVal, ok := repositoryToApiResponseTerraformSchemaValidationPossibleValueType[input.PossibleValues.Type]
+		if !ok {
+			return nil, fmt.Errorf("internal-error: missing mapping for `TerraformSchemaValidationPossibleValueType` %q", string(input.PossibleValues.Type))
+		}
+
+		output.PossibleValues = &models.TerraformSchemaValidationPossibleValuesDefinition{
+			Type:   possibleTypesVal,
+			Values: input.PossibleValues.Values,
+		}
 	}
 
-	return &output
+	return &output, nil
 }
 
-func mapMappings(input repositories.MappingDefinition) models.MappingDefinition {
-	var output models.MappingDefinition
+var repositoryToApiResourceFieldMappingDefinitionType = map[repositories.MappingDefinitionType]models.MappingDefinitionType{
+	repositories.DirectAssignmentTerraformFieldMappingDefinitionType: models.DirectAssignmentMappingDefinitionType,
+	repositories.ModelToModelTerraformFieldMappingDefinitionType:     models.ModelToModelMappingDefinitionType,
+	repositories.ManualTerraformFieldMappingDefinitionType:           models.ManualMappingDefinitionType,
+}
 
-	fieldMappings := make([]models.FieldMappingDefinition, 0)
+func mapMappings(input repositories.MappingDefinition) (*models.MappingDefinition, error) {
+	output := models.MappingDefinition{
+		Fields:        make([]models.FieldMappingDefinition, 0),
+		ModelToModels: make([]models.ModelToModelMappingDefinition, 0),
+		ResourceId:    make([]models.ResourceIdMappingDefinition, 0),
+	}
+
 	for _, field := range input.Fields {
+		mappingType, ok := repositoryToApiResourceFieldMappingDefinitionType[field.Type]
+		if !ok {
+			return nil, fmt.Errorf("internal-error: missing mapping for `MappingDefinitionType` %q", string(field.Type))
+		}
+
 		fieldMapping := models.FieldMappingDefinition{
-			Type: models.MappingDefinitionType(field.Type),
+			Type: mappingType,
 		}
 
 		if field.DirectAssignment != nil {
@@ -150,6 +175,8 @@ func mapMappings(input repositories.MappingDefinition) models.MappingDefinition 
 				SdkModelName:    field.DirectAssignment.SdkModelName,
 				SdkFieldPath:    field.DirectAssignment.SdkFieldPath,
 			}
+			output.Fields = append(output.Fields, fieldMapping)
+			continue
 		}
 
 		if field.ModelToModel != nil {
@@ -158,42 +185,39 @@ func mapMappings(input repositories.MappingDefinition) models.MappingDefinition 
 				SdkModelName:    field.ModelToModel.SdkModelName,
 				SdkFieldName:    field.ModelToModel.SdkFieldName,
 			}
+			output.Fields = append(output.Fields, fieldMapping)
+			continue
 		}
 
 		if field.Manual != nil {
 			fieldMapping.Manual = &models.FieldManualMappingDefinition{
 				MethodName: field.Manual.MethodName,
 			}
+			output.Fields = append(output.Fields, fieldMapping)
+			continue
 		}
 
-		fieldMappings = append(fieldMappings, fieldMapping)
+		return nil, fmt.Errorf("internal-error: unimplemented mapping type %q", string(field.Type))
 	}
-	output.Fields = fieldMappings
 
 	if input.ResourceId != nil {
-		resourceIds := make([]models.ResourceIdMappingDefinition, 0)
 		for _, id := range input.ResourceId {
-			resourceIds = append(resourceIds, models.ResourceIdMappingDefinition{
+			output.ResourceId = append(output.ResourceId, models.ResourceIdMappingDefinition{
 				SchemaFieldName:    id.SchemaFieldName,
 				SegmentName:        id.SegmentName,
 				ParsedFromParentID: id.ParsedFromParentID,
 			})
 		}
-
-		output.ResourceId = resourceIds
 	}
 
 	if input.ModelToModels != nil {
-		modelToModels := make([]models.ModelToModelMappingDefinition, 0)
 		for _, modelToModelMapping := range input.ModelToModels {
-			modelToModels = append(modelToModels, models.ModelToModelMappingDefinition{
+			output.ModelToModels = append(output.ModelToModels, models.ModelToModelMappingDefinition{
 				SchemaModelName: modelToModelMapping.SchemaModelName,
 				SdkModelName:    modelToModelMapping.SdkModelName,
 			})
 		}
-
-		output.ModelToModels = modelToModels
 	}
 
-	return output
+	return &output, nil
 }

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -843,7 +843,6 @@ func parseTerraformDefinitionResourceSchemaFromFilePath(resourcePath string, fil
 	}
 
 	var schemaModel dataapimodels.TerraformSchemaModel
-
 	if err := json.Unmarshal(*contents, &schemaModel); err != nil {
 		return input, fmt.Errorf("unmarshaling Terraform Resource Schema %+v", err)
 	}

--- a/tools/data-api/internal/repositories/terraform_models.go
+++ b/tools/data-api/internal/repositories/terraform_models.go
@@ -1,9 +1,5 @@
 package repositories
 
-const (
-	StringTerraformSchemaFieldType TerraformSchemaFieldType = "String"
-)
-
 type TerraformDetails struct {
 	DataSources map[string]TerraformDataSourceDetails
 	Resources   map[string]TerraformResourceDetails
@@ -208,6 +204,12 @@ type TerraformSchemaDocumentationDefinition struct {
 }
 
 type TerraformSchemaValidationPossibleValueType string
+
+const (
+	TerraformSchemaValidationPossibleValueTypeFloat  TerraformSchemaValidationPossibleValueType = "Float"
+	TerraformSchemaValidationPossibleValueTypeInt    TerraformSchemaValidationPossibleValueType = "Int"
+	TerraformSchemaValidationPossibleValueTypeString TerraformSchemaValidationPossibleValueType = "String"
+)
 
 type TerraformSchemaValidationPossibleValuesDefinition struct {
 	Type   TerraformSchemaValidationPossibleValueType


### PR DESCRIPTION
This updates the mapping logic so that we return a pointer to a map as the result of the function, rather than a map directly - this allows us to differentiate between unset (e.g. an error has occurred) and when a value exists - which fixes the root cause of https://github.com/hashicorp/pandora/pull/3628 (and means that downstream tooling can avoid nil-checking these)

This PR also adds some additional mappings for the `repository` types to the types used for the API responses rather than string casting - since string casting in Go will map the cast the literal value (which'll always be valid) meaning that we wouldn't necessarily map the value we're defining across.