### PR TITLE
`tools/data-api`: consolidating the `microsoft-graph` endpoints together

### DIFF
--- a/tools/data-api/internal/endpoints/routing.go
+++ b/tools/data-api/internal/endpoints/routing.go
@@ -12,23 +12,10 @@ import (
 func Router(directory string, serviceNames *[]string) func(chi.Router) {
 	return func(router chi.Router) {
 		router.Route("/v1", infrastructure.Router)
-		router.Route("/v1/microsoft-graph/beta", func(r chi.Router) {
+		router.Route("/v1/microsoft-graph", func(r chi.Router) {
 			opts := v1.Options{
-				ServiceType:     repositories.MicrosoftGraphV1BetaServiceType,
-				UriPrefix:       "/v1/microsoft-graph/beta",
-				UsesCommonTypes: true,
-			}
-			serviceRepo, err := repositories.NewServicesRepository(directory, opts.ServiceType, serviceNames)
-			if err != nil {
-				// TODO logging
-				log.Fatalf("Error: %+v", err)
-			}
-			v1.Router(r, opts, serviceRepo)
-		})
-		router.Route("/v1/microsoft-graph/stable-v1", func(r chi.Router) {
-			opts := v1.Options{
-				ServiceType:     repositories.MicrosoftGraphV1StableServiceType,
-				UriPrefix:       "/v1/microsoft-graph/stable-v1",
+				ServiceType:     repositories.MicrosoftGraphServiceType,
+				UriPrefix:       "/v1/microsoft-graph",
 				UsesCommonTypes: true,
 			}
 			serviceRepo, err := repositories.NewServicesRepository(directory, opts.ServiceType, serviceNames)

--- a/tools/data-api/internal/endpoints/routing.go
+++ b/tools/data-api/internal/endpoints/routing.go
@@ -11,7 +11,6 @@ import (
 
 func Router(directory string, serviceNames *[]string) func(chi.Router) {
 	return func(router chi.Router) {
-		router.Route("/infrastructure", infrastructure.Router)
 		router.Route("/v1", infrastructure.Router)
 		router.Route("/v1/microsoft-graph/beta", func(r chi.Router) {
 			opts := v1.Options{

--- a/tools/data-api/internal/repositories/models.go
+++ b/tools/data-api/internal/repositories/models.go
@@ -10,9 +10,8 @@ type ResourceIdSegmentType string
 type ServiceType string
 
 const (
-	MicrosoftGraphV1BetaServiceType   ServiceType = "microsoft-graph-beta"
-	MicrosoftGraphV1StableServiceType ServiceType = "microsoft-graph-v1-stable"
-	ResourceManagerServiceType        ServiceType = "resource-manager"
+	MicrosoftGraphServiceType  ServiceType = "microsoft-graph"
+	ResourceManagerServiceType ServiceType = "resource-manager"
 
 	HandWrittenApiDefinitionsSource                 ApiDefinitionSourceType = "HandWritten"
 	MicrosoftGraphMetadataApiDefinitionsSource      ApiDefinitionSourceType = "MicrosoftGraphMetadata"

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -63,16 +63,17 @@ func NewServicesRepository(directory string, serviceType ServiceType, serviceNam
 	// all service definitions for the specified service type, building a complete list of services as well as their directory paths
 	// to load from
 
-	var expectedDataSource dataapimodels.DataSource
-	if serviceType == ResourceManagerServiceType {
-		expectedDataSource = dataapimodels.AzureResourceManagerDataSource
+	dataSources := map[ServiceType]dataapimodels.DataSource{
+		MicrosoftGraphServiceType:  dataapimodels.MicrosoftGraphDataSource,
+		ResourceManagerServiceType: dataapimodels.AzureResourceManagerDataSource,
 	}
-	if serviceType == MicrosoftGraphV1StableServiceType {
-		expectedDataSource = dataapimodels.MicrosoftGraphDataSource
+	dataSource, ok := dataSources[serviceType]
+	if !ok {
+		return nil, fmt.Errorf("internal-error: unimplemented data source %q", string(serviceType))
 	}
 
 	repo := &ServicesRepositoryImpl{
-		expectedDataSource: expectedDataSource,
+		expectedDataSource: dataSource,
 		rootDirectory:      directory,
 		serviceNames:       serviceNames,
 		serviceType:        serviceType,

--- a/tools/data-api/internal/repositories/services_test.go
+++ b/tools/data-api/internal/repositories/services_test.go
@@ -16,12 +16,12 @@ func TestServices_ResourceManager(t *testing.T) {
 }
 
 func TestServices_MicrosoftGraph(t *testing.T) {
-	repo, err := NewServicesRepository("../../../../api-definitions/", MicrosoftGraphV1StableServiceType, nil)
+	repo, err := NewServicesRepository("../../../../api-definitions/", MicrosoftGraphServiceType, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 
-	if _, err := repo.GetAll(MicrosoftGraphV1StableServiceType); err != nil {
+	if _, err := repo.GetAll(MicrosoftGraphServiceType); err != nil {
 		t.Fatalf(err.Error())
 	}
 }

--- a/tools/sdk/resourcemanager/client.go
+++ b/tools/sdk/resourcemanager/client.go
@@ -18,22 +18,13 @@ type Client struct {
 	client *http.Client
 }
 
-func NewMicrosoftGraphBetaClient(endpoint string) Client {
+func NewMicrosoftGraphClient(endpoint string) Client {
 	return Client{
 		endpoint:    fmt.Sprintf("%s", endpoint),
-		apiEndpoint: "/v1/microsoft-graph/beta",
+		apiEndpoint: "/v1/microsoft-graph",
 		client:      retryablehttp.NewClient().StandardClient(),
 	}
 }
-
-func NewMicrosoftGraphStableV1Client(endpoint string) Client {
-	return Client{
-		endpoint:    fmt.Sprintf("%s", endpoint),
-		apiEndpoint: "/v1/microsoft-graph/stable-v1",
-		client:      retryablehttp.NewClient().StandardClient(),
-	}
-}
-
 func NewResourceManagerClient(endpoint string) Client {
 	return Client{
 		endpoint:    fmt.Sprintf("%s", endpoint),


### PR DESCRIPTION
Chatting with @manicminer - rather than having two separate Data Sources for `Beta` and `Stable V1` for Microsoft Graph, we're going to try and use the same versioning approach that Resource Manager does - that is `/v1/{DataSourceType}/{ServiceName}/{ApiVersion}/{ApiResource}` - e.g. `/v1/microsoft-graph/Applications/{beta|v1stable}/Application`.

As such this PR:

1. Consolidates `/v1/microsoft-graph/beta` and `/v1/microsoft-graph/stable-v1` into `/microsoft-graph`.
2. Updates the constants to reflect this.
3. Removes the unused `/infrastructure` endpoint (the SDK uses `/v1/health` rather than `/infrastructure/health`, so this is fine)