### PR TITLE
commonids - add common IDs for chaos studio capability and target

### DIFF
--- a/tools/data-api/internal/repositories/mappings.go
+++ b/tools/data-api/internal/repositories/mappings.go
@@ -166,3 +166,16 @@ func mapApiDefinitionSourceType(input dataapimodels.ApiDefinitionsSource) (*ApiD
 
 	return nil, fmt.Errorf("unmapped Definition Source Type %q", string(input))
 }
+
+func mapValidationPossibleValueTypes(input dataapimodels.TerraformSchemaValidationPossibleValuesType) (*TerraformSchemaValidationPossibleValueType, error) {
+	mappings := map[dataapimodels.TerraformSchemaValidationPossibleValuesType]TerraformSchemaValidationPossibleValueType{
+		dataapimodels.FloatTerraformSchemaValidationPossibleValuesType:   TerraformSchemaValidationPossibleValueTypeFloat,
+		dataapimodels.IntegerTerraformSchemaValidationPossibleValuesType: TerraformSchemaValidationPossibleValueTypeInt,
+		dataapimodels.StringTerraformSchemaValidationPossibleValuesType:  TerraformSchemaValidationPossibleValueTypeString,
+	}
+	if v, ok := mappings[input]; ok {
+		return &v, nil
+	}
+
+	return nil, fmt.Errorf("unmapped Validation Posssible Values Type %q", string(input))
+}

--- a/tools/data-api/internal/repositories/services.go
+++ b/tools/data-api/internal/repositories/services.go
@@ -864,9 +864,13 @@ func parseTerraformDefinitionResourceSchemaFromFilePath(resourcePath string, fil
 			}
 
 			if field.Validation.PossibleValues != nil {
+				valueType, err := mapValidationPossibleValueTypes(field.Validation.PossibleValues.Type)
+				if err != nil {
+					return input, err
+				}
 				fieldDefinition.Validation.PossibleValues = &TerraformSchemaValidationPossibleValuesDefinition{
-					Type:   fieldDefinition.Validation.PossibleValues.Type,
-					Values: fieldDefinition.Validation.PossibleValues.Values,
+					Type:   *valueType,
+					Values: field.Validation.PossibleValues.Values,
 				}
 			}
 		}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_capability.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_capability.go
@@ -1,0 +1,27 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdChaosStudioCapability{}
+
+type commonIdChaosStudioCapability struct{}
+
+func (commonIdChaosStudioCapability) id() models.ParsedResourceId {
+	name := "ChaosStudioCapability"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.ScopeResourceIDSegment("scope"),
+			models.StaticResourceIDSegment("staticProviders", "providers"),
+			models.ResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
+			models.StaticResourceIDSegment("staticTargets", "targets"),
+			models.UserSpecifiedResourceIDSegment("targetName"),
+			models.StaticResourceIDSegment("staticCapabilities", "capabilities"),
+			models.UserSpecifiedResourceIDSegment("capabilityName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_target.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_target.go
@@ -1,0 +1,25 @@
+package resourceids
+
+import (
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+var _ commonIdMatcher = commonIdChaosStudioTarget{}
+
+type commonIdChaosStudioTarget struct{}
+
+func (commonIdChaosStudioTarget) id() models.ParsedResourceId {
+	name := "ChaosStudioTarget"
+	return models.ParsedResourceId{
+		CommonAlias: &name,
+		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Segments: []resourcemanager.ResourceIdSegment{
+			models.ScopeResourceIDSegment("scope"),
+			models.StaticResourceIDSegment("staticProviders", "providers"),
+			models.ResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
+			models.StaticResourceIDSegment("staticTargets", "targets"),
+			models.UserSpecifiedResourceIDSegment("targetName"),
+		},
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -57,6 +57,10 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdBotService{},
 	commonIdBotServiceChannel{},
 
+	// Chaos
+	commonIdChaosStudioCapability{},
+	commonIdChaosStudioTarget{},
+
 	// Compute
 	commonIdAvailabilitySet{},
 	commonIdDedicatedHost{},

--- a/tools/importer-rest-api-specs/components/testing/attribute_value_for_field.go
+++ b/tools/importer-rest-api-specs/components/testing/attribute_value_for_field.go
@@ -147,6 +147,13 @@ var attributeValuesForBasicTypes = map[resourcemanager.TerraformSchemaFieldType]
 			return &val, nil
 		}
 
+		for k, v := range testData.Strings {
+			if strings.EqualFold(field.HclName, k) {
+				out := hclwrite.TokensForValue(cty.StringVal(v))
+				return &out, nil
+			}
+		}
+
 		if strings.EqualFold(field.HclName, "description") {
 			// Description for the Example Thing
 			out := hclwrite.TokensForValue(cty.StringVal(fmt.Sprintf("Description for the %s", resourceDisplayName)))

--- a/tools/importer-rest-api-specs/components/testing/attribute_value_for_field.go
+++ b/tools/importer-rest-api-specs/components/testing/attribute_value_for_field.go
@@ -148,7 +148,7 @@ var attributeValuesForBasicTypes = map[resourcemanager.TerraformSchemaFieldType]
 		}
 
 		for k, v := range testData.Strings {
-			if strings.EqualFold(field.HclName, k) {
+			if field.HclName == k {
 				out := hclwrite.TokensForValue(cty.StringVal(v))
 				return &out, nil
 			}

--- a/tools/importer-rest-api-specs/components/testing/complete.go
+++ b/tools/importer-rest-api-specs/components/testing/complete.go
@@ -13,6 +13,19 @@ func (tb TestBuilder) generateCompleteTest(dependencies *testDependencies) (*str
 	if !ok {
 		return nil, fmt.Errorf("the schema model %q was not found", tb.details.SchemaModelName)
 	}
+
+	completeRequired := false
+	for _, details := range topLevelModel.Fields {
+		if details.Required == false {
+			completeRequired = true
+			break
+		}
+	}
+
+	if !completeRequired {
+		return nil, nil
+	}
+
 	onlyRequiredFields := false // Compute should include all Required & Optional properties
 	block, err := tb.getBlockValueForModel("resource", topLevelModel, dependencies, onlyRequiredFields, tb.details.Tests.TestData.CompleteVariables)
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/testing/dependencies.go
+++ b/tools/importer-rest-api-specs/components/testing/dependencies.go
@@ -170,7 +170,7 @@ func DetermineDependencies(field, providerPrefix string, dependencies *testDepen
 		"subnet_id":                     {dependencies.setNeedsSubnet, fmt.Sprintf("%s_subnet.test.id", providerPrefix)},
 		"subscription_id":               {dependencies.setNeedsClientConfig, fmt.Sprintf("data.%s_client_config.test.subscription_id", providerPrefix)},
 		// Currently only Chaos Studio Targets has this property which can accept many different resource IDs
-		// for now setting this to storage is sufficient, but we will need to consider how to proceed in future
+		// for now setting this to kubernetes is sufficient, but we will need to consider how to proceed in future
 		"target_resource_id":        {dependencies.setNeedsKubernetesCluster, fmt.Sprintf("%s_kubernetes_cluster.test.id", providerPrefix)},
 		"tenant_id":                 {dependencies.setNeedsClientConfig, fmt.Sprintf("data.%s_client_config.test.tenant_id", providerPrefix)},
 		"user_assigned_identity_id": {dependencies.setNeedsUserAssignedIdentity, fmt.Sprintf("%s_user_assigned_identity.test.id", providerPrefix)},

--- a/tools/importer-rest-api-specs/components/testing/dependencies.go
+++ b/tools/importer-rest-api-specs/components/testing/dependencies.go
@@ -171,7 +171,7 @@ func DetermineDependencies(field, providerPrefix string, dependencies *testDepen
 		"subscription_id":               {dependencies.setNeedsClientConfig, fmt.Sprintf("data.%s_client_config.test.subscription_id", providerPrefix)},
 		// Currently only Chaos Studio Targets has this property which can accept many different resource IDs
 		// for now setting this to storage is sufficient, but we will need to consider how to proceed in future
-		"target_resource_id":        {dependencies.setNeedsStorageAccount, fmt.Sprintf("%s_storage_account.test.id", providerPrefix)},
+		"target_resource_id":        {dependencies.setNeedsKubernetesCluster, fmt.Sprintf("%s_kubernetes_cluster.test.id", providerPrefix)},
 		"tenant_id":                 {dependencies.setNeedsClientConfig, fmt.Sprintf("data.%s_client_config.test.tenant_id", providerPrefix)},
 		"user_assigned_identity_id": {dependencies.setNeedsUserAssignedIdentity, fmt.Sprintf("%s_user_assigned_identity.test.id", providerPrefix)},
 		"virtual_network_id":        {dependencies.setNeedsVirtualNetwork, fmt.Sprintf("%s_virtual_network.test.id", providerPrefix)},


### PR DESCRIPTION
This PR adds a common ID for Chaos Studio Capability and Target and also fixes the swapping out of test data for fields that have been renamed, as well as omits generation of the complete test configuration if all fields are Required.

Dependent on https://github.com/hashicorp/go-azure-sdk/pull/819