### PR TITLE
Config: Add `Microsoft.AzureStackHCI@2023-09-01-preview`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -61,7 +61,7 @@ service "azureactivedirectory" {
 }
 service "azurestackhci" {
   name      = "AzureStackHCI"
-  available = ["2023-03-01", "2023-06-01", "2023-08-01"]
+  available = ["2023-03-01", "2023-06-01", "2023-08-01", "2023-09-01-preview"]
 }
 service "batch" {
   name      = "Batch"


### PR DESCRIPTION
To onboard Arc VM on Azure Stack HCI, related doc can be found at [Create Arc virtual machines on Azure Stack HCI (preview)](https://learn.microsoft.com/en-us/azure-stack/hci/manage/create-arc-virtual-machines?tabs=azurecli)

The `2023-09-01-preview` is confirmed has no breaking changes in the future.

swagger: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/preview/2023-09-01-preview/virtualMachineInstances.json