### PR TITLE
`importer-rest-api-specs` - parse orphaned discriminated models in nested files

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -474,7 +474,7 @@ func (d *SwaggerDefinition) findOrphanedDiscriminatedModels() (*internal.ParseRe
 
 	// this will also pull out the parent model in the file which will already have been parsed, but that's ok
 	// since they will be de-duplicated when we call combineResourcesWith
-	nestedResult, err := d.findNestedItemsYetToBeParsed(nil, result)
+	nestedResult, err := d.findNestedItemsYetToBeParsed(map[string]models.OperationDetails{}, result)
 	if err != nil {
 		return nil, fmt.Errorf("finding nested items yet to be parsed: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/models_discriminators_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_discriminators_test.go
@@ -1116,3 +1116,207 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 		t.Fatalf("human.TypeHintValue should be `human` but it was %q", *human.TypeHintValue)
 	}
 }
+
+func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "/nestedtestdata/model_discriminators_orphaned_child.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	// the functionality we're testing here will use the file name as the inferred tag/resource since that's the pattern
+	// we observe in the Rest API Specs. The file name for the test data is meaningless so we just get the only resource
+	// that's available
+	var resource models.AzureApiResource
+	for _, v := range result.Resources {
+		resource = v
+	}
+
+	// sanity checking
+	if len(resource.Constants) != 0 {
+		t.Fatalf("expected no constants but got %d", len(resource.Constants))
+	}
+	if len(resource.Models) != 3 {
+		t.Fatalf("expected 3 models but got %d", len(resource.Models))
+	}
+	if len(resource.Operations) != 0 {
+		t.Fatalf("expected 0 operation but got %d", len(resource.Operations))
+	}
+	if len(resource.ResourceIds) != 0 {
+		t.Fatalf("expected 0 Resource ID but got %d", len(resource.ResourceIds))
+	}
+
+	animal, ok := resource.Models["Animal"]
+	if !ok {
+		t.Fatalf("the Model `Animal` was not found")
+	}
+	if animal.ParentTypeName != nil {
+		t.Fatalf("animal.ParentTypeName should be nil but was %q", *animal.ParentTypeName)
+	}
+	if animal.TypeHintIn == nil {
+		t.Fatal("animal.TypeHintIn should have a value but it doesn't")
+	}
+	if animal.TypeHintValue != nil {
+		t.Fatalf("animal.TypeHintValue should be nil but was %q", *animal.TypeHintValue)
+	}
+
+	cat, ok := resource.Models["Cat"]
+	if !ok {
+		t.Fatalf("the Model `Cat` was not found")
+	}
+	if cat.ParentTypeName == nil {
+		t.Fatalf("cat.ParentTypeName should have a value but it doesn't")
+	}
+	if *cat.ParentTypeName != "Animal" {
+		t.Fatalf("cat.ParentTypeName should be `Animal` but it was %q", *cat.ParentTypeName)
+	}
+	if cat.TypeHintIn == nil {
+		t.Fatal("cat.TypeHintIn should have a value but it doesn't")
+	}
+	if *cat.TypeHintIn != "AnimalType" {
+		t.Fatalf("cat.TypeHintIn should be `AnimalType` but it was %q", *cat.TypeHintIn)
+	}
+	if cat.TypeHintValue == nil {
+		t.Fatalf("cat.TypeHintValue should have a value but it doesn't")
+	}
+	if *cat.TypeHintValue != "cat" {
+		t.Fatalf("cat.TypeHintValue should be `cat` but it was %q", *cat.TypeHintValue)
+	}
+
+	dog, ok := resource.Models["Dog"]
+	if !ok {
+		t.Fatalf("the Model `Dog` was not found")
+	}
+	if dog.ParentTypeName == nil {
+		t.Fatalf("dog.ParentTypeName should have a value but it doesn't")
+	}
+	if *dog.ParentTypeName != "Animal" {
+		t.Fatalf("dog.ParentTypeName should be `Animal` but it was %q", *dog.ParentTypeName)
+	}
+	if dog.TypeHintIn == nil {
+		t.Fatal("dog.TypeHintIn should have a value but it doesn't")
+	}
+	if *dog.TypeHintIn != "AnimalType" {
+		t.Fatalf("dog.TypeHintIn should be `AnimalType` but it was %q", *dog.TypeHintIn)
+	}
+	if dog.TypeHintValue == nil {
+		t.Fatalf("dog.TypeHintValue should have a value but it doesn't")
+	}
+	if *dog.TypeHintValue != "dog" {
+		t.Fatalf("dog.TypeHintValue should be `dog` but it was %q", *dog.TypeHintValue)
+	}
+}
+
+func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
+	result, err := ParseSwaggerFileForTesting(t, "/nestedtestdata/model_discriminators_orphaned_child_with_nested_model.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	// the functionality we're testing here will use the file name as the inferred tag/resource since that's the pattern
+	// we observe in the Rest API Specs. The file name for the test data is meaningless so we just get the only resource
+	// that's available
+	var resource models.AzureApiResource
+	for _, v := range result.Resources {
+		resource = v
+	}
+
+	// sanity checking
+	if len(resource.Constants) != 0 {
+		t.Fatalf("expected no constants but got %d", len(resource.Constants))
+	}
+	if len(resource.Models) != 4 {
+		t.Fatalf("expected 4 models but got %d", len(resource.Models))
+	}
+	if len(resource.Operations) != 0 {
+		t.Fatalf("expected 0 operation but got %d", len(resource.Operations))
+	}
+	if len(resource.ResourceIds) != 0 {
+		t.Fatalf("expected 0 Resource ID but got %d", len(resource.ResourceIds))
+	}
+
+	animal, ok := resource.Models["Animal"]
+	if !ok {
+		t.Fatalf("the Model `Animal` was not found")
+	}
+	if animal.ParentTypeName != nil {
+		t.Fatalf("animal.ParentTypeName should be nil but was %q", *animal.ParentTypeName)
+	}
+	if animal.TypeHintIn == nil {
+		t.Fatal("animal.TypeHintIn should have a value but it doesn't")
+	}
+	if animal.TypeHintValue != nil {
+		t.Fatalf("animal.TypeHintValue should be nil but was %q", *animal.TypeHintValue)
+	}
+
+	cat, ok := resource.Models["Cat"]
+	if !ok {
+		t.Fatalf("the Model `Cat` was not found")
+	}
+	if cat.ParentTypeName == nil {
+		t.Fatalf("cat.ParentTypeName should have a value but it doesn't")
+	}
+	if *cat.ParentTypeName != "Animal" {
+		t.Fatalf("cat.ParentTypeName should be `Animal` but it was %q", *cat.ParentTypeName)
+	}
+	if cat.TypeHintIn == nil {
+		t.Fatal("cat.TypeHintIn should have a value but it doesn't")
+	}
+	if *cat.TypeHintIn != "AnimalType" {
+		t.Fatalf("cat.TypeHintIn should be `AnimalType` but it was %q", *cat.TypeHintIn)
+	}
+	if cat.TypeHintValue == nil {
+		t.Fatalf("cat.TypeHintValue should have a value but it doesn't")
+	}
+	if *cat.TypeHintValue != "cat" {
+		t.Fatalf("cat.TypeHintValue should be `cat` but it was %q", *cat.TypeHintValue)
+	}
+
+	dog, ok := resource.Models["Dog"]
+	if !ok {
+		t.Fatalf("the Model `Dog` was not found")
+	}
+	if dog.ParentTypeName == nil {
+		t.Fatalf("dog.ParentTypeName should have a value but it doesn't")
+	}
+	if *dog.ParentTypeName != "Animal" {
+		t.Fatalf("dog.ParentTypeName should be `Animal` but it was %q", *dog.ParentTypeName)
+	}
+	if dog.TypeHintIn == nil {
+		t.Fatal("dog.TypeHintIn should have a value but it doesn't")
+	}
+	if *dog.TypeHintIn != "AnimalType" {
+		t.Fatalf("dog.TypeHintIn should be `AnimalType` but it was %q", *dog.TypeHintIn)
+	}
+	if dog.TypeHintValue == nil {
+		t.Fatalf("dog.TypeHintValue should have a value but it doesn't")
+	}
+	if *dog.TypeHintValue != "dog" {
+		t.Fatalf("dog.TypeHintValue should be `dog` but it was %q", *dog.TypeHintValue)
+	}
+
+	keyValuePair, ok := resource.Models["KeyValuePair"]
+	if !ok {
+		t.Fatalf("the Model `KeyValuePair` was not found")
+	}
+	if keyValuePair.ParentTypeName != nil {
+		t.Fatalf("keyValuePair.ParentTypeName shouldn't have a value but has %q", *keyValuePair.ParentTypeName)
+	}
+	if keyValuePair.TypeHintIn != nil {
+		t.Fatalf("keyValuePair.TypeHintIn shouldn't have a value but has %q", *keyValuePair.TypeHintIn)
+	}
+	if keyValuePair.TypeHintValue != nil {
+		t.Fatalf("keyValuePair.TypeHintValue shouldn't have a value but has %q", *keyValuePair.TypeHintValue)
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/parse_data.go
+++ b/tools/importer-rest-api-specs/components/parser/parse_data.go
@@ -89,7 +89,12 @@ func combineModels(first map[string]models.ModelDetails, second map[string]model
 		if ok && len(existing.Fields) != len(v.Fields) {
 			return nil, fmt.Errorf("duplicate models named %q with different fields - first %d - second %d", k, len(existing.Fields), len(v.Fields))
 		}
+		output[k] = v
+	}
 
+	// once we've combined the models for a resource and de-duplicated them, we will iterate over all of them to link any
+	// orphaned discriminated models to their parent
+	for k, v := range output {
 		// this model is an implementation, so we need to find/update the parent
 		if v.ParentTypeName != nil && v.TypeHintIn != nil && v.TypeHintValue != nil {
 			parent, ok := output[*v.ParentTypeName]
@@ -104,8 +109,6 @@ func combineModels(first map[string]models.ModelDetails, second map[string]model
 			}
 			output[*v.ParentTypeName] = parent
 		}
-
-		output[k] = v
 	}
 
 	return &output, nil

--- a/tools/importer-rest-api-specs/components/parser/parse_data.go
+++ b/tools/importer-rest-api-specs/components/parser/parse_data.go
@@ -80,11 +80,11 @@ func combineConstants(first map[string]resourcemanager.ConstantDetails, second m
 func combineModels(first map[string]models.ModelDetails, second map[string]models.ModelDetails) (*map[string]models.ModelDetails, error) {
 	output := make(map[string]models.ModelDetails)
 
-	for k, v := range second {
+	for k, v := range first {
 		output[k] = v
 	}
 
-	for k, v := range first {
+	for k, v := range second {
 		existing, ok := output[k]
 		if ok && len(existing.Fields) != len(v.Fields) {
 			return nil, fmt.Errorf("duplicate models named %q with different fields - first %d - second %d", k, len(existing.Fields), len(v.Fields))

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -89,7 +89,12 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 					Models:    result.Models,
 				}
 				resource = normalizeAzureApiResource(resource)
-				resourcesOut[normalizedTag] = resource
+
+				if mergeResources, ok := resources[normalizedTag]; ok {
+					resources[normalizedTag] = models.MergeResourcesForTag(mergeResources, resource)
+				} else {
+					resourcesOut[normalizedTag] = resource
+				}
 			}
 		}
 	}

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -66,29 +66,31 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 		resourcesOut[resourceName] = updated
 	}
 
-	// discriminator implementations that are defined in separate files with no link to a swagger tag
-	// are not parsed. So far there are two known instances of this (Data Factory, Chaos Studio) where the
-	// files are defined in a nested directory e.g. d.Name = /Types/Capabilities
+	// TODO this can be removed when https://github.com/hashicorp/pandora/issues/3725 is resolved
+	if !strings.EqualFold(serviceName, "datafactory") {
+		// discriminator implementations that are defined in separate files with no link to a swagger tag
+		// are not parsed. So far there are two known instances of this (Data Factory, Chaos Studio) where the
+		// files are defined in a nested directory e.g. d.Name = /Types/Capabilities
+		swaggerFileName := strings.Split(d.Name, "/")
+		if len(resources) == 0 && len(swaggerFileName) > 2 {
+			// if we're here then there is no tag in this file, so we'll use the file name
+			inferredTag := cleanup.PluraliseName(swaggerFileName[len(swaggerFileName)-1])
+			normalizedTag := cleanup.NormalizeResourceName(inferredTag)
 
-	swaggerFileName := strings.Split(d.Name, "/")
-	if len(resources) == 0 && len(swaggerFileName) > 2 {
-		// if we're here then there is no tag in this file, so we'll use the file name
-		inferredTag := cleanup.PluraliseName(swaggerFileName[len(swaggerFileName)-1])
-		normalizedTag := cleanup.NormalizeResourceName(inferredTag)
-
-		result, err := d.findOrphanedDiscriminatedModels()
-		if err != nil {
-			return nil, fmt.Errorf("finding orphaned discriminated models in %q: %+v", d.Name, err)
-		}
-
-		// this is to avoid the creation of empty packages/directories in the api definitions
-		if len(result.Models) > 0 || len(result.Constants) > 0 {
-			resource := models.AzureApiResource{
-				Constants: result.Constants,
-				Models:    result.Models,
+			result, err := d.findOrphanedDiscriminatedModels()
+			if err != nil {
+				return nil, fmt.Errorf("finding orphaned discriminated models in %q: %+v", d.Name, err)
 			}
-			resource = normalizeAzureApiResource(resource)
-			resourcesOut[normalizedTag] = resource
+
+			// this is to avoid the creation of empty packages/directories in the api definitions
+			if len(result.Models) > 0 || len(result.Constants) > 0 {
+				resource := models.AzureApiResource{
+					Constants: result.Constants,
+					Models:    result.Models,
+				}
+				resource = normalizeAzureApiResource(resource)
+				resourcesOut[normalizedTag] = resource
+			}
 		}
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/testdata/nestedtestdata/model_discriminators_orphaned_child.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/nestedtestdata/model_discriminators_orphaned_child.json
@@ -1,0 +1,81 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "paths": {},
+  "definitions": {
+    "ExampleWrapper": {
+      "description": "The Resource definition.",
+      "properties": {
+        "nested": {
+          "$ref": "#/definitions/Animal"
+        }
+      },
+      "required": [
+        "nested"
+      ],
+      "title": "ExampleWrapper",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "Animal": {
+      "discriminator": "animalType",
+      "properties": {
+        "animalType": {
+          "type": "string",
+          "description": "The type of Animal this is, used as a Discriminator value."
+        }
+      },
+      "required": [
+        "animalType"
+      ],
+      "title": "Animal",
+      "type": "object"
+    },
+    "Cat": {
+      "description": "A cat is a kind of animal",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Animal"
+        }
+      ],
+      "properties": {
+        "isFluffy": {
+          "type": "boolean",
+          "description": "Are cats fluffy?"
+        }
+      },
+      "required": [
+        "animalType",
+        "isFluffy"
+      ],
+      "title": "Cat",
+      "type": "object",
+      "x-ms-discriminator-value": "cat"
+    },
+    "Dog": {
+      "description": "A dog is a kind of animal",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Animal"
+        }
+      ],
+      "properties": {
+        "barks": {
+          "type": "boolean",
+          "description": "Do dogs bark?"
+        }
+      },
+      "required": [
+        "animalType",
+        "barks"
+      ],
+      "title": "Dog",
+      "type": "object",
+      "x-ms-discriminator-value": "dog"
+    }
+  }
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/nestedtestdata/model_discriminators_orphaned_child_with_nested_model.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/nestedtestdata/model_discriminators_orphaned_child_with_nested_model.json
@@ -1,0 +1,112 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "paths": {},
+  "definitions": {
+    "ExampleWrapper": {
+      "description": "The Resource definition.",
+      "properties": {
+        "nested": {
+          "$ref": "#/definitions/Animal"
+        }
+      },
+      "required": [
+        "nested"
+      ],
+      "title": "ExampleWrapper",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "Animal": {
+      "discriminator": "animalType",
+      "properties": {
+        "animalType": {
+          "type": "string",
+          "description": "The type of Animal this is, used as a Discriminator value."
+        }
+      },
+      "required": [
+        "animalType"
+      ],
+      "title": "Animal",
+      "type": "object"
+    },
+    "Cat": {
+      "description": "A cat is a kind of animal",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Animal"
+        }
+      ],
+      "properties": {
+        "isFluffy": {
+          "type": "boolean",
+          "description": "Are cats fluffy?"
+        }
+      },
+      "required": [
+        "animalType",
+        "isFluffy"
+      ],
+      "title": "Cat",
+      "type": "object",
+      "x-ms-discriminator-value": "cat"
+    },
+    "Dog": {
+      "description": "A dog is a kind of animal",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Animal"
+        }
+      ],
+      "properties": {
+        "parameters": {
+          "description": "List of key value pairs.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/keyValuePair"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "barks": {
+          "type": "boolean",
+          "description": "Do dogs bark?"
+        }
+      },
+      "required": [
+        "animalType",
+        "barks"
+      ],
+      "title": "Dog",
+      "type": "object",
+      "x-ms-discriminator-value": "dog"
+    },
+    "keyValuePair": {
+      "description": "A map to describe the settings of a dog.",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "The name of the setting for the dog",
+          "type": "string",
+          "minLength": 1
+        },
+        "value": {
+          "description": "The value of the setting for the dog.",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This PR closes #3693 and is related to #2551 but doesn't close it since we skip over this new functionality for DataFactory due to #3725.

Although we iterate over files in a nested directory structure, if the files have no paths defined then we don't parse any of the models defined in them. 

This change adds the following functionality:
- Will find all discriminated models in files without any paths
- Find any models that the discriminated models reference
- Combine them into the resource they belong to (this depends on the file name, ChaosStudio and DataFactory use the resource name as the file name)
- Links the discriminated models to the parent, updating the data on the model that describes it as a discriminator 

Note: `DataMigration` and `SecurityInsights` are also affected by this change. `DataMigration` results in the addition of a lot of new "resources" due to the naming of the files, we may want to consider skipping this functionality for `DataMigration` as well.