### PR TITLE
`hybridaks`: importing API Version `2024-01-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -265,6 +265,10 @@ service "healthcareapis" {
   name      = "HealthcareApis"
   available = ["2022-12-01", "2023-02-28", "2023-09-06", "2023-11-01", "2023-12-01"]
 }
+service "hybridaks" {
+  name      = "HybridAzureKubernetesService"
+  available = ["2024-01-01"]
+}
 service "hybridcompute" {
   name      = "HybridCompute"
   available = ["2022-11-10", "2022-12-27"]

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
@@ -14,6 +14,8 @@ import (
 
 var knownSegmentsUsedForScope = []string{
 	"billingScope",
+	"connectedClusterResourceUri", // HybridAKS
+	"customLocationResourceUri",   // HybridAKS
 	"denyAssignmentId",
 	"ResourceId",
 	"resourceScope",


### PR DESCRIPTION
As @wuxu92 has mentioned in #2848, it appears that the issue blocking `HybridAKS` has been resolved - however we also need to detect the segments `connectedClusterResourceUri` and `customLocationResourceUri` as scope's.

As such this PR adds support for `HybridAzureKubernetesService` (which is intentionally spelled out since we also have `HybridKubernetes`) @ `2024-01-01`.