### PR TITLE
`keyvault`: `2023-07-01` uses the new base layer / removing unused API Versions

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -280,7 +280,7 @@ service "iotcentral" {
 }
 service "keyvault" {
   name      = "KeyVault"
-  available = ["2021-10-01", "2022-11-01", "2023-02-01", "2023-07-01"]
+  available = ["2023-02-01", "2023-07-01"]
 }
 service "kubernetesconfiguration" {
   name      = "KubernetesConfiguration"

--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -60,9 +60,14 @@ func main() {
 		// for services/resources which are auto-generated
 		"ContainerService",
 
-		// @tombuildsstuff: KeyVault requires that the exact casing retrieved from the API is re-sent back to the API
-		// as such will require custom work in the Provider (potentially a custom unmarshaller from the HTTP Body) to support this
-		"KeyVault",
+		// @tombuildsstuff: The Key Vault API has an issue where it requires that the EXACT casing returned in the Response
+		// is sent in the Request to update or remove a Key Vault Access Policy - and using other casings mean the update
+		// or removal fails - which is tracked in https://github.com/hashicorp/pandora/issues/3229.
+		//
+		// As such KeyVault has an opt-out of Constant Normalization when using the new base layer - details can be found
+		// in https://github.com/hashicorp/pandora/pull/3672 - however until that is removed Key Vault should be considered
+		// not fully using the new base layer, since it doesn't support Constant Normalization.
+		"KeyVault@2023-02-01",
 	)
 
 	var serviceNames string

--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -64,9 +64,8 @@ func main() {
 		// is sent in the Request to update or remove a Key Vault Access Policy - and using other casings mean the update
 		// or removal fails - which is tracked in https://github.com/hashicorp/pandora/issues/3229.
 		//
-		// As such KeyVault has an opt-out of Constant Normalization when using the new base layer - details can be found
-		// in https://github.com/hashicorp/pandora/pull/3672 - however until that is removed Key Vault should be considered
-		// not fully using the new base layer, since it doesn't support Constant Normalization.
+		// After testing it appears that `2023-07-01` doesn't suffer from this problem - as such we're going to leave
+                // `2023-02-01` on the older base layer and use the newer API Version as a divide to give us a clear migration path.
 		"KeyVault@2023-02-01",
 	)
 


### PR DESCRIPTION
This PR:

* Removes the now unused API Versions `2021-10-01` and `2022-11-01` for `KeyVault`
* Updates `KeyVault` API Version `2023-07-01` to use the new base layer

---

In creating an up-to-date repro for the Key Vault Constant casing issues, it appears that `2023-07-01` doesn't contain these issues - and whilst it's possible that earlier versions have been fixed - for the sake of a migration path this PR intentionally leaves `2023-02-01` on the older base layer - whilst allowing us a path to fixing some of the other open issues such as https://github.com/hashicorp/terraform-provider-azurerm/pull/24449