### PR TITLE
`tools/generator-go-sdk`: adding a temporary opt-out of Constant Normalization for `KeyVault/{Version}/Vaults` when using the new base layer

### DIFF
--- a/tools/generator-go-sdk/generator/templater_constants.go
+++ b/tools/generator-go-sdk/generator/templater_constants.go
@@ -34,6 +34,25 @@ func (c constantsTemplater) template(data ServiceGeneratorData) (*string, error)
 		// rollout of the new base layer, to allow us to go gradually
 		generateNormalizationFunction := data.useNewBaseLayer
 
+		// TODO: remove this when https://github.com/hashicorp/pandora/issues/3229 has been resolved
+		if data.servicePackageName == "keyvault" && data.packageName == "vaults" {
+			// The Key Vault API requires that the EXACT casing sent in the Response is sent in the Request
+			// to remove a Key Vault Access Policy.
+			//
+			// We need to raise a Swagger issue to track this - however for the moment we can disable
+			// the Normalization of Constants when using the new base layer specifically for Key Vault.
+			//
+			// Whilst typically we would avoid special-casing this - the Key Vault API is starting to
+			// behave differently to how the legacy base layer expects - such as the issue described in
+			// https://github.com/hashicorp/terraform-provider-azurerm/pull/24449 - as such there's
+			// benefit to using the new base layer, but having Constant Normalization disabled in this
+			// one specific scenario.
+			//
+			// Which is to say, this shouldn't be done for other services - and is only a temporary fix
+			// until the upstream API issue is resolved.
+			generateNormalizationFunction = false
+		}
+
 		// used to reduce the TLOC being output
 		usedInAResourceId := false
 		for _, id := range data.resourceIds {


### PR DESCRIPTION
This PR introduces a Service and Package level opt-out of constant normalization for Key Vault.

This is required until https://github.com/hashicorp/pandora/issues/3229 is resolved - where the Azure API requires that the exact casing specified in the Response is sent in the Request to update or remove a Key Vault Access Policy - meaning that constant normalization breaks this.

This is an API bug which needs to be resolved - and wants an upstream issue to track that - however the API behaviour (specifically around LROs) is starting to differ from the behaviours defined in the old base layer - as such there's benefit to updating Key Vault to use the new base layer, and then normalizing the constants when the API is fixed.

This obviously isn't ideal, but feels pragmatic given the API behaviour is differing from what the existing LRO pollers are expecting - whilst allowing us a path forward to re-enable constant normalization once the API issues are resolved.

> NOTE: This PR doesn't update Key Vault to use the new base layer - but enables us to do so in a subsequent PR.

This change is currently a noop - but with Key Vault opted into the new base layer, the following `constants.go` files are updated:

```
 $ git status resource-manager/keyvault/**/**/constants.go
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   resource-manager/keyvault/2021-10-01/keys/constants.go
	modified:   resource-manager/keyvault/2021-10-01/managedhsms/constants.go
	modified:   resource-manager/keyvault/2021-10-01/mhsmlistprivateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2021-10-01/mhsmprivateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2021-10-01/mhsmprivatelinkresources/constants.go
	modified:   resource-manager/keyvault/2021-10-01/privateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2022-11-01/keys/constants.go
	modified:   resource-manager/keyvault/2022-11-01/managedhsmkeys/constants.go
	modified:   resource-manager/keyvault/2022-11-01/managedhsms/constants.go
	modified:   resource-manager/keyvault/2022-11-01/mhsmlistprivateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2022-11-01/mhsmprivateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2022-11-01/mhsmprivatelinkresources/constants.go
	modified:   resource-manager/keyvault/2022-11-01/privateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2023-02-01/keys/constants.go
	modified:   resource-manager/keyvault/2023-02-01/managedhsmkeys/constants.go
	modified:   resource-manager/keyvault/2023-02-01/managedhsms/constants.go
	modified:   resource-manager/keyvault/2023-02-01/mhsmlistprivateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2023-02-01/mhsmlistregions/constants.go
	modified:   resource-manager/keyvault/2023-02-01/mhsmprivateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2023-02-01/mhsmprivatelinkresources/constants.go
	modified:   resource-manager/keyvault/2023-02-01/privateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2023-07-01/keys/constants.go
	modified:   resource-manager/keyvault/2023-07-01/managedhsmkeys/constants.go
	modified:   resource-manager/keyvault/2023-07-01/managedhsms/constants.go
	modified:   resource-manager/keyvault/2023-07-01/mhsmlistprivateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2023-07-01/mhsmlistregions/constants.go
	modified:   resource-manager/keyvault/2023-07-01/mhsmprivateendpointconnections/constants.go
	modified:   resource-manager/keyvault/2023-07-01/mhsmprivatelinkresources/constants.go
	modified:   resource-manager/keyvault/2023-07-01/privateendpointconnections/constants.go
```