### PR TITLE
tools/importer-rest-api-specs: extending the workaround for https://github.com/Azure/azure-rest-api-specs/pull/27351 to account for the constant being incorrectly defined

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 var _ workaround = workaroundBotService27351{}
@@ -65,6 +66,14 @@ func (workaroundBotService27351) Process(input models.AzureApiDefinition) (*mode
 		}
 		resource.Operations[operationName] = operation
 	}
+
+	// ensure the Constant `EmailChannelAuthMethod` is updated to be an Integer rather than a Float
+	constant, ok := resource.Constants["EmailChannelAuthMethod"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Constant named `EmailChannelAuthMethod` but didn't get one")
+	}
+	constant.Type = resourcemanager.IntegerConstant
+	resource.Constants["EmailChannelAuthMethod"] = constant
 
 	output.Resources["Channel"] = resource
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/pandora/pull/3635/files#diff-dbffa561a5c7eb7b00c278bb4fcdc7fc2098a3b70bf572d6f119d32dc9fd1aaaR3

This should be explicitly defined as an integer, since `number` (without an explicit `format`) means float.