### PR TITLE
nit: adding the `copywrite` configuration

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -6,6 +6,7 @@ project {
 
   header_ignore = [
     ".github/**",
-    "api-definitions/**"
+    "api-definitions/**",
+    "submodules/**"
   ]
 }

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,11 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2023
+
+  header_ignore = [
+    ".github/**",
+    "api-definitions/**"
+  ]
+}

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -7,6 +7,7 @@ project {
   header_ignore = [
     ".github/**",
     "api-definitions/**",
-    "submodules/**"
+    "submodules/**",
+    "tools/**/vendor/**"
   ]
 }


### PR DESCRIPTION
As a part of going through the open PRs to see what's mergeable/closed - this PR adds the copywrite configuration needed to enable copywrite to be used in the future.

This allows closing the PR https://github.com/hashicorp/pandora/pull/2117 which has been parked for ages - but should finally be actionable once https://github.com/hashicorp/pandora/issues/3583 is completed (and the old Data API is removed).