### PR TITLE
`tools/importer-rest-api-specs`: adding a test assertion helper for the Swagger Parser

### DIFF
--- a/tools/data-api/internal/endpoints/home_page.go
+++ b/tools/data-api/internal/endpoints/home_page.go
@@ -2,12 +2,13 @@ package endpoints
 
 import (
 	"fmt"
-	"github.com/go-chi/chi/v5"
 	"html/template"
 	"log"
 	"net/http"
 	"sort"
 	"strings"
+
+	"github.com/go-chi/chi/v5"
 )
 
 const homePageTemplate = `

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_resource_id.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_resource_id.go
@@ -3,6 +3,7 @@ package dataapigeneratorjson
 import (
 	"encoding/json"
 	"fmt"
+
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/dataapimodels"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_resource_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/templater_terraform_resource_definition.go
@@ -2,6 +2,7 @@ package dataapigeneratorjson
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/pandora/tools/sdk/dataapimodels"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )

--- a/tools/importer-rest-api-specs/components/discovery/data.go
+++ b/tools/importer-rest-api-specs/components/discovery/data.go
@@ -14,7 +14,7 @@ type FindServiceInput struct {
 	ConfigFilePath   string
 	OutputDirectory  string
 	SwaggerDirectory string
-	Logger              hclog.Logger
+	Logger           hclog.Logger
 }
 
 func FindServices(input FindServiceInput, terraformConfig definitions.Config) (*[]ServiceInput, error) {

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
@@ -2,7 +2,7 @@ package dataworkarounds
 
 import (
 	"fmt"
-	
+
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_streamanalytics_27577.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_streamanalytics_27577.go
@@ -2,6 +2,7 @@ package dataworkarounds
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -1,13 +1,18 @@
 package parser
 
 import (
+	"fmt"
+	"sort"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func ParseSwaggerFileForTesting(t *testing.T, file string) (*models.AzureApiDefinition, error) {
+	// TODO: make this function private
 	parsed, err := load("testdata/", file, hclog.New(hclog.DefaultOptions))
 	if err != nil {
 		t.Fatalf("loading: %+v", err)
@@ -25,4 +30,269 @@ func ParseSwaggerFileForTesting(t *testing.T, file string) (*models.AzureApiDefi
 	}
 
 	return out, nil
+}
+
+func validateParsedSwaggerResultMatches(t *testing.T, expected models.AzureApiDefinition, actual *models.AzureApiDefinition) {
+	if actual == nil {
+		t.Fatal("`actual` was nil")
+	}
+	if actual.ServiceName != expected.ServiceName {
+		t.Fatalf("expected `ServiceName` to be %q but got %q", expected.ServiceName, actual.ServiceName)
+	}
+	if actual.ApiVersion != expected.ApiVersion {
+		t.Fatalf("expected `ApiVersion` to be %q but got %q", expected.ApiVersion, actual.ApiVersion)
+	}
+
+	validateMapsMatch(t, expected.Resources, actual.Resources, "API Resource", validateParsedApiResourceMatches)
+}
+
+func validateParsedApiResourceMatches(t *testing.T, expected models.AzureApiResource, actual models.AzureApiResource, apiResourceName string) {
+	t.Logf("Validating API Resource %q..", apiResourceName)
+	// Validate each of the maps matches what we're expecting
+	validateMapsMatch(t, expected.Constants, actual.Constants, "Constants", validateParsedConstantsMatch)
+	validateMapsMatch(t, expected.Models, actual.Models, "Models", validateParsedModelsMatch)
+	validateMapsMatch(t, expected.Operations, actual.Operations, "Operations", validateParsedOperationsMatch)
+	validateMapsMatch(t, expected.ResourceIds, actual.ResourceIds, "Resource IDs", validateParsedResourceIDsMatch)
+	validateObjectsMatch(t, expected.Terraform, actual.Terraform, "Terraform", validateParsedTerraformDetailsMatch)
+}
+
+func validateParsedConstantsMatch(t *testing.T, expected resourcemanager.ConstantDetails, actual resourcemanager.ConstantDetails, constantName string) {
+	if expected.Type != actual.Type {
+		t.Fatalf("expected Type to be %q but got %q for Constant %q", string(expected.Type), string(actual.Type), constantName)
+	}
+	if expected.CaseInsensitive != actual.CaseInsensitive {
+		t.Fatalf("expected CaseInsensitive to be %t but got %t for Constant %q", expected.CaseInsensitive, actual.CaseInsensitive, constantName)
+	}
+	validateMapsMatch(t, expected.Values, actual.Values, "Values", validateStringsMatch)
+}
+
+func validateParsedFieldsMatch(t *testing.T, expected models.FieldDetails, actual models.FieldDetails, fieldName string) {
+	if expected.JsonName != actual.JsonName {
+		t.Fatalf("expected `JsonName` to be %q but got %q for Field %q", expected.JsonName, actual.JsonName, fieldName)
+	}
+	if expected.ReadOnly != actual.ReadOnly {
+		t.Fatalf("expected `ReadOnly` to be %t but got %t for Field %q", expected.ReadOnly, actual.ReadOnly, fieldName)
+	}
+	if expected.Required != actual.Required {
+		t.Fatalf("expected `Required` to be %t but got %t for Field %q", expected.Required, actual.Required, fieldName)
+	}
+	if expected.Sensitive != actual.Sensitive {
+		t.Fatalf("expected `Sensitive` to be %t but got %t for Field %q", expected.Sensitive, actual.Sensitive, fieldName)
+	}
+
+	// NOTE: this will be replaced by ObjectDefinition in the future
+	if expected.CustomFieldType != nil && actual.CustomFieldType == nil {
+		t.Fatalf("expected `CustomFieldType` to be %q but got nil for Field %q", string(*expected.CustomFieldType), fieldName)
+	}
+	if expected.CustomFieldType == nil && actual.CustomFieldType != nil {
+		t.Fatalf("expected `CustomFieldType` to be nil but got %q for Field %q", string(*actual.CustomFieldType), fieldName)
+	}
+	if expected.CustomFieldType != nil && actual.CustomFieldType != nil && *expected.CustomFieldType != *actual.CustomFieldType {
+		t.Fatalf("expected `CustomFieldType` to be %q but got %q for Field %q", *expected.CustomFieldType, *actual.CustomFieldType, fieldName)
+	}
+
+	if expected.ObjectDefinition != nil && actual.ObjectDefinition == nil {
+		t.Fatalf("expected `ObjectDefinition` to be %q but got nil for Field %q", expected.ObjectDefinition.String(), fieldName)
+	}
+	if expected.ObjectDefinition == nil && actual.ObjectDefinition != nil {
+		t.Fatalf("expected `ObjectDefinition` to be nil but got %q for Field %q", actual.ObjectDefinition.String(), fieldName)
+	}
+	if expected.ObjectDefinition != nil && actual.ObjectDefinition != nil {
+		validateParsedObjectDefinitionsMatch(t, *expected.ObjectDefinition, *actual.ObjectDefinition, fieldName)
+	}
+}
+
+func validateParsedModelsMatch(t *testing.T, expected models.ModelDetails, actual models.ModelDetails, modelName string) {
+	if pointer.From(expected.ParentTypeName) != pointer.From(actual.ParentTypeName) {
+		// NOTE: this should be nil when unset, otherwise a value
+		t.Fatalf("expected `ParentTypeName` to be %q but got %q for Model %q", pointer.From(expected.ParentTypeName), pointer.From(actual.ParentTypeName), modelName)
+	}
+	if pointer.From(expected.TypeHintIn) != pointer.From(actual.TypeHintIn) {
+		// NOTE: this should be nil when unset, otherwise a value
+		t.Fatalf("expected `TypeHintIn` to be %q but got %q for Model %q", pointer.From(expected.TypeHintIn), pointer.From(actual.TypeHintIn), modelName)
+	}
+	if pointer.From(expected.TypeHintValue) != pointer.From(actual.TypeHintValue) {
+		// NOTE: this should be nil when unset, otherwise a value
+		t.Fatalf("expected `TypeHintValue` to be %q but got %q for Model %q", pointer.From(expected.TypeHintValue), pointer.From(actual.TypeHintValue), modelName)
+	}
+	if expected.Description != actual.Description {
+		t.Fatalf("expected `Description` to be %q but got %q for Model %q", expected.Description, actual.Description, modelName)
+	}
+	validateMapsMatch(t, expected.Fields, actual.Fields, "Fields", validateParsedFieldsMatch)
+}
+
+func validateParsedObjectDefinitionsMatch(t *testing.T, expected, actual models.ObjectDefinition, fieldName string) {
+	if pointer.From(expected.Maximum) != pointer.From(actual.Maximum) {
+		t.Fatalf("expected `Maximum` to be %d but got %d for Field %q", pointer.From(expected.Maximum), pointer.From(actual.Maximum), fieldName)
+	}
+	if pointer.From(expected.Minimum) != pointer.From(actual.Minimum) {
+		t.Fatalf("expected `Minimum` to be %d but got %d for Field %q", pointer.From(expected.Minimum), pointer.From(actual.Minimum), fieldName)
+	}
+	if pointer.From(expected.ReferenceName) != pointer.From(actual.ReferenceName) {
+		t.Fatalf("expected `ReferenceName` to be %q but got %q for Field %q", pointer.From(expected.ReferenceName), pointer.From(actual.ReferenceName), fieldName)
+	}
+	if expected.Type != actual.Type {
+		t.Fatalf("expected `Type` to be %q but got %q for Field %q", string(expected.Type), string(actual.Type), fieldName)
+	}
+	if pointer.From(expected.UniqueItems) != pointer.From(actual.UniqueItems) {
+		t.Fatalf("expected `UniqueItems` to be %t but got %t for Field %q", pointer.From(expected.UniqueItems), pointer.From(actual.UniqueItems), fieldName)
+	}
+
+	validateObjectsMatch(t, expected.NestedItem, actual.NestedItem, "NestedItem", validateParsedObjectDefinitionsMatch)
+}
+
+func validateParsedOperationsMatch(t *testing.T, expected, actual models.OperationDetails, operationName string) {
+	if expected.ContentType != actual.ContentType {
+		t.Fatalf("expected `ContentType` to be %q but got %q for Operation %q", expected.ContentType, actual.ContentType, operationName)
+	}
+	validateSlicesMatch(t, expected.ExpectedStatusCodes, actual.ExpectedStatusCodes, "ExpectedStatusCodes", validateIntegersMatch)
+	if pointer.From(expected.FieldContainingPaginationDetails) != pointer.From(actual.FieldContainingPaginationDetails) {
+		t.Fatalf("expected `FieldContainingPaginationDetails` to be %q but got %q for Operation %q", pointer.From(expected.FieldContainingPaginationDetails), pointer.From(actual.FieldContainingPaginationDetails), operationName)
+	}
+	if expected.IsListOperation != actual.IsListOperation {
+		t.Fatalf("expected `IsListOperation` to be %t but got %t for Operation %q", expected.IsListOperation, actual.IsListOperation, operationName)
+	}
+	if expected.LongRunning != actual.LongRunning {
+		t.Fatalf("expected `LongRunning` to be %t but got %t for Operation %q", expected.LongRunning, actual.LongRunning, operationName)
+	}
+	if expected.Method != actual.Method {
+		t.Fatalf("expected `Method` to be %q but got %q for Operation %q", expected.Method, actual.Method, operationName)
+	}
+	if expected.OperationId != actual.OperationId {
+		t.Fatalf("expected `OperationId` to be %q but got %q for Operation %q", expected.OperationId, actual.OperationId, operationName)
+	}
+	validateMapsMatch(t, expected.Options, actual.Options, "Options", validateParsedOptionsMatch)
+	if pointer.From(expected.ResourceIdName) != pointer.From(actual.ResourceIdName) {
+		t.Fatalf("expected `ResourceIdName` to be %q but got %q for Operation %q", pointer.From(expected.ResourceIdName), pointer.From(actual.ResourceIdName), operationName)
+	}
+	validateObjectsMatch(t, expected.RequestObject, actual.RequestObject, "RequestObject", validateParsedObjectDefinitionsMatch)
+	validateObjectsMatch(t, expected.ResponseObject, actual.ResponseObject, "ResponseObject", validateParsedObjectDefinitionsMatch)
+	if pointer.From(expected.UriSuffix) != pointer.From(actual.UriSuffix) {
+		t.Fatalf("expected `UriSuffix` to be %q but got %q for Operation %q", pointer.From(expected.UriSuffix), pointer.From(actual.UriSuffix), operationName)
+	}
+}
+
+func validateParsedOptionsMatch(t *testing.T, expected, actual models.OperationOption, optionName string) {
+	if pointer.From(expected.HeaderName) != pointer.From(actual.HeaderName) {
+		t.Errorf("expected `HeaderName` to be %q but got %q for Option %q", pointer.From(expected.HeaderName), pointer.From(actual.HeaderName), optionName)
+	}
+	if pointer.From(expected.QueryStringName) != pointer.From(actual.QueryStringName) {
+		t.Errorf("expected `QueryStringName` to be %q but got %q for Option %q", pointer.From(expected.QueryStringName), pointer.From(actual.QueryStringName), optionName)
+	}
+	if expected.Required != actual.Required {
+		t.Errorf("expected `Required` to be %t but got %t for Option %q", expected.Required, actual.Required, optionName)
+	}
+	// NOTE: this will become its own type once refactored
+	validateObjectsMatch(t, expected.ObjectDefinition, actual.ObjectDefinition, "OptionObjectDefinition", validateParsedObjectDefinitionsMatch)
+}
+
+func validateParsedResourceIDsMatch(t *testing.T, expected, actual models.ParsedResourceId, resourceIdName string) {
+	if pointer.From(expected.CommonAlias) != pointer.From(actual.CommonAlias) {
+		t.Errorf("expected `CommonAlias` to be %q but got %q for Resource ID %q", pointer.From(expected.CommonAlias), pointer.From(actual.CommonAlias), resourceIdName)
+	}
+	validateMapsMatch(t, expected.Constants, actual.Constants, "Constants", validateParsedConstantsMatch)
+	validateSlicesMatch(t, expected.Segments, actual.Segments, "Segments", validateParsedResourceIDSegmentsMatch)
+}
+
+func validateParsedResourceIDSegmentsMatch(t *testing.T, expected, actual resourcemanager.ResourceIdSegment, segmentName string) {
+	if pointer.From(expected.ConstantReference) != pointer.From(actual.ConstantReference) {
+		t.Errorf("expected `ConstantReference` to be %q but got %q for %s", pointer.From(expected.ConstantReference), pointer.From(actual.ConstantReference), segmentName)
+	}
+	if expected.ExampleValue != actual.ExampleValue {
+		t.Errorf("expected `ExampleValue` to be %q but got %q for %s", expected.ExampleValue, actual.ExampleValue, segmentName)
+	}
+	if pointer.From(expected.FixedValue) != pointer.From(actual.FixedValue) {
+		t.Errorf("expected `FixedValue` to be %q but got %q for %s", pointer.From(expected.FixedValue), pointer.From(actual.FixedValue), segmentName)
+	}
+	if expected.Name != actual.Name {
+		t.Errorf("expected `Name` to be %q but got %q for %s", expected.Name, actual.Name, segmentName)
+	}
+	if string(expected.Type) != string(actual.Type) {
+		t.Errorf("expected `Type` to be %q but got %q for %s", string(expected.Type), string(expected.Type), segmentName)
+	}
+}
+
+func validateParsedTerraformDetailsMatch(t *testing.T, expected, actual resourcemanager.TerraformDetails, _ string) {
+	if len(expected.DataSources) > 0 || len(actual.DataSources) > 0 {
+		t.Fatalf("unimplemented: data source comparisons")
+	}
+	if len(expected.Resources) > 0 || len(actual.Resources) > 0 {
+		// At this time we don't implement Terraform Resource comparisons since we're not expecting
+		// these to be present as a result of the Swagger Parser (these are the next stage).
+		t.Fatalf("unimplemented: Terraform Resource comparisons")
+	}
+}
+
+func validateIntegersMatch(t *testing.T, expected, actual int, key string) {
+	if expected != actual {
+		t.Fatalf("expected %q to be %d but got %d", key, expected, actual)
+	}
+}
+
+func validateStringsMatch(t *testing.T, expected, actual string, key string) {
+	if expected != actual {
+		t.Fatalf("expected %q to be %q but got %q", key, expected, actual)
+	}
+}
+
+// Generic helper functions below this point
+
+func validateObjectsMatch[T any](t *testing.T, expected, actual *T, name string, innerAssert func(t *testing.T, expected T, actual T, key string)) {
+	if expected != nil && actual == nil {
+		t.Fatalf("expected %q to be %q but got nil for %q", name, expected, name)
+	}
+	if expected == nil && actual != nil {
+		t.Fatalf("expected %q to be nil but got %q for %q", name, actual, name)
+	}
+	if expected != nil && actual != nil {
+		innerAssert(t, *expected, *actual, name)
+	}
+}
+
+func validateMapsMatch[T any](t *testing.T, expected, actual map[string]T, name string, innerAssert func(t *testing.T, expected T, actual T, key string)) {
+	if len(actual) != len(expected) {
+		t.Fatalf("expected there to be %d %q but got %d", len(expected), name, len(actual))
+	}
+	resourceKeys := uniqueKeys[T](actual, expected)
+	for _, resourceKey := range resourceKeys {
+		expectedItem, ok := expected[resourceKey]
+		if !ok {
+			t.Fatalf("found an unexpected `%s` called %q", name, resourceKey)
+		}
+		actualItem, ok := actual[resourceKey]
+		if !ok {
+			t.Fatalf("expected a `%s` called %q but got nil", name, resourceKey)
+		}
+
+		innerAssert(t, expectedItem, actualItem, resourceKey)
+	}
+}
+
+func validateSlicesMatch[T any](t *testing.T, expected, actual []T, name string, innerAssert func(t *testing.T, expected T, actual T, key string)) {
+	if len(actual) != len(expected) {
+		t.Fatalf("expected there to be %d %q but got %d", len(expected), name, len(actual))
+	}
+	for i := range expected {
+		expectedItem := expected[i]
+		actualItem := actual[i]
+
+		innerAssert(t, expectedItem, actualItem, fmt.Sprintf("%s item %d", name, i))
+	}
+}
+
+func uniqueKeys[T any](first, second map[string]T) []string {
+	keys := make(map[string]struct{})
+	for key := range first {
+		keys[key] = struct{}{}
+	}
+	for key := range second {
+		keys[key] = struct{}{}
+	}
+
+	out := make([]string, 0)
+	for k := range keys {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/tools/importer-rest-api-specs/components/parser/parse_data.go
+++ b/tools/importer-rest-api-specs/components/parser/parse_data.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -71,7 +71,6 @@ var commonIdTypes = []commonIdMatcher{
 	// HDInsight
 	commonIdHDInsightCluster{},
 
-
 	// Key Vault
 	commonIdKeyVault{},
 	commonIdKeyVaultKey{},

--- a/tools/importer-rest-api-specs/components/schema/builder.go
+++ b/tools/importer-rest-api-specs/components/schema/builder.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/helpers"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/schema/processors"

--- a/tools/importer-rest-api-specs/pipeline/interface.go
+++ b/tools/importer-rest-api-specs/pipeline/interface.go
@@ -14,9 +14,9 @@ type RunInput struct {
 	DataApiEndpoint          *string
 	JustOutputSegments       bool
 	JustParseData            bool
-	Logger          hclog.Logger
-	OutputDirectory string
-	ProviderPrefix  string
+	Logger                   hclog.Logger
+	OutputDirectory          string
+	ProviderPrefix           string
 	Services                 []string
 	SwaggerDirectory         string
 	TerraformDefinitionsPath string


### PR DESCRIPTION
This PR introduces a test assertion helper for the Swagger Parser - the intention being to allow defining the object we're expecting rather than checking specific fields - which should reduce the size of (most of) these tests. It also has the benefit of centralising these assertions, which'll make the upcoming refactoring work in `importer-rest-api-specs` easier.

In this PR I've intentionally only switched over a couple of tests to using this for now, given the number of tests (~150) this wants doing piecemeal to make reviewing easier.