### PR TITLE
config: adding back in two versions of CosmosDB

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -121,7 +121,7 @@ service "containerservice" {
 }
 service "cosmos-db" {
   name      = "CosmosDB"
-  available = ["2023-04-15", "2023-09-15", "2023-11-15"]
+  available = ["2022-05-15", "2022-11-15", "2023-04-15", "2023-09-15", "2023-11-15"]
 }
 service "cost-management" {
   name      = "CostManagement"


### PR DESCRIPTION
These two are still needed:

```
 $ go get github.com/hashicorp/go-azure-sdk@v0.20240124.1094959                                                                                                                                                   (dependencies/go-azure-sdk)
go: downloading github.com/hashicorp/go-azure-sdk v0.20240124.1094959
go: upgraded github.com/hashicorp/go-azure-sdk v0.20240122.1074123 => v0.20240124.1094959
11:01AM hashicorp/terraform-provider-azurerm
 $ go mod tidy
go: finding module for package github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb
go: finding module for package github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-11-15/mongorbacs
go: finding module for package github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/sqldedicatedgateway
go: github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos imports
	github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb: module github.com/hashicorp/go-azure-sdk@latest found (v0.20240124.1094959), but does not contain package github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb
go: github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos imports
	github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/sqldedicatedgateway: module github.com/hashicorp/go-azure-sdk@latest found (v0.20240124.1094959), but does not contain package github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/sqldedicatedgateway
go: github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos imports
	github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-11-15/mongorbacs: module github.com/hashicorp/go-azure-sdk@latest found (v0.20240124.1094959), but does not contain package github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-11-15/mongorbacs
```