### PR TITLE
`tools/generator-go-sdk`: fixing support for top-level discriminated lists in the new base layer

### DIFF
--- a/tools/generator-go-sdk/generator/templater_methods_test.go
+++ b/tools/generator-go-sdk/generator/templater_methods_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -330,6 +331,160 @@ func (c pandaClient) RebootThenPoll(ctx context.Context , id PandaPop) error {
 // * When the Response Object is a Model or a List (of a Model) we include support for predicate filtering.
 // * When the Response Object is a Simple Type (e.g. int/string) we don't.
 // As such these tests (whilst similar) cover the two different code paths.
+
+func TestTemplateMethodsListWithDiscriminatedType(t *testing.T) {
+	input := ServiceGeneratorData{
+		packageName:       "chubbyPandas",
+		serviceClientName: "pandaClient",
+		source:            AccTestLicenceType,
+		models: map[string]resourcemanager.ModelDetails{
+			"Bottle": {
+				Fields: map[string]resourcemanager.FieldDetails{
+					"Type": {
+						ObjectDefinition: resourcemanager.ApiObjectDefinition{
+							Type: resourcemanager.StringApiObjectDefinitionType,
+						},
+						Required: true,
+					},
+				},
+				ParentTypeName: nil,
+				TypeHintIn:     pointer.To("Type"),
+				TypeHintValue:  nil,
+			},
+			"MilkBottle": {
+				Fields: map[string]resourcemanager.FieldDetails{
+					"Size": {
+						ObjectDefinition: resourcemanager.ApiObjectDefinition{
+							Type: resourcemanager.StringApiObjectDefinitionType,
+						},
+						Required: true,
+					},
+				},
+				ParentTypeName: pointer.To("Bottle"),
+				TypeHintIn:     pointer.To("Type"),
+				TypeHintValue:  pointer.To("Milk"),
+			},
+		},
+		resourceIds: map[string]resourcemanager.ResourceIdDefinition{
+			"PandaPop": {
+				Id: "LingLing",
+			},
+		},
+	}
+
+	actual, err := methodsPandoraTemplater{
+		operation: resourcemanager.ApiOperation{
+			ExpectedStatusCodes:              []int{200},
+			FieldContainingPaginationDetails: stringPointer("nextLink"),
+			Method:                           "GET",
+			ResponseObject: &resourcemanager.ApiObjectDefinition{
+				Type:          resourcemanager.ReferenceApiObjectDefinitionType,
+				ReferenceName: stringPointer("Bottle"),
+			},
+			ResourceIdName: stringPointer("PandaPop"),
+			UriSuffix:      stringPointer("/pandas"),
+		},
+		operationName: "List",
+	}.listOperationTemplate(input)
+
+	if err != nil {
+		t.Fatalf("err %+v", err)
+	}
+
+	expected := fmt.Sprintf(`
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+    OData *odata.OData
+	Model *[]Bottle
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items []Bottle
+}
+
+// List ...
+func (c pandaClient) List(ctx context.Context , id PandaPop) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path: fmt.Sprintf("%%s/pandas", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]json.RawMessage %[1]s
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	temp := make([]Bottle, 0)
+	if values.Values != nil {
+		for i, v := range *values.Values {
+			val, err := unmarshalBottleImplementation(v)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling item %%d for Bottle (%%q): %%+v", i, v, err)
+				return result, err
+			}
+			temp = append(temp, val)
+		}
+	}
+	result.Model = &temp
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c pandaClient) ListComplete(ctx context.Context, id PandaPop) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, BottleOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, id PandaPop, predicate BottleOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]Bottle, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %%+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items: items,
+	}
+	return
+}
+`, "`json:\"value\"`")
+
+	assertTemplatedCodeMatches(t, expected, *actual)
+}
 
 func TestTemplateMethodsListWithSimpleType(t *testing.T) {
 


### PR DESCRIPTION
This PR fixes an issue in the new base layer where a list of Discriminated Types is returned from a (in this case, List) operation.

This mirrors the behaviour of the old base layer, by creating an intermediate slice to deserialize into, calling `unmarshal` on each of the items.

Fixes https://github.com/hashicorp/pandora/issues/3639
Unblocks https://github.com/hashicorp/terraform-provider-azurerm/pull/24481