### PR TITLE
`tools/importer-rest-api-specs`: support for importing `Resources/*/Tags`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/internal/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/helpers.go
@@ -36,6 +36,9 @@ func OperationShouldBeIgnored(operationUri string) bool {
 		"/privatelinkscopeoperationstatuses/":         {},
 		"/recommendedactionsessionsoperationresults/": {},
 
+		// Tags within this package is unnecessary
+		"/providers/microsoft.consumption/tags": {},
+
 		// we can't just use `/operations` since some APIs (e.g. API Management) expose these, so we're intentionally
 		// checking more (but not all) of the path
 		// /providers/Microsoft.KubernetesConfiguration/extensions/{extensionName}/operations/{operationId}

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags.go
@@ -6,8 +6,9 @@ import (
 )
 
 var tagsToIgnore = map[string]struct{}{
-	"deploymentoperations": {},
-	"usage":                {},
+	"deploymentoperations":  {},
+	"azurefirewallfqdntags": {},
+	"usage":                 {},
 }
 
 func (d *SwaggerDefinition) findTags() []string {

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags.go
@@ -7,7 +7,6 @@ import (
 
 var tagsToIgnore = map[string]struct{}{
 	"deploymentoperations": {},
-	"tags":                 {},
 	"usage":                {},
 }
 


### PR DESCRIPTION
This PR unblocks migrating the `Tags` client from `Azure/azure-sdk-for-go` to `hashicorp/go-azure-sdk` as used here: https://github.com/hashicorp/terraform-provider-azurerm/blob/75182167d45fbfd0d68b0c9e9ce6340496276f0b/internal/services/resource/client/client.go#L121-L126

We're currently skipping importing both the `AzureFirewallFqdnTags` and the Consumption tags - taking a quick look at the generated output for both I'm not necessarily sure we should be supporting these, so I've added exceptions for these back in for the moment.