### PR TITLE
`tools/importer-rest-api-specs`: fixing a regression where a Model inheriting from a Model and defining properties within `AllOf` would be unintentionally flattened into the Parent

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -570,7 +570,7 @@ func (d SwaggerDefinition) parseObjectDefinition(
 			allOfFields := make([]spec.Schema, 0)
 			for _, item := range input.AllOf {
 				fragmentName := fragmentNameFromReference(item.Ref)
-				if fragmentName == nil && len(item.Type) == 0 {
+				if fragmentName == nil && len(item.Type) == 0 && len(item.Properties) == 0 {
 					continue
 				}
 				allOfFields = append(allOfFields, item)

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -754,9 +754,97 @@ func TestParseModelSingleInheritingFromObjectWithOnlyDescription(t *testing.T) {
 		t.Fatalf("expected there to be a model called FirstObject")
 	}
 	if len(firstObject.Fields) != 1 {
-		t.Fatalf("expected the model SecondObject to have 1 field but got %d", len(firstObject.Fields))
+		t.Fatalf("expected the model FirstObject to have 1 field but got %d", len(firstObject.Fields))
 	}
 	if _, ok := firstObject.Fields["Name"]; !ok {
+		t.Fatalf("expected the model FirstObject to have a field named `Name` but didn't get one")
+	}
+}
+
+func TestParseModelSingleInheritingFromObjectWithPropertiesWithinAllOf(t *testing.T) {
+	// This test ensures that when a Model inherits from a Model and defines properties within
+	// the `AllOf` field, that the Model isn't flattened into the Parent Model.
+	// This covers a regression from https://github.com/hashicorp/pandora/pull/3720
+	// which surfaced in https://github.com/hashicorp/pandora/pull/3726 for the model `AgentPool`
+	// within `ContainerService@2019-08-01/AgentPools` which was renamed `SubResource`.
+	result, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_with_properties_within_allof.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
+	}
+
+	hello, ok := result.Resources["Hello"]
+	if !ok {
+		t.Fatalf("no resources were output with the tag Hello")
+	}
+
+	if len(hello.Constants) != 0 {
+		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
+	}
+	if len(hello.Models) != 1 {
+		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
+	}
+	if len(hello.Operations) != 1 {
+		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
+	}
+	if len(hello.ResourceIds) != 0 {
+		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
+	}
+
+	world, ok := hello.Operations["GetWorld"]
+	if !ok {
+		t.Fatalf("no resources were output with the name GetWorld")
+	}
+	if world.Method != "GET" {
+		t.Fatalf("expected a GET operation but got %q", world.Method)
+	}
+	if len(world.ExpectedStatusCodes) != 1 {
+		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
+	}
+	if world.ExpectedStatusCodes[0] != 200 {
+		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
+	}
+	if world.RequestObject != nil {
+		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
+	}
+	if world.ResponseObject == nil {
+		t.Fatal("expected a response object but didn't get one")
+	}
+	if world.ResponseObject.Type != models.ObjectDefinitionReference {
+		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
+	}
+	if *world.ResponseObject.ReferenceName != "SecondObject" {
+		t.Fatalf("expected the response object to be 'SecondObject' but got %q", *world.ResponseObject.ReferenceName)
+	}
+	if world.ResourceIdName != nil {
+		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
+	}
+	if world.UriSuffix == nil {
+		t.Fatal("expected world.UriSuffix to have a value")
+	}
+	if *world.UriSuffix != "/things" {
+		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
+	}
+	if world.LongRunning {
+		t.Fatal("expected a non-long running operation but it was long running")
+	}
+
+	// SecondObject is referenced as the Response Object, but because it inherits from one Model
+	// (FirstObject) and uses another (ThirdObject) it shouldn't be flattened into the parent type(s)
+	// and should instead remain `SecondObject`.
+	secondObject, ok := hello.Models["SecondObject"]
+	if !ok {
+		t.Fatalf("expected there to be a model called SecondObject")
+	}
+	if len(secondObject.Fields) != 1 {
+		t.Fatalf("expected the model SecondObject to have 1 field but got %d", len(secondObject.Fields))
+	}
+	if _, ok := secondObject.Fields["Name"]; !ok {
 		t.Fatalf("expected the model SecondObject to have a field named `Name` but didn't get one")
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/testdata/model_inheriting_from_other_model_with_properties_within_allof.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/model_inheriting_from_other_model_with_properties_within_allof.json
@@ -1,0 +1,76 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/things": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_GetWorld",
+        "description": "A GET request with a body returned.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/SecondObject"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "FirstObject": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "title": "FirstObject"
+    },
+    "SecondObject": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirstObject"
+        },
+        {
+          "properties": {
+            "properties": {
+              "description": "Properties of a thing",
+              "$ref": "#/definitions/ThirdObject"
+            }
+          }
+        }
+      ]
+    },
+    "ThirdObject": {
+      "properties": {
+        "canInvokeHammerTime": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "title": "ThirdObject"
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
This PR fixes an regression in `ContainerService@2019-08-01` introduced https://github.com/hashicorp/pandora/pull/3720 where the model `AgentPool` would be unintentionally flattened into `SubResource` - despite it containing nested properties within the `AllOf` block.

This is because the Model in question defines both the Parent model and it's properties within the `AllOf` block:

```json
    "AgentPool": {
      "allOf": [
        {
          "$ref": "#/definitions/SubResource"
        },
        {
          "properties": {
            "properties": {
              "description": "Properties of an agent pool.",
              "$ref": "#/definitions/ManagedClusterAgentPoolProfileProperties",
              "x-ms-client-flatten": true
            }
          }
        }
      ],
      "description": "Agent Pool."
    }
```

I'd missed when reviewing https://github.com/hashicorp/pandora/pull/3726 that the Properties model was being removed rather than renamed, as such this commit fixes this - which reintroduces the model `ManagedClusterAgentPoolProfileProperties` - and removes the unintentional flattening, so this becomes `AgentPool` once again.