### PR TITLE
`tools/importer-rest-api-specs`: supporting `AllOf` containing only a description

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -680,6 +680,87 @@ func TestParseModelSingleInheritingFromObjectWithNoExtraFieldsInlined(t *testing
 	}
 }
 
+func TestParseModelSingleInheritingFromObjectWithOnlyDescription(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_with_only_description.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "FirstObject" {
+		t.Fatalf("expected the response object to be 'FirstObject' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	// whilst the response model references SecondObject, it's only inheriting from FirstObject, so it'll be switched out
+	firstObject, ok := hello.Models["FirstObject"]
+	if !ok {
+		t.Fatalf("expected there to be a model called FirstObject")
+	}
+	if len(firstObject.Fields) != 1 {
+		t.Fatalf("expected the model SecondObject to have 1 field but got %d", len(firstObject.Fields))
+	}
+	if _, ok := firstObject.Fields["Name"]; !ok {
+		t.Fatalf("expected the model SecondObject to have a field named `Name` but didn't get one")
+	}
+}
+
 func TestParseModelSingleWithDateTimeNoType(t *testing.T) {
 	result, err := ParseSwaggerFileForTesting(t, "model_single_datetime_no_type.json")
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/parser/testdata/model_inheriting_from_other_model_with_only_description.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/model_inheriting_from_other_model_with_only_description.json
@@ -1,0 +1,62 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/SecondObject"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "FirstObject": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "title": "FirstObject"
+    },
+    "SecondObject": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirstObject"
+        },
+        {
+          "description": "This only has a description and no ref value"
+        }
+      ]
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
`AllOf` is intended to be a reference, however sometimes can contain a description instead.