### PR TITLE
`tools/generator-terraform`: removing support for the old base layer

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -54,17 +54,12 @@ func main() {
 		"Automation@2020-01-13-preview",
 		"Automation@2021-06-22",
 
-		// @tombuildsstuff: there's generated resources associated with these three - please check before removing these
-		// NOTE: also see the list in ./tools/generator-terraform/generator/definitions/template_service_client.go
-		// for services/resources which are auto-generated
-		"ContainerService",
-
 		// @tombuildsstuff: The Key Vault API has an issue where it requires that the EXACT casing returned in the Response
 		// is sent in the Request to update or remove a Key Vault Access Policy - and using other casings mean the update
 		// or removal fails - which is tracked in https://github.com/hashicorp/pandora/issues/3229.
 		//
 		// After testing it appears that `2023-07-01` doesn't suffer from this problem - as such we're going to leave
-                // `2023-02-01` on the older base layer and use the newer API Version as a divide to give us a clear migration path.
+		// `2023-02-01` on the older base layer and use the newer API Version as a divide to give us a clear migration path.
 		"KeyVault@2023-02-01",
 	)
 

--- a/tools/generator-terraform/generator/definitions/template_service_client.go
+++ b/tools/generator-terraform/generator/definitions/template_service_client.go
@@ -10,8 +10,7 @@ import (
 )
 
 var servicesUsingOldBaseLayer = map[string]struct{}{
-	// these should be lower-cased
-	"containerservice": {},
+	// TODO: the old base layer related logic can be removed from `generator-terraform` in a follow-up PR
 
 	// purely for testing purposes
 	"examplelegacypackage": {},

--- a/tools/generator-terraform/generator/definitions/template_service_client.go
+++ b/tools/generator-terraform/generator/definitions/template_service_client.go
@@ -9,13 +9,6 @@ import (
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
 )
 
-var servicesUsingOldBaseLayer = map[string]struct{}{
-	// TODO: the old base layer related logic can be removed from `generator-terraform` in a follow-up PR
-
-	// purely for testing purposes
-	"examplelegacypackage": {},
-}
-
 func templateForServiceClient(input models.ServiceInput) string {
 	importLines := make([]string, 0)
 	autoClientLines := make([]string, 0)
@@ -89,30 +82,5 @@ func NewClient(o *common.ClientOptions) (*AutoClient, error) {
 	}, nil
 }
 `, strings.Join(importLines, "\n"), strings.Join(autoClientLines, "\n"), strings.Join(assignmentLines, "\n"), strings.Join(returnLines, "\n"), input.ProviderPrefix)
-
-	if _, ok := servicesUsingOldBaseLayer[strings.ToLower(input.SdkServiceName)]; ok {
-		output = fmt.Sprintf(`
-package client
-
-import (
-	"github.com/Azure/go-autorest/autorest"
-	%[1]s
-	"github.com/hashicorp/terraform-provider-%[5]s/internal/common"
-)
-
-type AutoClient struct {
-	%[2]s
-}
-
-func NewClient(o *common.ClientOptions) (*AutoClient, error) {
-	%[3]s
-
-	return &AutoClient{
-		%[4]s
-	}, nil
-}
-`, strings.Join(importLines, "\n"), strings.Join(autoClientLines, "\n"), strings.Join(assignmentOldBaseLayerLines, "\n"), strings.Join(returnOldBaseLayerLines, "\n"), input.ProviderPrefix)
-	}
-
 	return strings.TrimSpace(output)
 }

--- a/tools/generator-terraform/generator/definitions/template_service_client_test.go
+++ b/tools/generator-terraform/generator/definitions/template_service_client_test.go
@@ -3,9 +3,8 @@ package definitions
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
-
 	"github.com/hashicorp/pandora/tools/generator-terraform/generator/models"
+	"github.com/hashicorp/pandora/tools/sdk/testhelpers"
 )
 
 func TestTemplateForServiceClient(t *testing.T) {
@@ -63,7 +62,7 @@ package client
 import (
 	resourcesV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01-preview"
 	resourcesV20200101 "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-01-01"
-    	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
 )
 
@@ -110,7 +109,7 @@ package client
 
 import (
 	resourcesV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2015-11-01-preview"
-    	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
 )
 
@@ -127,119 +126,6 @@ func NewClient(o *common.ClientOptions) (*AutoClient, error) {
 	}
 	return &AutoClient{
 		V20151101Preview: *v20151101PreviewClient,
-	}, nil
-}
-`
-	testhelpers.AssertTemplatedCodeMatches(t, expected, actual)
-}
-
-func TestTemplateForServiceClient_GoAutoRest(t *testing.T) {
-	input := models.ServiceInput{
-		ProviderPrefix: "myprovider", // intentionally not used, since this is `client`
-		ResourceToApiVersion: map[string]string{
-			"load_test_service_resource": "2015-11-01-preview",
-		},
-		SdkServiceName:     "examplelegacypackage",
-		ServicePackageName: "mypackage",
-	}
-	actual := templateForServiceClient(input)
-	expected := `
-package client
-
-import (
-	"github.com/Azure/go-autorest/autorest"
-	examplelegacypackageV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/examplelegacypackage/2015-11-01-preview"
-	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
-)
-
-type AutoClient struct {
-	V20151101Preview examplelegacypackageV20151101Preview.Client
-}
-
-func NewClient(o *common.ClientOptions) (*AutoClient, error) {
-	v20151101PreviewClient := examplelegacypackageV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
-	})
-	return &AutoClient{
-		V20151101Preview: v20151101PreviewClient,
-	}, nil
-}
-`
-	testhelpers.AssertTemplatedCodeMatches(t, expected, actual)
-}
-
-func TestTemplateForServiceClient_GoAutoRest_WithMultipleApiVersions(t *testing.T) {
-	input := models.ServiceInput{
-		ProviderPrefix: "myprovider", // intentionally not used, since this is `client`
-		ResourceToApiVersion: map[string]string{
-			"load_test_service_one_resource": "2015-11-01-preview",
-			"load_test_service_two_resource": "2021-10-10",
-		},
-		SdkServiceName:     "examplelegacypackage",
-		ServicePackageName: "mypackage",
-	}
-	actual := templateForServiceClient(input)
-	expected := `
-package client
-
-import (
-	"github.com/Azure/go-autorest/autorest"
-	examplelegacypackageV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/examplelegacypackage/2015-11-01-preview"
-	examplelegacypackageV20211010 "github.com/hashicorp/go-azure-sdk/resource-manager/examplelegacypackage/2021-10-10"
-	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
-)
-
-type AutoClient struct {
-	V20151101Preview examplelegacypackageV20151101Preview.Client
-	V20211010 examplelegacypackageV20211010.Client
-}
-
-func NewClient(o *common.ClientOptions) (*AutoClient, error) {
-	v20151101PreviewClient := examplelegacypackageV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
-	})
-	v20211010Client := examplelegacypackageV20211010.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
-	})
-	return &AutoClient{
-		V20151101Preview: v20151101PreviewClient,
-		V20211010: v20211010Client,
-	}, nil
-}
-`
-	testhelpers.AssertTemplatedCodeMatches(t, expected, actual)
-}
-
-func TestTemplateForServiceClient_GoAutoRest_WithMultipleResourcesAndOneApiVersion(t *testing.T) {
-	input := models.ServiceInput{
-		ProviderPrefix: "myprovider", // intentionally not used, since this is `client`
-		ResourceToApiVersion: map[string]string{
-			"load_test_service_one_resource": "2015-11-01-preview",
-			"load_test_service_two_resource": "2015-11-01-preview",
-		},
-		SdkServiceName:     "examplelegacypackage",
-		ServicePackageName: "mypackage",
-	}
-	actual := templateForServiceClient(input)
-	expected := `
-package client
-
-import (
-	"github.com/Azure/go-autorest/autorest"
-	examplelegacypackageV20151101Preview "github.com/hashicorp/go-azure-sdk/resource-manager/examplelegacypackage/2015-11-01-preview"
-	"github.com/hashicorp/terraform-provider-myprovider/internal/common"
-)
-
-type AutoClient struct {
-	V20151101Preview examplelegacypackageV20151101Preview.Client
-}
-
-func NewClient(o *common.ClientOptions) (*AutoClient, error) {
-	v20151101PreviewClient := examplelegacypackageV20151101Preview.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
-	})
-	return &AutoClient{
-		V20151101Preview: v20151101PreviewClient,
 	}, nil
 }
 `


### PR DESCRIPTION
This PR removes support for using SDK Clients using the old base layer from `./tools/generator-terraform` - since once #3742 has been merged, all (existing) generated resources will be exclusively using the new base layer. Any newly generated resources should be using the new base layer from the start at this point - so this should be fine to remove.

> **Note:** this doesn't remove support for the old base layer from `./tools/generator-go-sdk` since [this is still needed at this time](https://github.com/hashicorp/pandora/blob/356b3c415d30b6fcdac6600fa063d04695349082/tools/generator-go-sdk/main.go#L30-L69).

Dependent on #3742