### PR TITLE
`tools/importer-rest-api-specs`: updating (half) the tests to use the new test assertion helpers

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -213,7 +213,7 @@ func validateParsedResourceIDSegmentsMatch(t *testing.T, expected, actual resour
 		t.Errorf("expected `Name` to be %q but got %q for %s", expected.Name, actual.Name, segmentName)
 	}
 	if string(expected.Type) != string(actual.Type) {
-		t.Errorf("expected `Type` to be %q but got %q for %s", string(expected.Type), string(expected.Type), segmentName)
+		t.Errorf("expected `Type` to be %q but got %q for %s", string(expected.Type), string(actual.Type), segmentName)
 	}
 }
 

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -145,6 +145,7 @@ func validateParsedObjectDefinitionsMatch(t *testing.T, expected, actual models.
 }
 
 func validateParsedOperationsMatch(t *testing.T, expected, actual models.OperationDetails, operationName string) {
+	t.Logf("Validating Operation %q..", operationName)
 	if expected.ContentType != actual.ContentType {
 		t.Fatalf("expected `ContentType` to be %q but got %q for Operation %q", expected.ContentType, actual.ContentType, operationName)
 	}
@@ -201,9 +202,10 @@ func validateParsedResourceIDSegmentsMatch(t *testing.T, expected, actual resour
 	if pointer.From(expected.ConstantReference) != pointer.From(actual.ConstantReference) {
 		t.Errorf("expected `ConstantReference` to be %q but got %q for %s", pointer.From(expected.ConstantReference), pointer.From(actual.ConstantReference), segmentName)
 	}
-	if expected.ExampleValue != actual.ExampleValue {
-		t.Errorf("expected `ExampleValue` to be %q but got %q for %s", expected.ExampleValue, actual.ExampleValue, segmentName)
-	}
+	// TODO: enable once the SDK migration is completed
+	//if expected.ExampleValue != actual.ExampleValue {
+	//	t.Errorf("expected `ExampleValue` to be %q but got %q for %s", expected.ExampleValue, actual.ExampleValue, segmentName)
+	//}
 	if pointer.From(expected.FixedValue) != pointer.From(actual.FixedValue) {
 		t.Errorf("expected `FixedValue` to be %q but got %q for %s", pointer.From(expected.FixedValue), pointer.From(actual.FixedValue), segmentName)
 	}

--- a/tools/importer-rest-api-specs/components/parser/operations_test.go
+++ b/tools/importer-rest-api-specs/components/parser/operations_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestParseOperationsEmpty(t *testing.T) {
@@ -51,3185 +52,1586 @@ func TestParseOperationSingleWithTag(t *testing.T) {
 }
 
 func TestParseOperationSingleWithTagAndResourceId(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag_resource_id.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag_resource_id.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"HeadWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_HeadWorld",
+						ResourceIdName:      pointer.To("ThingId"),
+					},
+				},
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ThingId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
+							NewStaticValueResourceIDSegment("staticThings", "things"),
+							NewUserSpecifiedResourceIDSegment("thing", "thing"),
+						},
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["HeadWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name HeadWorld")
-	}
-	if world.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName == nil {
-		t.Fatal("expected a ResourceId but was nil")
-	}
-	if *world.ResourceIdName != "ThingId" {
-		t.Fatalf("expected world.ResourceIdName to be 'Thing' but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix != nil {
-		t.Fatalf("expected world.UriSuffix to be nil but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithTagAndResourceIdSuffix(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag_resource_id_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag_resource_id_suffix.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"HeadWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_HeadWorld",
+						ResourceIdName:      pointer.To("ThingId"),
+						UriSuffix:           pointer.To("/restart"),
+					},
+				},
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ThingId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
+							NewStaticValueResourceIDSegment("staticThings", "things"),
+							NewUserSpecifiedResourceIDSegment("thing", "thing"),
+						},
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["HeadWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name HeadWorld")
-	}
-	if world.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName == nil {
-		t.Fatal("expected a ResourceId but was nil")
-	}
-	if *world.ResourceIdName != "ThingId" {
-		t.Fatalf("expected world.RessourceIdName to be 'Thing' but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/restart" {
-		t.Fatalf("expected world.UriSuffix to be `/restart` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithRequestObject(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_object.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							Type:          models.ObjectDefinitionReference,
+							ReferenceName: pointer.To("Example"),
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but was nil")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the request object to be a reference but got %q", string(world.RequestObject.Type))
-	}
-	if *world.RequestObject.ReferenceName != "Example" {
-		t.Fatalf("expected the request object to be 'Example' but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	exampleModel, ok := hello.Models["Example"]
-	if !ok {
-		t.Fatalf("expected there to be a model called Example")
-	}
-	if len(exampleModel.Fields) != 1 {
-		t.Fatalf("expected the model Example to have 1 field but got %d", len(exampleModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithRequestObjectInlined(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_object_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_object_inlined.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							Type:          models.ObjectDefinitionReference,
+							ReferenceName: pointer.To("Example"),
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but was nil")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the request object to be a reference but got %q", string(world.RequestObject.Type))
-	}
-	if *world.RequestObject.ReferenceName != "Example" {
-		t.Fatalf("expected the request object to be 'Example' but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	exampleModel, ok := hello.Models["Example"]
-	if !ok {
-		t.Fatalf("expected there to be a model called Example")
-	}
-	if len(exampleModel.Fields) != 1 {
-		t.Fatalf("expected the model Example to have 1 field but got %d", len(exampleModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithResponseObject(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"GetWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GetWorld",
+						ResponseObject: &models.ObjectDefinition{
+							Type:          models.ObjectDefinitionReference,
+							ReferenceName: pointer.To("Example"),
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GetWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GetWorld")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatal("expected a response object but didn't get one")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
-	}
-	if *world.ResponseObject.ReferenceName != "Example" {
-		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	exampleModel, ok := hello.Models["Example"]
-	if !ok {
-		t.Fatalf("expected there to be a model called Example")
-	}
-	if len(exampleModel.Fields) != 1 {
-		t.Fatalf("expected the model Example to have 1 field but got %d", len(exampleModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithResponseObjectInlined(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object_inlined.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"GetWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GetWorld",
+						ResponseObject: &models.ObjectDefinition{
+							Type:          models.ObjectDefinitionReference,
+							ReferenceName: pointer.To("Example"),
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GetWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GetWorld")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatal("expected a response object but didn't get one")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
-	}
-	if *world.ResponseObject.ReferenceName != "Example" {
-		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	exampleModel, ok := hello.Models["Example"]
-	if !ok {
-		t.Fatalf("expected there to be a model called Example")
-	}
-	if len(exampleModel.Fields) != 1 {
-		t.Fatalf("expected the model Example to have 1 field but got %d", len(exampleModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithResponseObjectInlinedList(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object_inlined_list.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object_inlined_list.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"GetWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GetWorld",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionList,
+							NestedItem: &models.ObjectDefinition{
+								Type:          models.ObjectDefinitionReference,
+								ReferenceName: pointer.To("Example"),
+							},
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GetWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GetWorld")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatal("expected a response object but didn't get one")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the response object to be a List but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object reference to be nil but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem == nil {
-		t.Fatal("expected the response object to have a nested item but it didn't")
-	}
-	if world.ResponseObject.NestedItem.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response objects nested item to be a reference but got %q", string(world.ResponseObject.NestedItem.Type))
-	}
-	if *world.ResponseObject.NestedItem.ReferenceName != "Example" {
-		t.Fatalf("expected the response objects nested item reference to be 'Example' but got %q", *world.ResponseObject.NestedItem.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	exampleModel, ok := hello.Models["Example"]
-	if !ok {
-		t.Fatalf("expected there to be a model called Example")
-	}
-	if len(exampleModel.Fields) != 1 {
-		t.Fatalf("expected the model Example to have 1 field but got %d", len(exampleModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleRequestingWithABool(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_bool.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_bool.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionBoolean,
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but was nil")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionBoolean {
-		t.Fatalf("expected the request object to be a boolean but got %q", string(world.RequestObject.Type))
-	}
-	if world.RequestObject.ReferenceName != nil {
-		t.Fatalf("expected the request object to be null but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleRequestingWithAInteger(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_int.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_int.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionInteger,
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but was nil")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionInteger {
-		t.Fatalf("expected the request object to be a integer but got %q", string(world.RequestObject.Type))
-	}
-	if world.RequestObject.ReferenceName != nil {
-		t.Fatalf("expected the request object to be null but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleRequestingWithADictionaryOfStrings(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_dictionary_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_dictionary_of_strings.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionDictionary,
+							NestedItem: &models.ObjectDefinition{
+								Type: models.ObjectDefinitionString,
+							},
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but was nil")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionDictionary {
-		t.Fatalf("expected the request object to be a dictionary but got %q", string(world.RequestObject.Type))
-	}
-	if world.RequestObject.ReferenceName != nil {
-		t.Fatalf("expected the request object to be null but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.RequestObject.NestedItem == nil {
-		t.Fatalf("expected the request objects nested item to have a value but didn't get one")
-	}
-	if world.RequestObject.NestedItem.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the request objects nested item to be a string but got %q", string(world.RequestObject.NestedItem.Type))
-	}
-	if world.RequestObject.NestedItem.ReferenceName != nil {
-		t.Fatalf("expected the request objects nested item reference to be nil but got %q", *world.RequestObject.NestedItem.ReferenceName)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleRequestingWithAListOfStrings(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_list_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_list_of_strings.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionList,
+							NestedItem: &models.ObjectDefinition{
+								Type: models.ObjectDefinitionString,
+							},
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but was nil")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the request object to be a list but got %q", string(world.RequestObject.Type))
-	}
-	if world.RequestObject.ReferenceName != nil {
-		t.Fatalf("expected the request object to be null but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.RequestObject.NestedItem == nil {
-		t.Fatalf("expected the request objects nested item to have a value but didn't get one")
-	}
-	if world.RequestObject.NestedItem.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the request objects nested item to be a string but got %q", string(world.RequestObject.NestedItem.Type))
-	}
-	if world.RequestObject.NestedItem.ReferenceName != nil {
-		t.Fatalf("expected the request objects nested item reference to be nil but got %q", *world.RequestObject.NestedItem.ReferenceName)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 // Models are already tested above
 
 func TestParseOperationSingleRequestingWithAString(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_string.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_string.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionString,
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but was nil")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the request object to be a string but got %q", string(world.RequestObject.Type))
-	}
-	if world.RequestObject.ReferenceName != nil {
-		t.Fatalf("expected the request object to be null but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningABool(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_bool.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_bool.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeABoolean": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeABoolean",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionBoolean,
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeABoolean"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeABoolean")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionBoolean {
-		t.Fatalf("expected the response object to be a bool but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAFloat(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_float.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_float.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeAFloat": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAFloat",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionFloat,
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAFloat"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAFloat")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionFloat {
-		t.Fatalf("expected the response object to be a float but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAFile(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_file.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_file.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeAFile": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAFile",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionRawFile,
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAFile"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAFile")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionRawFile {
-		t.Fatalf("expected the response object to be a RawFile but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAnInteger(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_integer.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_integer.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeAnInteger": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAnInteger",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionInteger,
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAnInteger"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAnInteger")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionInteger {
-		t.Fatalf("expected the response object to be a int but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAString(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_string.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_string.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeAString": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAString",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionString,
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAString"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAString")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the response object to be a string but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAnErrorStatusCode(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_error_status_code.json")
+	// In this instance the error status code should be ignored we're only concerned with 2XX status codes
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_error_status_code.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeAString": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAString",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionString,
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAString"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAString")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	// the 401 should be ignored
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the response object to be a string but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningATopLevelRawObject(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_top_level_raw_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_top_level_raw_object.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"RawObjectToMeToYou": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_RawObjectToMeToYou",
+						RequestObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionRawObject,
+						},
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionRawObject,
+						},
+						UriSuffix: pointer.To("/chuckle"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	operation, ok := hello.Operations["RawObjectToMeToYou"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAString")
-	}
-	if operation.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", operation.Method)
-	}
-	if len(operation.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(operation.ExpectedStatusCodes))
-	}
-	if operation.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", operation.ExpectedStatusCodes[0])
-	}
-	if operation.RequestObject == nil {
-		t.Fatalf("expected a request object but got none")
-	}
-	if operation.RequestObject.Type != models.ObjectDefinitionRawObject {
-		t.Fatalf("expected the request object to be a RawObject but got %q", string(operation.RequestObject.Type))
-	}
-	if operation.RequestObject.ReferenceName != nil {
-		t.Fatalf("expected the request object to have no reference but got %q", *operation.RequestObject.ReferenceName)
-	}
-	if operation.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if operation.ResponseObject.Type != models.ObjectDefinitionRawObject {
-		t.Fatalf("expected the response object to be a RawObject but got %q", string(operation.ResponseObject.Type))
-	}
-	if operation.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *operation.ResponseObject.ReferenceName)
-	}
-	if operation.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix == nil {
-		t.Fatal("expected operation.UriSuffix to have a value")
-	}
-	if *operation.UriSuffix != "/worlds" {
-		t.Fatalf("expected operation.UriSuffix to be `/worlds` but got %q", *operation.UriSuffix)
-	}
-	if operation.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningADictionaryOfAModel(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_dictionary_of_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_dictionary_of_model.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Person": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"GimmeADictionaryOfAModel": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeADictionaryOfAModel",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionDictionary,
+							NestedItem: &models.ObjectDefinition{
+								ReferenceName: pointer.To("Person"),
+								Type:          models.ObjectDefinitionReference,
+							},
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeADictionaryOfAModel"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeADictionaryOfAModel")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionDictionary {
-		t.Fatalf("expected the response object to be a dictionary but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem == nil {
-		t.Fatalf("expected the response objects nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response objects nested item to be a referenc but got %q", string(world.ResponseObject.NestedItem.Type))
-	}
-	if world.ResponseObject.NestedItem.ReferenceName == nil {
-		t.Fatalf("expected the response objects nested item to have a reference but got nothing")
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningADictionaryOfStrings(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_dictionary_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_dictionary_of_strings.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeADictionaryOfStrings": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeADictionaryOfStrings",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionDictionary,
+							NestedItem: &models.ObjectDefinition{
+								Type: models.ObjectDefinitionString,
+							},
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeADictionaryOfStrings"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeADictionaryOfStrings")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionDictionary {
-		t.Fatalf("expected the response object to be a dictionary but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem == nil {
-		t.Fatalf("expected the response objects nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the response objects nested item to be a string but got %q", string(world.ResponseObject.NestedItem.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response objects nested item to have no reference but got %q", *world.ResponseObject.NestedItem.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAListOfIntegers(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_ints.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_ints.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeAListOfIntegers": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAListOfIntegers",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionList,
+							NestedItem: &models.ObjectDefinition{
+								Type: models.ObjectDefinitionInteger,
+							},
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAListOfIntegers"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAListOfIntegers")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the response object to be a list but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem == nil {
-		t.Fatalf("expected the response objects nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.Type != models.ObjectDefinitionInteger {
-		t.Fatalf("expected the response objects nested item to be an integer but got %q", string(world.ResponseObject.NestedItem.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response objects nested item to have no reference but got %q", *world.ResponseObject.NestedItem.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAListOfAModel(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_model.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Person": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"GimmeAListOfModels": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAListOfModels",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionList,
+							NestedItem: &models.ObjectDefinition{
+								ReferenceName: pointer.To("Person"),
+								Type:          models.ObjectDefinitionReference,
+							},
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAListOfModel"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAListOfModel")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the response object to be a list but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem == nil {
-		t.Fatalf("expected the response objects nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response objects nested item to be a reference but got %q", string(world.ResponseObject.NestedItem.Type))
-	}
-	if world.ResponseObject.NestedItem.ReferenceName == nil {
-		t.Fatalf("expected the response objects nested item to have a reference but it didn't have one")
-	}
-	if *world.ResponseObject.NestedItem.ReferenceName != "Person" {
-		t.Fatalf("expected the response objects nested item reference to be `Person` but it was %q", *world.ResponseObject.NestedItem.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAListOfStrings(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_strings.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeAListOfStrings": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAListOfStrings",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionList,
+							NestedItem: &models.ObjectDefinition{
+								Type: models.ObjectDefinitionString,
+							},
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAListOfStrings"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAListOfStrings")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the response object to be a list but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem == nil {
-		t.Fatalf("expected the response objects nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the response objects nested item to be a string but got %q", string(world.ResponseObject.NestedItem.Type))
-	}
-	if world.ResponseObject.NestedItem.ReferenceName != nil {
-		t.Fatalf("expected the response objects nested item to have no reference but got %q", *world.ResponseObject.NestedItem.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAListOfListOfAModel(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_list_of_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_list_of_model.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Person": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"GimmeAListOfListOfModels": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAListOfListOfModels",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionList,
+							NestedItem: &models.ObjectDefinition{
+								Type: models.ObjectDefinitionList,
+								NestedItem: &models.ObjectDefinition{
+									ReferenceName: pointer.To("Person"),
+									Type:          models.ObjectDefinitionReference,
+								},
+							},
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAListOfListOfAModel"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAListOfListOfAModel")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the response object to be a list but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem == nil {
-		t.Fatalf("expected the response objects nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the response objects nested item to be a list but got %q", string(world.ResponseObject.NestedItem.Type))
-	}
-	if world.ResponseObject.NestedItem.ReferenceName != nil {
-		t.Fatalf("expected the response objects nested item to have no reference but got %q", *world.ResponseObject.NestedItem.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem.NestedItem == nil {
-		t.Fatalf("expected the response objects nested items nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.NestedItem.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response objects nested item to be a reference but got %q", string(world.ResponseObject.NestedItem.NestedItem.Type))
-	}
-	if world.ResponseObject.NestedItem.NestedItem.ReferenceName == nil {
-		t.Fatalf("expected the response objects nested items nested item to have a reference but didn't get one")
-	}
-	if *world.ResponseObject.NestedItem.NestedItem.ReferenceName != "Person" {
-		t.Fatalf("expected the response objects nested item reference to be `Person` but it was %q", *world.ResponseObject.NestedItem.NestedItem.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleReturningAListOfListOfStrings(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_list_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_list_of_strings.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"GimmeAListOfListOfStrings": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_GimmeAListOfListOfStrings",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionList,
+							NestedItem: &models.ObjectDefinition{
+								Type: models.ObjectDefinitionList,
+								NestedItem: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+							},
+						},
+						UriSuffix: pointer.To("/worlds/favourite"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["GimmeAListOfListOfStrings"]
-	if !ok {
-		t.Fatalf("no resources were output with the name GimmeAListOfStrings")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatalf("expected a response object but got none")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the response object to be a list but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem == nil {
-		t.Fatalf("expected the response objects nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.Type != models.ObjectDefinitionList {
-		t.Fatalf("expected the response objects nested item to be a list but got %q", string(world.ResponseObject.NestedItem.Type))
-	}
-	if world.ResponseObject.NestedItem.ReferenceName != nil {
-		t.Fatalf("expected the response objects nested item to have no reference but got %q", *world.ResponseObject.NestedItem.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem.NestedItem == nil {
-		t.Fatalf("expected the response objects nested items nested item to have a valid but it didn't")
-	}
-	if world.ResponseObject.NestedItem.NestedItem.ReferenceName != nil {
-		t.Fatalf("expected the response objects nested items nested item to have no reference but got %q", *world.ResponseObject.NestedItem.NestedItem.ReferenceName)
-	}
-	if world.ResponseObject.NestedItem.NestedItem.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the response objects nested item to be a string but got %q", string(world.ResponseObject.NestedItem.NestedItem.Type))
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds/favourite" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds/favourite` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithList(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_list.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"World": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"ListWorlds": {
+						ContentType:                      "application/json",
+						ExpectedStatusCodes:              []int{200},
+						FieldContainingPaginationDetails: pointer.To("nextLink"),
+						IsListOperation:                  true,
+						Method:                           "GET",
+						OperationId:                      "Hello_ListWorlds",
+						ResponseObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("World"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/worlds"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["ListWorlds"]
-	if !ok {
-		t.Fatalf("no resources were output with the name ListWorlds")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatal("expected a response object but didn't get one")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
-	}
-	if *world.ResponseObject.ReferenceName != "World" {
-		t.Fatalf("expected the response object to be 'World' but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.FieldContainingPaginationDetails == nil {
-		t.Fatalf("expected there to be pagination details but there weren't")
-	}
-	if *world.FieldContainingPaginationDetails != "nextLink" {
-		t.Fatalf("expected the field containing pagination details to be 'nextLink' but got %q", *world.FieldContainingPaginationDetails)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-	if len(world.Options) > 0 {
-		t.Fatalf("expected no options (since skipToken isn't directly configurable) but got %d options", len(world.Options))
-	}
-
-	worldModel, ok := hello.Models["World"]
-	if !ok {
-		t.Fatalf("expected there to be a model called World")
-	}
-	if len(worldModel.Fields) != 1 {
-		t.Fatalf("expected the model World to have 1 field but got %d", len(worldModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithListWhichIsNotAList(t *testing.T) {
 	// all List operations should have an `x-ms-pageable` attribute, but some don't due to bad data
 	// as such this checks we can duck-type it out
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_list_which_is_not_a_list.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_which_is_not_a_list.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"World": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"ListWorlds": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						// This signifies there's a list of items without a means of paging over it.
+						// This is _likely_ a badly documented API Definition, but it's hard to say for sure.
+						FieldContainingPaginationDetails: nil,
+						IsListOperation:                  true,
+						Method:                           "GET",
+						OperationId:                      "Hello_ListWorlds",
+						ResponseObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("World"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/worlds"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["ListWorlds"]
-	if !ok {
-		t.Fatalf("no resources were output with the name ListWorlds")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatal("expected a response object but didn't get one")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
-	}
-	if *world.ResponseObject.ReferenceName != "World" {
-		t.Fatalf("expected the response object to be 'World' but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.FieldContainingPaginationDetails != nil {
-		t.Fatalf("expected there to be no pagination details (since this isn't actually a list) but got %q", *world.FieldContainingPaginationDetails)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-	if len(world.Options) > 0 {
-		t.Fatalf("expected no options (since skipToken isn't directly configurable) but got %d options", len(world.Options))
-	}
-
-	worldModel, ok := hello.Models["World"]
-	if !ok {
-		t.Fatalf("expected there to be a model called World")
-	}
-	if len(worldModel.Fields) != 1 {
-		t.Fatalf("expected the model World to have 1 field but got %d", len(worldModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithListReturningAListOfStrings(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_list_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_of_strings.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"ListWorlds": {
+						ContentType:                      "application/json",
+						ExpectedStatusCodes:              []int{200},
+						FieldContainingPaginationDetails: pointer.To("nextLink"),
+						IsListOperation:                  true,
+						Method:                           "GET",
+						OperationId:                      "Hello_ListWorlds",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionString,
+						},
+						UriSuffix: pointer.To("/worlds"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected No Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["ListWorlds"]
-	if !ok {
-		t.Fatalf("no resources were output with the name ListWorlds")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatal("expected a response object but didn't get one")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected the response object to be a string but got %q", string(world.ResponseObject.Type))
-	}
-	if world.ResponseObject.ReferenceName != nil {
-		t.Fatalf("expected the response object to have no reference but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.FieldContainingPaginationDetails == nil {
-		t.Fatalf("expected there to be pagination details but there weren't")
-	}
-	if *world.FieldContainingPaginationDetails != "nextLink" {
-		t.Fatalf("expected the field containing pagination details to be 'nextLink' but got %q", *world.FieldContainingPaginationDetails)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-	if len(world.Options) > 0 {
-		t.Fatalf("expected no options (since skipToken isn't directly configurable) but got %d options", len(world.Options))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithListWithoutPageable(t *testing.T) {
 	// all List operations should have an `x-ms-pageable` attribute, but some don't due to bad data
 	// as such this checks we can duck-type it out
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_list_without_pageable.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_without_pageable.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"World": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"ListWorlds": {
+						ContentType:                      "application/json",
+						ExpectedStatusCodes:              []int{200},
+						FieldContainingPaginationDetails: pointer.To("nextLink"),
+						IsListOperation:                  true,
+						Method:                           "GET",
+						OperationId:                      "Hello_ListWorlds",
+						ResponseObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("World"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/worlds"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["ListWorlds"]
-	if !ok {
-		t.Fatalf("no resources were output with the name ListWorlds")
-	}
-	if world.Method != "GET" {
-		t.Fatalf("expected a GET operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject == nil {
-		t.Fatal("expected a response object but didn't get one")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
-	}
-	if *world.ResponseObject.ReferenceName != "World" {
-		t.Fatalf("expected the response object to be 'World' but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.FieldContainingPaginationDetails == nil {
-		t.Fatalf("expected there to be pagination details but there weren't")
-	}
-	if *world.FieldContainingPaginationDetails != "nextLink" {
-		t.Fatalf("expected the field containing pagination details to be 'nextLink' but got %q", *world.FieldContainingPaginationDetails)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/worlds" {
-		t.Fatalf("expected world.UriSuffix to be `/worlds` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-	if len(world.Options) > 0 {
-		t.Fatalf("expected no options (since skipToken isn't directly configurable) but got %d options", len(world.Options))
-	}
-
-	worldModel, ok := hello.Models["World"]
-	if !ok {
-		t.Fatalf("expected there to be a model called World")
-	}
-	if len(worldModel.Fields) != 1 {
-		t.Fatalf("expected the model World to have 1 field but got %d", len(worldModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithLongRunningOperation(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_long_running.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_long_running.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						LongRunning:         true,
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but didn't get one")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the request object to be a reference but got %q", string(world.RequestObject.Type))
-	}
-	if *world.RequestObject.ReferenceName != "Example" {
-		t.Fatalf("expected the request object to be 'Example' but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if !world.LongRunning {
-		t.Fatal("expected a long running operation but it wasn't")
-	}
-
-	exampleModel, ok := hello.Models["Example"]
-	if !ok {
-		t.Fatalf("expected there to be a model called Example")
-	}
-	if len(exampleModel.Fields) != 1 {
-		t.Fatalf("expected the model Example to have 1 field but got %d", len(exampleModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithRequestAndResponseObject(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_and_response_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_and_response_object.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"PutWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutWorld",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						ResponseObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["PutWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name PutWorld")
-	}
-	if world.Method != "PUT" {
-		t.Fatalf("expected a PUT operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject == nil {
-		t.Fatal("expected a request object but didn't get one")
-	}
-	if world.RequestObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the request object to be a reference but got %q", string(world.RequestObject.Type))
-	}
-	if *world.RequestObject.ReferenceName != "Example" {
-		t.Fatalf("expected the request object to be 'Example' but got %q", *world.RequestObject.ReferenceName)
-	}
-	if world.ResponseObject == nil {
-		t.Fatal("expected a response object but didn't get one")
-	}
-	if world.ResponseObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the response object to be a reference but got %q", string(world.ResponseObject.Type))
-	}
-	if *world.ResponseObject.ReferenceName != "Example" {
-		t.Fatalf("expected the response object to be 'Example' but got %q", *world.ResponseObject.ReferenceName)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	exampleModel, ok := hello.Models["Example"]
-	if !ok {
-		t.Fatalf("expected there to be a model called Example")
-	}
-	if len(exampleModel.Fields) != 1 {
-		t.Fatalf("expected the model Example to have 1 field but got %d", len(exampleModel.Fields))
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithMultipleTags(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_tags.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_tags.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 2 {
-		t.Fatalf("expected 2 resources but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"HeadThings": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_HeadThings",
+						UriSuffix:           pointer.To("/things"),
+					},
+				},
+			},
+			"Other": {
+				Operations: map[string]models.OperationDetails{
+					// Whilst the operation name should be `HeadThings`, since this is another Tag
+					// it's intentionally prefixed for when things cross boundaries (to avoid conflicts)
+					"HelloHeadThings": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_HeadThings",
+						UriSuffix:           pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	things, ok := hello.Operations["HeadThings"]
-	if !ok {
-		t.Fatalf("no resources were output with the name HeadThings")
-	}
-	if things.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", things.Method)
-	}
-	if len(things.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(things.ExpectedStatusCodes))
-	}
-	if things.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", things.ExpectedStatusCodes[0])
-	}
-	if things.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *things.RequestObject)
-	}
-	if things.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *things.ResponseObject)
-	}
-	if things.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *things.ResourceIdName)
-	}
-	if things.UriSuffix == nil {
-		t.Fatal("expected things.UriSuffix to have a value")
-	}
-	if *things.UriSuffix != "/things" {
-		t.Fatalf("expected things.UriSuffix to be `/things` but got %q", *things.UriSuffix)
-	}
-	if things.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	// then validate it in Other too
-	other, ok := result.Resources["Other"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Other")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	// whilst the operation name should be `HeadThings`, since this is another Tag
-	// it's intentionally prefixed for when things cross boundaries (to avoid conflicts)
-	things, ok = other.Operations["HelloHeadThings"]
-	if !ok {
-		t.Fatalf("no resources were output with the name HelloHeadThings")
-	}
-	if things.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", things.Method)
-	}
-	if len(things.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(things.ExpectedStatusCodes))
-	}
-	if things.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", things.ExpectedStatusCodes[0])
-	}
-	if things.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *things.RequestObject)
-	}
-	if things.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *things.ResponseObject)
-	}
-	if things.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *things.ResourceIdName)
-	}
-	if things.UriSuffix == nil {
-		t.Fatal("expected things.UriSuffix to have a value")
-	}
-	if *things.UriSuffix != "/things" {
-		t.Fatalf("expected things.UriSuffix to be `/things` but got %q", *things.UriSuffix)
-	}
-	if things.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithInferredTag(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_no_tag.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_no_tag.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	// since there's no tags, the file name is used to infer the tag (in this case, 'OperationsSingleWithNoTags')
-	example, ok := result.Resources["OperationsSingleWithNoTags"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			// since there's no tags, the file name is used to infer the tag (in this case, 'OperationsSingleWithNoTags')
+			"OperationsSingleWithNoTags": {
+				Operations: map[string]models.OperationDetails{
+					// since the prefix doesn't match the Tag (since no tag) this gets a combined name
+					"HelloHeadWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_HeadWorld",
+						UriSuffix:           pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(example.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(example.Constants))
-	}
-	if len(example.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(example.Models))
-	}
-	if len(example.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(example.Operations))
-	}
-	if len(example.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(example.ResourceIds))
-	}
-
-	// since the prefix doesn't match the Tag (since no tag) this gets a combined name
-	world, ok := example.Operations["HelloHeadWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name HelloHeadWorld")
-	}
-	if world.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithHeaderOptions(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_header_options.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_header_options.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"HeadWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_HeadWorld",
+						Options: map[string]models.OperationOption{
+							"BoolValue": {
+								HeaderName: pointer.To("boolValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionBoolean,
+								},
+								Required: true,
+							},
+							"CsvOfDoubleValue": {
+								HeaderName: pointer.To("csvOfDoubleValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionCsv,
+									NestedItem: &models.ObjectDefinition{
+										Type: models.ObjectDefinitionFloat,
+									},
+								},
+								Required: true,
+							},
+							"CsvOfStringValue": {
+								HeaderName: pointer.To("csvOfStringValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionCsv,
+									NestedItem: &models.ObjectDefinition{
+										Type: models.ObjectDefinitionString,
+									},
+								},
+								Required: true,
+							},
+							"DecimalValue": {
+								HeaderName: pointer.To("decimalValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionFloat,
+								},
+								Required: true,
+							},
+							"DoubleValue": {
+								HeaderName: pointer.To("doubleValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionFloat,
+								},
+								Required: true,
+							},
+							"IntValue": {
+								HeaderName: pointer.To("intValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionInteger,
+								},
+								Required: true,
+							},
+							"StringValue": {
+								HeaderName: pointer.To("stringValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: true,
+							},
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["HeadWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name HeadWorld")
-	}
-	if world.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	if len(world.Options) != 7 {
-		t.Fatalf("expected HeadWorld to have 7 options but got %d", len(world.Options))
-	}
-
-	boolOption, ok := world.Options["BoolValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'BoolValue' but didn't get it")
-	}
-	if boolOption.ObjectDefinition.Type != models.ObjectDefinitionBoolean {
-		t.Fatalf("expected HeadWorld Option 'BoolValue' to be a Boolean but got %q", string(boolOption.ObjectDefinition.Type))
-	}
-	if boolOption.QueryStringName != nil {
-		t.Fatalf("expected HeadWorld Option 'BoolValue's QueryStringName to be nil but got %q", *boolOption.QueryStringName)
-	}
-	if boolOption.HeaderName == nil {
-		t.Fatalf("expected HeadWorld Option 'BoolValue's QueryStringName to be `boolValue` but was nil")
-	}
-	if boolOption.HeaderName != nil && *boolOption.HeaderName != "boolValue" {
-		t.Fatalf("expected HeadWorld Option 'BoolValue's HeaderName to be `boolValue` but got %q", *boolOption.HeaderName)
-	}
-
-	csvOfDoubleValueOption, ok := world.Options["CsvOfDoubleValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'CsvOfDoubleValue' but didn't get it")
-	}
-	if csvOfDoubleValueOption.ObjectDefinition.Type != models.ObjectDefinitionCsv {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue' to be a Csv but got %q", string(csvOfDoubleValueOption.ObjectDefinition.Type))
-	}
-	if csvOfDoubleValueOption.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionFloat {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue's Nested Type to be a Float but got %q", string(csvOfDoubleValueOption.ObjectDefinition.NestedItem.Type))
-	}
-	if csvOfDoubleValueOption.QueryStringName != nil {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue's QueryStringName to be nil but got %q", *csvOfDoubleValueOption.QueryStringName)
-	}
-	if csvOfDoubleValueOption.HeaderName == nil {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue's HeaderName to be `csvOfDoubleValue` but was nil")
-	}
-	if csvOfDoubleValueOption.HeaderName != nil && *csvOfDoubleValueOption.HeaderName != "csvOfDoubleValue" {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue's HeaderName to be `csvOfDoubleValue` but got %q", *csvOfDoubleValueOption.HeaderName)
-	}
-
-	csvOfStringOption, ok := world.Options["CsvOfStringValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'CsvOfStringValue' but didn't get it")
-	}
-	if csvOfStringOption.ObjectDefinition.Type != models.ObjectDefinitionCsv {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue' to be a Csv but got %q", string(csvOfStringOption.ObjectDefinition.Type))
-	}
-	if csvOfStringOption.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue's Nested Type to be a String but got %q", string(csvOfStringOption.ObjectDefinition.NestedItem.Type))
-	}
-	if csvOfStringOption.QueryStringName != nil {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue's QueryStringName to be nil but got %q", *csvOfStringOption.QueryStringName)
-	}
-	if csvOfStringOption.HeaderName == nil {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue's HeaderName to be `csvOfStringValue` but was nil")
-	}
-	if csvOfStringOption.HeaderName != nil && *csvOfStringOption.HeaderName != "csvOfStringValue" {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue's HeaderName to be `csvOfStringValue` but got %q", *csvOfStringOption.HeaderName)
-	}
-
-	decimalOption, ok := world.Options["DecimalValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'DecimalValue' but didn't get it")
-	}
-	if decimalOption.ObjectDefinition.Type != models.ObjectDefinitionFloat {
-		t.Fatalf("expected HeadWorld Option 'DecimalValue' to be a Float but got %q", string(decimalOption.ObjectDefinition.Type))
-	}
-	if decimalOption.QueryStringName != nil {
-		t.Fatalf("expected HeadWorld Option 'DecimalValue's QueryStringName to be nil but got %q", *decimalOption.QueryStringName)
-	}
-	if decimalOption.HeaderName == nil {
-		t.Fatalf("expected HeadWorld Option 'DecimalValue's HeaderName to be `decimalValue` but was nil")
-	}
-	if decimalOption.HeaderName != nil && *decimalOption.HeaderName != "decimalValue" {
-		t.Fatalf("expected HeadWorld Option 'DecimalValue's HeaderName to be `decimalValue` but got %q", *decimalOption.HeaderName)
-	}
-
-	doubleOption, ok := world.Options["DoubleValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'DoubleValue' but didn't get it")
-	}
-	if doubleOption.ObjectDefinition.Type != models.ObjectDefinitionFloat {
-		t.Fatalf("expected HeadWorld Option 'DoubleValue' to be a Float but got %q", string(doubleOption.ObjectDefinition.Type))
-	}
-	if doubleOption.QueryStringName != nil {
-		t.Fatalf("expected HeadWorld Option 'DoubleValue's QueryStringName to be nil but got %q", *doubleOption.QueryStringName)
-	}
-	if doubleOption.HeaderName == nil {
-		t.Fatalf("expected HeadWorld Option 'DoubleValue's HeaderName to be `doubleValue` but was nil")
-	}
-	if doubleOption.HeaderName != nil && *doubleOption.HeaderName != "doubleValue" {
-		t.Fatalf("expected HeadWorld Option 'DoubleValue's HeaderName to be `doubleValue` but got %q", *doubleOption.HeaderName)
-	}
-
-	intOption, ok := world.Options["IntValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'IntValue' but didn't get it")
-	}
-	if intOption.ObjectDefinition.Type != models.ObjectDefinitionInteger {
-		t.Fatalf("expected HeadWorld Option 'IntValue' to be a Integer but got %q", string(intOption.ObjectDefinition.Type))
-	}
-	if intOption.QueryStringName != nil {
-		t.Fatalf("expected HeadWorld Option 'IntValue's QueryStringName to be nil but got %q", *intOption.QueryStringName)
-	}
-	if intOption.HeaderName == nil {
-		t.Fatalf("expected HeadWorld Option 'IntValue's HeaderName to be `intValue` but was nil")
-	}
-	if intOption.HeaderName != nil && *intOption.HeaderName != "intValue" {
-		t.Fatalf("expected HeadWorld Option 'IntValue's HeaderName to be `intValue` but got %q", *intOption.HeaderName)
-	}
-
-	stringOption, ok := world.Options["StringValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'StringValue' but didn't get it")
-	}
-	if stringOption.ObjectDefinition.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected HeadWorld Option 'StringValue' to be a String but got %q", string(stringOption.ObjectDefinition.Type))
-	}
-	if stringOption.QueryStringName != nil {
-		t.Fatalf("expected HeadWorld Option 'StringValue's QueryStringName to be nil but got %q", *stringOption.QueryStringName)
-	}
-	if stringOption.HeaderName == nil {
-		t.Fatalf("expected HeadWorld Option 'StringValue's HeaderName to be `stringValue` but was nil")
-	}
-	if stringOption.HeaderName != nil && *stringOption.HeaderName != "stringValue" {
-		t.Fatalf("expected HeadWorld Option 'StringValue's HeaderName to be `stringValue` but got %q", *stringOption.HeaderName)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationSingleWithQueryStringOptions(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_with_querystring_options.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_querystring_options.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"HeadWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_HeadWorld",
+						Options: map[string]models.OperationOption{
+							"BoolValue": {
+								QueryStringName: pointer.To("boolValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionBoolean,
+								},
+								Required: true,
+							},
+							"CsvOfDoubleValue": {
+								QueryStringName: pointer.To("csvOfDoubleValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionCsv,
+									NestedItem: &models.ObjectDefinition{
+										Type: models.ObjectDefinitionFloat,
+									},
+								},
+								Required: true,
+							},
+							"CsvOfStringValue": {
+								QueryStringName: pointer.To("csvOfStringValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionCsv,
+									NestedItem: &models.ObjectDefinition{
+										Type: models.ObjectDefinitionString,
+									},
+								},
+								Required: true,
+							},
+							"DecimalValue": {
+								QueryStringName: pointer.To("decimalValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionFloat,
+								},
+								Required: true,
+							},
+							"DoubleValue": {
+								QueryStringName: pointer.To("doubleValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionFloat,
+								},
+								Required: true,
+							},
+							"IntValue": {
+								QueryStringName: pointer.To("intValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionInteger,
+								},
+								Required: true,
+							},
+							"StringValue": {
+								QueryStringName: pointer.To("stringValue"),
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: true,
+							},
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["HeadWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name HeadWorld")
-	}
-	if world.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName != nil {
-		t.Fatalf("expected no ResourceId but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix == nil {
-		t.Fatal("expected world.UriSuffix to have a value")
-	}
-	if *world.UriSuffix != "/things" {
-		t.Fatalf("expected world.UriSuffix to be `/things` but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	if len(world.Options) != 6 {
-		t.Fatalf("expected HeadWorld to have 6 options but got %d", len(world.Options))
-	}
-
-	boolOption, ok := world.Options["BoolValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'BoolValue' but didn't get it")
-	}
-	if boolOption.ObjectDefinition.Type != models.ObjectDefinitionBoolean {
-		t.Fatalf("expected HeadWorld Option 'BoolValue' to be a Boolean but got %q", string(boolOption.ObjectDefinition.Type))
-	}
-	if boolOption.HeaderName != nil {
-		t.Fatalf("expected HeadWorld Option 'BoolValue's HeaderName to be nil but got %q", *boolOption.HeaderName)
-	}
-	if boolOption.QueryStringName == nil {
-		t.Fatalf("expected HeadWorld Option 'BoolValue's QueryStringName to be `boolValue` but was nil")
-	}
-	if boolOption.QueryStringName != nil && *boolOption.QueryStringName != "boolValue" {
-		t.Fatalf("expected HeadWorld Option 'BoolValue's QueryStringName to be `boolValue` but got %q", *boolOption.QueryStringName)
-	}
-
-	csvOfDoubleValueOption, ok := world.Options["CsvOfDoubleValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'CsvOfDoubleValue' but didn't get it")
-	}
-	if csvOfDoubleValueOption.ObjectDefinition.Type != models.ObjectDefinitionCsv {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue' to be a Csv but got %q", string(csvOfDoubleValueOption.ObjectDefinition.Type))
-	}
-	if csvOfDoubleValueOption.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionFloat {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue's Nested Type to be a Float but got %q", string(csvOfDoubleValueOption.ObjectDefinition.NestedItem.Type))
-	}
-	if csvOfDoubleValueOption.HeaderName != nil {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue's HeaderName to be nil but got %q", *csvOfDoubleValueOption.HeaderName)
-	}
-	if csvOfDoubleValueOption.QueryStringName == nil {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue's QueryStringName to be `csvOfDoubleValue` but was nil")
-	}
-	if csvOfDoubleValueOption.QueryStringName != nil && *csvOfDoubleValueOption.QueryStringName != "csvOfDoubleValue" {
-		t.Fatalf("expected HeadWorld Option 'CsvOfDoubleValue's QueryStringName to be `csvOfDoubleValue` but got %q", *csvOfDoubleValueOption.QueryStringName)
-	}
-
-	csvOfStringOption, ok := world.Options["CsvOfStringValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'CsvOfStringValue' but didn't get it")
-	}
-	if csvOfStringOption.ObjectDefinition.Type != models.ObjectDefinitionCsv {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue' to be a Csv but got %q", string(csvOfStringOption.ObjectDefinition.Type))
-	}
-	if csvOfStringOption.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue's Nested Type to be a String but got %q", string(csvOfStringOption.ObjectDefinition.NestedItem.Type))
-	}
-	if csvOfStringOption.HeaderName != nil {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue's HeaderName to be nil but got %q", *csvOfStringOption.HeaderName)
-	}
-	if csvOfStringOption.QueryStringName == nil {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue's QueryStringName to be `csvOfStringValue` but was nil")
-	}
-	if csvOfStringOption.QueryStringName != nil && *csvOfStringOption.QueryStringName != "csvOfStringValue" {
-		t.Fatalf("expected HeadWorld Option 'CsvOfStringValue's QueryStringName to be `csvOfStringValue` but got %q", *csvOfStringOption.QueryStringName)
-	}
-
-	doubleOption, ok := world.Options["DoubleValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'DoubleValue' but didn't get it")
-	}
-	if doubleOption.ObjectDefinition.Type != models.ObjectDefinitionFloat {
-		t.Fatalf("expected HeadWorld Option 'DoubleValue' to be a Float but got %q", string(doubleOption.ObjectDefinition.Type))
-	}
-	if doubleOption.HeaderName != nil {
-		t.Fatalf("expected HeadWorld Option 'DoubleValue's HeaderName to be nil but got %q", *doubleOption.HeaderName)
-	}
-	if doubleOption.QueryStringName == nil {
-		t.Fatalf("expected HeadWorld Option 'DoubleValue's QueryStringName to be `doubleValue` but was nil")
-	}
-	if doubleOption.QueryStringName != nil && *doubleOption.QueryStringName != "doubleValue" {
-		t.Fatalf("expected HeadWorld Option 'DoubleValue's QueryStringName to be `doubleValue` but got %q", *doubleOption.QueryStringName)
-	}
-
-	intOption, ok := world.Options["IntValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'IntValue' but didn't get it")
-	}
-	if intOption.ObjectDefinition.Type != models.ObjectDefinitionInteger {
-		t.Fatalf("expected HeadWorld Option 'IntValue' to be a Integer but got %q", string(intOption.ObjectDefinition.Type))
-	}
-	if intOption.HeaderName != nil {
-		t.Fatalf("expected HeadWorld Option 'IntValue's HeaderName to be nil but got %q", *intOption.HeaderName)
-	}
-	if intOption.QueryStringName == nil {
-		t.Fatalf("expected HeadWorld Option 'IntValue's QueryStringName to be `intValue` but was nil")
-	}
-	if intOption.QueryStringName != nil && *intOption.QueryStringName != "intValue" {
-		t.Fatalf("expected HeadWorld Option 'IntValue's QueryStringName to be `intValue` but got %q", *intOption.QueryStringName)
-	}
-
-	stringOption, ok := world.Options["StringValue"]
-	if !ok {
-		t.Fatalf("expected HeadWorld Options to contain 'StringValue' but didn't get it")
-	}
-	if stringOption.ObjectDefinition.Type != models.ObjectDefinitionString {
-		t.Fatalf("expected HeadWorld Option 'StringValue' to be a String but got %q", string(stringOption.ObjectDefinition.Type))
-	}
-	if stringOption.HeaderName != nil {
-		t.Fatalf("expected HeadWorld Option 'StringValue's HeaderName to be nil but got %q", *stringOption.HeaderName)
-	}
-	if stringOption.QueryStringName == nil {
-		t.Fatalf("expected HeadWorld Option 'StringValue's QueryStringName to be `stringValue` but was nil")
-	}
-	if stringOption.QueryStringName != nil && *stringOption.QueryStringName != "stringValue" {
-		t.Fatalf("expected HeadWorld Option 'StringValue's QueryStringName to be `stringValue` but got %q", *stringOption.QueryStringName)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationMultipleBasedOnTheSameResourceId(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_multiple_same_resource_id.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_multiple_same_resource_id.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"HeadWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_HeadWorld",
+						ResourceIdName:      pointer.To("ThingId"),
+					},
+					"RestartWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_RestartWorld",
+						ResourceIdName:      pointer.To("ThingId"),
+						UriSuffix:           pointer.To("/restart"),
+					},
+				},
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ThingId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
+							NewStaticValueResourceIDSegment("staticThings", "things"),
+							NewUserSpecifiedResourceIDSegment("thing", "thing"),
+						},
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 2 {
-		t.Fatalf("expected 2 Operations but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	world, ok := hello.Operations["HeadWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name HeadWorld")
-	}
-	if world.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", world.Method)
-	}
-	if len(world.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(world.ExpectedStatusCodes))
-	}
-	if world.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", world.ExpectedStatusCodes[0])
-	}
-	if world.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *world.RequestObject)
-	}
-	if world.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *world.ResponseObject)
-	}
-	if world.ResourceIdName == nil {
-		t.Fatal("expected a ResourceId but was nil")
-	}
-	if *world.ResourceIdName != "ThingId" {
-		t.Fatalf("expected world.ResourceIdName to be 'Thing' but got %q", *world.ResourceIdName)
-	}
-	if world.UriSuffix != nil {
-		t.Fatalf("expected world.UriSuffix to be nil but got %q", *world.UriSuffix)
-	}
-	if world.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
-
-	restart, ok := hello.Operations["RestartWorld"]
-	if !ok {
-		t.Fatalf("no resources were output with the name RestartWorld")
-	}
-	if restart.Method != "HEAD" {
-		t.Fatalf("expected a HEAD operation but got %q", restart.Method)
-	}
-	if len(restart.ExpectedStatusCodes) != 1 {
-		t.Fatalf("expected 1 status code but got %d", len(restart.ExpectedStatusCodes))
-	}
-	if restart.ExpectedStatusCodes[0] != 200 {
-		t.Fatalf("expected the status code to be 200 but got %d", restart.ExpectedStatusCodes[0])
-	}
-	if restart.RequestObject != nil {
-		t.Fatalf("expected no request object but got %+v", *restart.RequestObject)
-	}
-	if restart.ResponseObject != nil {
-		t.Fatalf("expected no response object but got %+v", *restart.ResponseObject)
-	}
-	if restart.ResourceIdName == nil {
-		t.Fatal("expected a ResourceId but was nil")
-	}
-	if *restart.ResourceIdName != "ThingId" {
-		t.Fatalf("expected restart.RessourceIdName to be 'Thing' but got %q", *restart.ResourceIdName)
-	}
-	if restart.UriSuffix == nil {
-		t.Fatal("expected restart.UriSuffix to have a value but it was nil")
-	}
-	if *restart.UriSuffix != "/restart" {
-		t.Fatalf("expected restart.UriSuffix to be `/restart` but got %q", *restart.UriSuffix)
-	}
-	if restart.LongRunning {
-		t.Fatal("expected a non-long running operation but it was long running")
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationsContainingContentTypes(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operation_content_types.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operation_content_types.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Operations: map[string]models.OperationDetails{
+					"Default": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Hello_Default",
+						UriSuffix:           pointer.To("/default"),
+					},
+					"JsonRequest": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_JsonRequest",
+						RequestObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionString,
+						},
+						// this can become `/json-request` when https://github.com/hashicorp/pandora/issues/3807 is fixed
+						UriSuffix: pointer.To("/jsonRequest"),
+					},
+					"JsonResponse": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_JsonResponse",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionString,
+						},
+						UriSuffix: pointer.To("/jsonResponse"),
+					},
+					"XmlRequest": {
+						ContentType:         "application/xml",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						OperationId:         "Hello_XmlRequest",
+						RequestObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionString,
+						},
+						UriSuffix: pointer.To("/xmlRequest"),
+					},
+					"XmlResponse": {
+						ContentType:         "application/xml",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_XmlResponse",
+						ResponseObject: &models.ObjectDefinition{
+							Type: models.ObjectDefinitionString,
+						},
+						UriSuffix: pointer.To("/xmlResponse"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 3 {
-		t.Fatalf("expected 3 Operations but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	var validateOperationHasContentType = func(operationName, contentType string) {
-		operation, ok := hello.Operations[operationName]
-		if !ok {
-			t.Fatalf("an operation named %q was not found", operationName)
-		}
-
-		if operation.ContentType != contentType {
-			t.Fatalf("expected the operation %q to have the content-type %q but got %q", operationName, contentType, operation.ContentType)
-		}
-	}
-	validateOperationHasContentType("Default", "application/json")
-	validateOperationHasContentType("XmlRequest", "application/xml")
-	validateOperationHasContentType("XmlResponse", "application/xml")
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseOperationContainingMultipleReturnObjects(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_return_objects.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_return_objects.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Hello")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"FirstModel": {
+						Fields: map[string]models.FieldDetails{
+							"Hello": {
+								JsonName: "hello",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"HeadWorld": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200, 202},
+						Method:              "PUT",
+						OperationId:         "Hello_HeadWorld",
+						ResponseObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("FirstModel"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/things"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 1 {
-		t.Fatalf("expected 1 Model but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	operation, ok := hello.Operations["HeadWorld"]
-	if !ok {
-		t.Fatalf("expected an operation named `HeadWorld` but didn't get one")
-	}
-	if operation.RequestObject != nil {
-		t.Fatalf("expected there to be no Request object but got: %+v", *operation.RequestObject)
-	}
-	if operation.ResponseObject == nil {
-		t.Fatalf("expected there to be a Response object but didn't get one")
-	}
-	if operation.ResponseObject.Type != models.ObjectDefinitionReference {
-		t.Fatalf("expected the Response Object to be a Reference but got %q", string(operation.ResponseObject.Type))
-	}
-	if operation.ResponseObject.ReferenceName == nil || *operation.ResponseObject.ReferenceName != "FirstModel" {
-		t.Fatalf("expected the Response Object to be a Reference to FirstModel but got %q", *operation.ResponseObject.ReferenceName)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }

--- a/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
@@ -4,299 +4,144 @@
 package parser
 
 import (
-	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestParseResourceIdBasic(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_basic.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_basic.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedValue := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SomeResourceProvider/servers/{serverName}"
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("subscriptions"),
-				Name:       "staticSubscriptions",
-			},
-			{
-				Type: resourcemanager.SubscriptionIdSegment,
-				Name: "subscriptionId",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("resourceGroups"),
-				Name:       "staticResourceGroups",
-			},
-			{
-				Type: resourcemanager.ResourceGroupSegment,
-				Name: "resourceGroupName",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("providers"),
-				Name:       "staticProviders",
-			},
-			{
-				Type:       resourcemanager.ResourceProviderSegment,
-				FixedValue: strPtr("Microsoft.SomeResourceProvider"),
-				Name:       "staticMicrosoftSomeResourceProvider",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("servers"),
-				Name:       "staticServers",
-			},
-			{
-				Type: resourcemanager.UserSpecifiedSegment,
-				Name: "serverName",
-			},
-		},
-	}
-	actualValue, ok := hello.ResourceIds["ServerId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ServerId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the ServerId ResourceId to match %q but got %q", expectedValue, actualValue.String())
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["Test"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named Test but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ServerId" {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to be ServerId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation Test to have no value but got %q", *operation.UriSuffix)
-	}
-}
-
-func TestParseResourceIdContainingAConstant(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_constant.json")
-	if err != nil {
-		t.Fatalf("parsing: %+v", err)
-	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
-
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 1 {
-		t.Fatalf("expected 1 Constant but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{
-			"Planet": {
-				Type: resourcemanager.StringConstant,
-				Values: map[string]string{
-					"Earth":   "Earth",
-					"Jupiter": "Jupiter",
-					"Mars":    "Mars",
-					"Saturn":  "Saturn",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ServerId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							NewStaticValueResourceIDSegment("staticServers", "servers"),
+							NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_Test",
+						ResourceIdName:      pointer.To("ServerId"),
+					},
 				},
 			},
 		},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("planets"),
-				Name:       "staticPlanets",
-			},
-			{
-				Type:              resourcemanager.ConstantSegment,
-				ConstantReference: strPtr("Planet"),
-				Name:              "planetName",
-			},
-		},
 	}
-	expectedValue := "/planets/{planetName}"
-	actualValue, ok := hello.ResourceIds["PlanetId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named PlanetId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the PlanetId ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	if _, ok := actualValue.Constants["Planet"]; !ok {
-		t.Fatalf("expected the ResourceId to have an embedded constant named Planet but didn't get one")
-	}
-
-	constant, ok := hello.Constants["Planet"]
-	if !ok {
-		t.Fatalf("expected there to be a Constant named Planet")
-	}
-	if constant.Type != resourcemanager.StringConstant {
-		t.Fatalf("expected the Constant Planet to be a String but got %q", string(constant.Type))
-	}
-	if len(constant.Values) != 4 {
-		t.Fatalf("expected there to be 4 values for Planets but got %d", len(constant.Values))
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["OperationContainingAConstant"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named OperationContainingAConstant but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAConstant to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "PlanetId" {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAConstant to be PlanetId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAConstant to have no value but got %q", *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
-func TestParseResourceIdContainingAScope(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_scope.json")
+func TestParseResourceIdContainingAConstant(t *testing.T) {
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_constant.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type: resourcemanager.ScopeSegment,
-				Name: "scope",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("providers"),
-				Name:       "staticProviders",
-			},
-			{
-				Type:       resourcemanager.ResourceProviderSegment,
-				FixedValue: strPtr("Microsoft.FooBar"),
-				Name:       "staticMicrosoftFooBar",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("virtualMachines"),
-				Name:       "staticVirtualMachines",
-			},
-			{
-				Type: resourcemanager.UserSpecifiedSegment,
-				Name: "virtualMachineName",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				Constants: map[string]resourcemanager.ConstantDetails{
+					"Planet": {
+						Type: resourcemanager.StringConstant,
+						Values: map[string]string{
+							"Earth":   "Earth",
+							"Jupiter": "Jupiter",
+							"Mars":    "Mars",
+							"Saturn":  "Saturn",
+						},
+					},
+				},
+				ResourceIds: map[string]models.ParsedResourceId{
+					"PlanetId": {
+						Constants: map[string]resourcemanager.ConstantDetails{
+							"Planet": {
+								Type: resourcemanager.StringConstant,
+								Values: map[string]string{
+									"Earth":   "Earth",
+									"Jupiter": "Jupiter",
+									"Mars":    "Mars",
+									"Saturn":  "Saturn",
+								},
+							},
+						},
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticPlanets", "planets"),
+							NewConstantResourceIDSegment("planetName", "Planet", "Earth"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"OperationContainingAConstant": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_OperationContainingAConstant",
+						ResourceIdName:      pointer.To("PlanetId"),
+					},
+				},
 			},
 		},
 	}
-	expectedValue := "/{scope}/providers/Microsoft.FooBar/virtualMachines/{virtualMachineName}" // NOTE: this has to have a leading slash to be valid in Swagger
-	actualValue, ok := hello.ResourceIds["ScopedVirtualMachineId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ScopedVirtualMachineId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the ScopedVirtualMachineId ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
+	validateParsedSwaggerResultMatches(t, expected, actual)
+}
+
+func TestParseResourceIdContainingAScope(t *testing.T) {
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_scope.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
 	}
 
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["OperationContainingAScope"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named OperationContainingAScope but didn't get one")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ScopedVirtualMachineId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewScopeResourceIDSegment("scope"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
+							NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
+							NewUserSpecifiedResourceIDSegment("virtualMachineName", "virtualMachinesName"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"OperationContainingAScope": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_OperationContainingAScope",
+						ResourceIdName:      pointer.To("ScopedVirtualMachineId"),
+					},
+				},
+			},
+		},
 	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAScope to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ScopedVirtualMachineId" {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAScope to be ScopedVirtualMachineId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
@@ -309,212 +154,109 @@ func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
 		t.Run(file, func(t *testing.T) {
 			fileName := file
 
-			result, err := ParseSwaggerFileForTesting(t, fileName)
+			actual, err := ParseSwaggerFileForTesting(t, fileName)
 			if err != nil {
 				t.Fatalf("parsing: %+v", err)
 			}
-			if result == nil {
-				t.Fatal("result was nil")
-			}
-			if len(result.Resources) != 1 {
-				t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-			}
 
-			hello, ok := result.Resources["Example"]
-			if !ok {
-				t.Fatalf("no resources were output with the tag Example")
-			}
-
-			if len(hello.Constants) != 0 {
-				t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-			}
-			if len(hello.Models) != 0 {
-				t.Fatalf("expected no Models but got %d", len(hello.Models))
-			}
-			if len(hello.Operations) != 1 {
-				t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-			}
-			if len(hello.ResourceIds) != 1 {
-				t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-			}
-
-			// first check the ResourceId looks good
-			expectedResourceId := models.ParsedResourceId{
-				Constants: map[string]resourcemanager.ConstantDetails{},
-				Segments: []resourcemanager.ResourceIdSegment{
-					{
-						Type: resourcemanager.ScopeSegment,
-						Name: "scope",
+			expected := models.AzureApiDefinition{
+				ServiceName: "Example",
+				ApiVersion:  "2020-01-01",
+				Resources: map[string]models.AzureApiResource{
+					"Example": {
+						ResourceIds: map[string]models.ParsedResourceId{
+							"ScopeId": {
+								CommonAlias: pointer.To("Scope"),
+								Segments: []resourcemanager.ResourceIdSegment{
+									NewScopeResourceIDSegment("scope"),
+								},
+							},
+						},
+						Operations: map[string]models.OperationDetails{
+							"OperationContainingAHiddenScope": {
+								ContentType:         "application/json",
+								ExpectedStatusCodes: []int{200},
+								Method:              "HEAD",
+								OperationId:         "Example_OperationContainingAHiddenScope",
+								ResourceIdName:      pointer.To("ScopeId"),
+							},
+						},
 					},
 				},
 			}
-			expectedValue := "/{scope}"
-			actualValue, ok := hello.ResourceIds["ScopeId"]
-			if !ok {
-				t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
-			}
-			if actualValue.String() != expectedValue {
-				t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
-			}
-			if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-				t.Fatalf(err.Error())
-			}
-
-			// then check it's exposed in the operation itself
-			operation, ok := hello.Operations["OperationContainingAHiddenScope"]
-			if !ok {
-				t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
-			}
-			if operation.ResourceIdName == nil {
-				t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
-			}
-			if *operation.ResourceIdName != "ScopeId" {
-				t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
-			}
-			if operation.UriSuffix != nil {
-				t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
-			}
+			validateParsedSwaggerResultMatches(t, expected, actual)
 		})
 	}
 }
 
 func TestParseResourceIdContainingAHiddenScopeWithExtraSegment(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_extra_segment.json")
+	// The extra segment should be ignored and detected as a regular scope
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_extra_segment.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type: resourcemanager.ScopeSegment,
-				Name: "scope",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ScopeId": {
+						CommonAlias: pointer.To("Scope"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewScopeResourceIDSegment("scope"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"OperationContainingAHiddenScope": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_OperationContainingAHiddenScope",
+						ResourceIdName:      pointer.To("ScopeId"),
+					},
+				},
 			},
 		},
 	}
-	expectedValue := "/{scope}"
-	actualValue, ok := hello.ResourceIds["ScopeId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ScopeId" {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be 'nil' but got %q", *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdContainingAHiddenScopeWithSuffix(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_suffix.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type: resourcemanager.ScopeSegment,
-				Name: "scope",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ScopeId": {
+						CommonAlias: pointer.To("Scope"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewScopeResourceIDSegment("scope"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"OperationContainingAHiddenScope": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_OperationContainingAHiddenScope",
+						ResourceIdName:      pointer.To("ScopeId"),
+						UriSuffix:           pointer.To("/someEndpoint"),
+					},
+				},
 			},
 		},
 	}
-	expectedValue := "/{scope}"
-	actualValue, ok := hello.ResourceIds["ScopeId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ScopeId" {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix == nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be '/someEndpoint' but was nil")
-	}
-	if *operation.UriSuffix != "/someEndpoint" {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be '/someEndpoint' but got %q", *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
@@ -527,827 +269,360 @@ func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
 		t.Run(file, func(t *testing.T) {
 			fileName := file
 
-			result, err := ParseSwaggerFileForTesting(t, fileName)
+			actual, err := ParseSwaggerFileForTesting(t, fileName)
 			if err != nil {
 				t.Fatalf("parsing: %+v", err)
 			}
-			if result == nil {
-				t.Fatal("result was nil")
-			}
-			if len(result.Resources) != 1 {
-				t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-			}
 
-			hello, ok := result.Resources["Example"]
-			if !ok {
-				t.Fatalf("no resources were output with the tag Example")
-			}
-
-			if len(hello.Constants) != 0 {
-				t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-			}
-			if len(hello.Models) != 0 {
-				t.Fatalf("expected no Models but got %d", len(hello.Models))
-			}
-			if len(hello.Operations) != 1 {
-				t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-			}
-			if len(hello.ResourceIds) != 1 {
-				t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-			}
-
-			// first check the ResourceId looks good
-			expectedResourceId := models.ParsedResourceId{
-				Constants: map[string]resourcemanager.ConstantDetails{},
-				Segments: []resourcemanager.ResourceIdSegment{
-					{
-						Type: resourcemanager.ScopeSegment,
-						Name: "scope",
+			expected := models.AzureApiDefinition{
+				ServiceName: "Example",
+				ApiVersion:  "2020-01-01",
+				Resources: map[string]models.AzureApiResource{
+					"Example": {
+						ResourceIds: map[string]models.ParsedResourceId{
+							"ScopeId": {
+								CommonAlias: pointer.To("Scope"),
+								Segments: []resourcemanager.ResourceIdSegment{
+									NewScopeResourceIDSegment("scope"),
+								},
+							},
+						},
+						Operations: map[string]models.OperationDetails{
+							"OperationContainingAHiddenScope": {
+								ContentType:         "application/json",
+								ExpectedStatusCodes: []int{200},
+								Method:              "HEAD",
+								OperationId:         "Example_OperationContainingAHiddenScope",
+								ResourceIdName:      pointer.To("ScopeId"),
+							},
+						},
 					},
 				},
 			}
-			expectedValue := "/{scope}"
-			actualValue, ok := hello.ResourceIds["ScopeId"]
-			if !ok {
-				t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
-			}
-			if actualValue.String() != expectedValue {
-				t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
-			}
-			if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-				t.Fatalf(err.Error())
-			}
-
-			// then check it's exposed in the operation itself
-			operation, ok := hello.Operations["OperationContainingAHiddenScope"]
-			if !ok {
-				t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
-			}
-			if operation.ResourceIdName == nil {
-				t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
-			}
-			if *operation.ResourceIdName != "ScopeId" {
-				t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
-			}
-			if operation.UriSuffix != nil {
-				t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to have no value but got %q", *operation.UriSuffix)
-			}
+			validateParsedSwaggerResultMatches(t, expected, actual)
 		})
 	}
 }
 
 func TestParseResourceIdContainingAHiddenScopeNestedWithExtraSegment(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_extra_segment.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_extra_segment.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type: resourcemanager.ScopeSegment,
-				Name: "scope",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ScopeId": {
+						CommonAlias: pointer.To("Scope"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewScopeResourceIDSegment("scope"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"OperationContainingAHiddenScope": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_OperationContainingAHiddenScope",
+						ResourceIdName:      pointer.To("ScopeId"),
+					},
+				},
 			},
 		},
 	}
-	expectedValue := "/{scope}"
-	actualValue, ok := hello.ResourceIds["ScopeId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ScopeId" {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be 'nil' but got %q", *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdContainingAHiddenScopeNestedWithSuffix(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_suffix.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type: resourcemanager.ScopeSegment,
-				Name: "scope",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ScopeId": {
+						CommonAlias: pointer.To("Scope"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewScopeResourceIDSegment("scope"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"OperationContainingAHiddenScope": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_OperationContainingAHiddenScope",
+						ResourceIdName:      pointer.To("ScopeId"),
+						UriSuffix:           pointer.To("/someEndpoint"),
+					},
+				},
 			},
 		},
 	}
-	expectedValue := "/{scope}"
-	actualValue, ok := hello.ResourceIds["ScopeId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ScopeId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the OperationContainingAHiddenScope ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["OperationContainingAHiddenScope"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named OperationContainingAHiddenScope but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ScopeId" {
-		t.Fatalf("expected the ResourceIdName for the Operation OperationContainingAHiddenScope to be ScopeId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix == nil {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be '/someEndpoint' but was nil")
-	}
-	if *operation.UriSuffix != "/someEndpoint" {
-		t.Fatalf("expected the UriSuffix for the Operation OperationContainingAScope to be '/someEndpoint' but got %q", *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdWithJustUriSuffix(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_with_just_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_just_suffix.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	example, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				Operations: map[string]models.OperationDetails{
+					"JustSuffix": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_JustSuffix",
+						UriSuffix:           pointer.To("/restart"),
+					},
+				},
+			},
+		},
 	}
-
-	if len(example.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(example.Constants))
-	}
-	if len(example.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(example.Models))
-	}
-	if len(example.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(example.Operations))
-	}
-	if len(example.ResourceIds) != 0 {
-		t.Fatalf("expected no ResourceIds but got %d", len(example.ResourceIds))
-	}
-
-	operation, ok := example.Operations["JustSuffix"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named JustSuffix but didn't get one")
-	}
-	if operation.ResourceIdName != nil {
-		t.Fatalf("expected the Operation JustSuffix to have no ResourceIdName but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix == nil {
-		t.Fatalf("expected the Operation JustSuffix to have a UriSuffix but didn't get one")
-	}
-	expectedSuffix := "/restart"
-	if *operation.UriSuffix != expectedSuffix {
-		t.Fatalf("expected the Operation JustSuffix to be %q but got %q", expectedSuffix, *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdWithResourceIdAndUriSuffix(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_with_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_suffix.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("subscriptions"),
-				Name:       "staticSubscriptions",
-			},
-			{
-				Type: resourcemanager.SubscriptionIdSegment,
-				Name: "subscriptionId",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("resourceGroups"),
-				Name:       "staticResourceGroups",
-			},
-			{
-				Type: resourcemanager.ResourceGroupSegment,
-				Name: "resourceGroupName",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("providers"),
-				Name:       "staticProviders",
-			},
-			{
-				Type:       resourcemanager.ResourceProviderSegment,
-				FixedValue: strPtr("Microsoft.SomeResourceProvider"),
-				Name:       "staticMicrosoftSomeResourceProvider",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("servers"),
-				Name:       "staticServers",
-			},
-			{
-				Type: resourcemanager.UserSpecifiedSegment,
-				Name: "serverName",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ServerId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							NewStaticValueResourceIDSegment("staticServers", "servers"),
+							NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_Test",
+						ResourceIdName:      pointer.To("ServerId"),
+						UriSuffix:           pointer.To("/someOperation"),
+					},
+				},
 			},
 		},
 	}
-	expectedValue := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SomeResourceProvider/servers/{serverName}"
-	actualValue, ok := hello.ResourceIds["ServerId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ServerId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the ServerId ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["Test"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named Test but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ServerId" {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to have a value but didn't get one")
-	}
-	if operation.UriSuffix == nil {
-		t.Fatalf("expected the UriSuffix for the Operation Test to have a value but didn't get one")
-	}
-	expectedSuffix := "/someOperation"
-	if *operation.UriSuffix != expectedSuffix {
-		t.Fatalf("expected the UriSuffix for the Operation Test to be %q but got %q", expectedSuffix, *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdWithResourceIdAndUriSuffixForMultipleUris(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_with_suffix_multiple_uris.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_suffix_multiple_uris.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 3 {
-		t.Fatalf("expected 3 Operations but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("subscriptions"),
-				Name:       "staticSubscriptions",
-			},
-			{
-				Type: resourcemanager.SubscriptionIdSegment,
-				Name: "subscriptionId",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("resourceGroups"),
-				Name:       "staticResourceGroups",
-			},
-			{
-				Type: resourcemanager.ResourceGroupSegment,
-				Name: "resourceGroupName",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("providers"),
-				Name:       "staticProviders",
-			},
-			{
-				Type:       resourcemanager.ResourceProviderSegment,
-				FixedValue: strPtr("Microsoft.SomeResourceProvider"),
-				Name:       "staticMicrosoftSomeResourceProvider",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("servers"),
-				Name:       "staticServers",
-			},
-			{
-				Type: resourcemanager.UserSpecifiedSegment,
-				Name: "serverName",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ServerId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							NewStaticValueResourceIDSegment("staticServers", "servers"),
+							NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"Restart": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_Restart",
+						ResourceIdName:      pointer.To("ServerId"),
+						UriSuffix:           pointer.To("/restart"),
+					},
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_Test",
+						ResourceIdName:      pointer.To("ServerId"),
+						UriSuffix:           pointer.To("/someOperation"),
+					},
+					"TopLevel": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_TopLevel",
+						ResourceIdName:      pointer.To("ServerId"),
+					},
+				},
 			},
 		},
 	}
-	expectedValue := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SomeResourceProvider/servers/{serverName}"
-	actualValue, ok := hello.ResourceIds["ServerId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ServerId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the ServerId ResourceId to match %q but got %q", expectedValue, actualValue)
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in each of the operations itself
-	operation, ok := hello.Operations["TopLevel"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named TopLevel but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation TopLevel to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ServerId" {
-		t.Fatalf("expected the ResourceIdName for the Operation TopLevel to have a value but didn't get one")
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation TopLevel to have no value got %q", *operation.UriSuffix)
-	}
-
-	// nested operation 'Test'
-	operation, ok = hello.Operations["Test"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named Test but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ServerId" {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to have a value but didn't get one")
-	}
-	if operation.UriSuffix == nil {
-		t.Fatalf("expected the UriSuffix for the Operation Test to have a value but didn't get one")
-	}
-	expectedSuffix := "/someOperation"
-	if *operation.UriSuffix != expectedSuffix {
-		t.Fatalf("expected the UriSuffix for the Operation Test to be %q but got %q", expectedSuffix, *operation.UriSuffix)
-	}
-
-	// nested operation 'Restart'
-	operation, ok = hello.Operations["Restart"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named Restart but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation Restart to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ServerId" {
-		t.Fatalf("expected the ResourceIdName for the Operation Restart to have a value but didn't get one")
-	}
-	if operation.UriSuffix == nil {
-		t.Fatalf("expected the UriSuffix for the Operation Restart to have a value but didn't get one")
-	}
-	expectedSuffix = "/restart"
-	if *operation.UriSuffix != expectedSuffix {
-		t.Fatalf("expected the UriSuffix for the Operation Restart to be %q but got %q", expectedSuffix, *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdContainingResourceProviderShouldGetTitleCased(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_lowercased_resource_provider.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_lowercased_resource_provider.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the ResourceId looks good
-	expectedValue := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SomeResourceProvider/servers/{serverName}"
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("subscriptions"),
-				Name:       "staticSubscriptions",
-			},
-			{
-				Type: resourcemanager.SubscriptionIdSegment,
-				Name: "subscriptionId",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("resourceGroups"),
-				Name:       "staticResourceGroups",
-			},
-			{
-				Type: resourcemanager.ResourceGroupSegment,
-				Name: "resourceGroupName",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("providers"),
-				Name:       "staticProviders",
-			},
-			{
-				Type:       resourcemanager.ResourceProviderSegment,
-				FixedValue: strPtr("Microsoft.SomeResourceProvider"),
-				Name:       "staticMicrosoftSomeResourceProvider",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("servers"),
-				Name:       "staticServers",
-			},
-			{
-				Type: resourcemanager.UserSpecifiedSegment,
-				Name: "serverName",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ServerId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							NewStaticValueResourceIDSegment("staticServers", "servers"),
+							NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_Test",
+						ResourceIdName:      pointer.To("ServerId"),
+					},
+				},
 			},
 		},
 	}
-	actualValue, ok := hello.ResourceIds["ServerId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ServerId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the ServerId ResourceId to match %q but got %q", expectedValue, actualValue.String())
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["Test"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named Test but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "ServerId" {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to be ServerId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation Test to have no value but got %q", *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdContainingTheSameResourceIdWithDifferentSegments(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_same_id_different_segment_casing.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_same_id_different_segment_casing.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 2 {
-		t.Fatalf("expected 2 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the Server ResourceId looks good
-	expectedValue := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SomeResourceProvider/virtualMachines/{machineName}"
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("subscriptions"),
-				Name:       "staticSubscriptions",
-			},
-			{
-				Type: resourcemanager.SubscriptionIdSegment,
-				Name: "subscriptionId",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("resourceGroups"),
-				Name:       "staticResourceGroups",
-			},
-			{
-				Type: resourcemanager.ResourceGroupSegment,
-				Name: "resourceGroupName",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("providers"),
-				Name:       "staticProviders",
-			},
-			{
-				Type:       resourcemanager.ResourceProviderSegment,
-				FixedValue: strPtr("Microsoft.SomeResourceProvider"),
-				Name:       "staticMicrosoftSomeResourceProvider",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				FixedValue: strPtr("virtualMachines"),
-				Name:       "staticVirtualMachines",
-			},
-			{
-				Type: resourcemanager.UserSpecifiedSegment,
-				Name: "machineName",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"VirtualMachineId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
+							NewUserSpecifiedResourceIDSegment("machineName", "machineName"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"Restart": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_Restart",
+						ResourceIdName:      pointer.To("VirtualMachineId"),
+						UriSuffix:           pointer.To("/restart"),
+					},
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_Test",
+						ResourceIdName:      pointer.To("VirtualMachineId"),
+					},
+				},
 			},
 		},
 	}
-	actualValue, ok := hello.ResourceIds["VirtualMachineId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named ServerId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the VirtualMachineId ResourceId to match %q but got %q", expectedValue, actualValue.String())
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["Test"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named Test but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "VirtualMachineId" {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to be VirtualMachineId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix != nil {
-		t.Fatalf("expected the UriSuffix for the Operation Test to have no value but got %q", *operation.UriSuffix)
-	}
-
-	// then check it's exposed in the Restart operation itself
-	restartOperation, ok := hello.Operations["Restart"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named Restart but didn't get one")
-	}
-	if restartOperation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation Restart to have a value but didn't get one")
-	}
-	if *restartOperation.ResourceIdName != "VirtualMachineId" {
-		t.Fatalf("expected the ResourceIdName for the Operation Restart to be VirtualMachineId but got %q", *restartOperation.ResourceIdName)
-	}
-	if restartOperation.UriSuffix == nil {
-		t.Fatalf("expected the UriSuffix for the Operation Restart to have a value but got nil")
-	}
-	if *restartOperation.UriSuffix != "/restart" {
-		t.Fatalf("expected the UriSuffix for the Operation Restart to have be `/restart` but got %q", *restartOperation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdContainingTheSegmentsNamedTheSame(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_multiple_segments_same_name.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_multiple_segments_same_name.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 1 {
-		t.Fatalf("expected 1 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 1 {
-		t.Fatalf("expected 1 ResourceId but got %d", len(hello.ResourceIds))
-	}
-
-	// first check the Billing Period ResourceId looks good
-	expectedValue := "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}"
-	expectedResourceId := models.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
-		Segments: []resourcemanager.ResourceIdSegment{
-			{
-				Type:       resourcemanager.StaticSegment,
-				Name:       "staticProviders",
-				FixedValue: strPtr("providers"),
-			},
-			{
-				Type:       resourcemanager.ResourceProviderSegment,
-				Name:       "staticMicrosoftManagement",
-				FixedValue: strPtr("Microsoft.Management"),
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				Name:       "staticManagementGroups",
-				FixedValue: strPtr("managementGroups"),
-			},
-			{
-				Type: resourcemanager.UserSpecifiedSegment,
-				Name: "managementGroupId",
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				Name:       "staticProviders2",
-				FixedValue: strPtr("providers"),
-			},
-			{
-				Type:       resourcemanager.ResourceProviderSegment,
-				Name:       "staticMicrosoftBilling",
-				FixedValue: strPtr("Microsoft.Billing"),
-			},
-			{
-				Type:       resourcemanager.StaticSegment,
-				Name:       "staticBillingPeriods",
-				FixedValue: strPtr("billingPeriods"),
-			},
-			{
-				Type: resourcemanager.UserSpecifiedSegment,
-				Name: "billingPeriodName",
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"BillingPeriodId": {
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftManagement", "Microsoft.Management"),
+							NewStaticValueResourceIDSegment("staticManagementGroups", "managementGroups"),
+							NewUserSpecifiedResourceIDSegment("managementGroupId", "managementGroupId"),
+							NewStaticValueResourceIDSegment("staticProviders2", "providers"),
+							NewResourceProviderResourceIDSegment("staticMicrosoftBilling", "Microsoft.Billing"),
+							NewStaticValueResourceIDSegment("staticBillingPeriods", "billingPeriods"),
+							NewUserSpecifiedResourceIDSegment("billingPeriodName", "billingPeriodName"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_Test",
+						ResourceIdName:      pointer.To("BillingPeriodId"),
+						UriSuffix:           pointer.To("/Microsoft.Consumption/aggregatedCost"),
+					},
+				},
 			},
 		},
 	}
-	actualValue, ok := hello.ResourceIds["BillingPeriodId"]
-	if !ok {
-		t.Fatalf("expected a ResourceId named BillingPeriodId but didn't get one")
-	}
-	if actualValue.String() != expectedValue {
-		t.Fatalf("expected the BillingPeriodId ResourceId to match %q but got %q", expectedValue, actualValue.String())
-	}
-	if err := validateResourceId(actualValue, expectedValue, expectedResourceId); err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	// then check it's exposed in the operation itself
-	operation, ok := hello.Operations["Test"]
-	if !ok {
-		t.Fatalf("expected there to be an Operation named Test but didn't get one")
-	}
-	if operation.ResourceIdName == nil {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to have a value but didn't get one")
-	}
-	if *operation.ResourceIdName != "BillingPeriodId" {
-		t.Fatalf("expected the ResourceIdName for the Operation Test to be VirtualMachineId but got %q", *operation.ResourceIdName)
-	}
-	if operation.UriSuffix == nil {
-		t.Fatalf("expected the UriSuffix for the Operation Test to have a value but didn't get one")
-	}
-	if *operation.UriSuffix != "/Microsoft.Consumption/aggregatedCost" {
-		t.Fatalf("expected the UriSuffix for the Operation Test to have be '/Microsoft.Consumption/aggregatedCost' but got %q", *operation.UriSuffix)
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperation(t *testing.T) {
@@ -1364,190 +639,170 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 	for i := 0; i < 100; i++ {
 		t.Logf("iteration %d", i)
 
-		result, err := ParseSwaggerFileForTesting(t, "resource_ids_same_uri_different_constant_values_per_operation.json")
+		actual, err := ParseSwaggerFileForTesting(t, "resource_ids_same_uri_different_constant_values_per_operation.json")
 		if err != nil {
 			t.Fatalf("parsing: %+v", err)
 		}
-		if result == nil {
-			t.Fatal("result was nil")
-		}
-		if len(result.Resources) != 1 {
-			t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-		}
 
-		hello, ok := result.Resources["Hello"]
-		if !ok {
-			t.Fatalf("no resources were output with the tag `Hello`")
+		expected := models.AzureApiDefinition{
+			ServiceName: "Example",
+			ApiVersion:  "2020-01-01",
+			Resources: map[string]models.AzureApiResource{
+				"Hello": {
+					Constants: map[string]resourcemanager.ConstantDetails{
+						"PlanetNames": {
+							Type: resourcemanager.StringConstant,
+							Values: map[string]string{
+								"Earth": "Earth",
+								"Mars":  "Mars",
+							},
+						},
+					},
+					ResourceIds: map[string]models.ParsedResourceId{
+						"GalaxyId": {
+							Segments: []resourcemanager.ResourceIdSegment{
+								NewStaticValueResourceIDSegment("staticGalaxies", "galaxies"),
+								NewUserSpecifiedResourceIDSegment("galaxyName", "galaxyName"),
+							},
+						},
+						"PlanetId": {
+							Constants: map[string]resourcemanager.ConstantDetails{
+								"PlanetNames": {
+									Type: resourcemanager.StringConstant,
+									Values: map[string]string{
+										"Earth": "Earth",
+										"Mars":  "Mars",
+									},
+								},
+							},
+							Segments: []resourcemanager.ResourceIdSegment{
+								NewStaticValueResourceIDSegment("staticGalaxies", "galaxies"),
+								NewUserSpecifiedResourceIDSegment("galaxyName", "galaxyName"),
+								NewStaticValueResourceIDSegment("staticHello", "hello"),
+								NewConstantResourceIDSegment("planetName", "PlanetNames", "Earth"),
+							},
+						},
+					},
+					Operations: map[string]models.OperationDetails{
+						"Delete": {
+							ContentType:         "application/json",
+							ExpectedStatusCodes: []int{200},
+							Method:              "DELETE",
+							OperationId:         "Hello_Delete",
+							ResourceIdName:      pointer.To("GalaxyId"),
+							UriSuffix:           pointer.To("/hello/Earth"),
+						},
+						"Head": {
+							ContentType:         "application/json",
+							ExpectedStatusCodes: []int{200},
+							Method:              "HEAD",
+							OperationId:         "Hello_Head",
+							ResourceIdName:      pointer.To("PlanetId"),
+						},
+					},
+				},
+			},
 		}
-
-		if len(hello.Constants) != 1 {
-			t.Fatalf("expected 1 Constant but got %d", len(hello.Constants))
-		}
-		if len(hello.Models) != 0 {
-			t.Fatalf("expected No Models but got %d", len(hello.Models))
-		}
-		if len(hello.Operations) != 2 {
-			t.Fatalf("expected 2 Operations but got %d", len(hello.Operations))
-		}
-		if len(hello.ResourceIds) != 2 {
-			t.Fatalf("expected 2 ResourceIds but got %d", len(hello.ResourceIds))
-		}
-
-		// sanity check we're pulling out both values
-		planetNamesConst, ok := hello.Constants["PlanetNames"]
-		if !ok {
-			t.Fatalf("expected a Constant named `PlanetNames` but didn't get one")
-		}
-		expected := map[string]string{
-			"Earth": "Earth",
-			"Mars":  "Mars",
-		}
-		if !reflect.DeepEqual(expected, planetNamesConst.Values) {
-			t.Fatalf("expected the Constant `PlanetNames` to have 2 values but got %+v", planetNamesConst.Values)
-		}
-
-		headOperation, ok := hello.Operations["Head"]
-		if !ok {
-			t.Fatalf("expected an operation `Head` but didn't get one")
-		}
-		if headOperation.UriSuffix != nil {
-			t.Fatalf("expected UriSuffix to be nil for the Head operation but got %q", *headOperation.UriSuffix)
-		}
-		if headOperation.ResourceIdName == nil {
-			t.Fatalf("expected the ResourceIdName for the Head operation to be `PlanetId` but got nil")
-		}
-		if *headOperation.ResourceIdName != "PlanetId" {
-			t.Fatalf("expected the ResourceIdName for the Head operation to be `PlanetId` but got %q", *headOperation.ResourceIdName)
-		}
-
-		deleteOperation, ok := hello.Operations["Delete"]
-		if !ok {
-			t.Fatalf("expected an operation `Delete` but didn't get one")
-		}
-		if deleteOperation.UriSuffix == nil {
-			t.Fatalf("expected UriSuffix to be `/hello/Earth` for the Delete operation but got nil")
-		}
-		if *deleteOperation.UriSuffix != "/hello/Earth" {
-			t.Fatalf("expected UriSuffix to be `/hello/Earth` for the Delete operation but got %q", *deleteOperation.UriSuffix)
-		}
-		if deleteOperation.ResourceIdName == nil {
-			t.Fatalf("expected the ResourceIdName for the Head operation to be `GalaxyId` but got nil")
-		}
-		if *deleteOperation.ResourceIdName != "GalaxyId" {
-			t.Fatalf("expected the ResourceIdName for the Head operation to be `GalaxyId` but got %q", *deleteOperation.ResourceIdName)
-		}
+		validateParsedSwaggerResultMatches(t, expected, actual)
 	}
 }
 
 func TestParseResourceIdsCommon(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "resource_ids_common.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_common.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
+
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Example": {
+				ResourceIds: map[string]models.ParsedResourceId{
+					"ManagementGroupId": {
+						CommonAlias: pointer.To("ManagementGroup"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("providers", "providers"),
+							NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
+							NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
+							NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
+						},
+					},
+					"ResourceGroupId": {
+						CommonAlias: pointer.To("ResourceGroup"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+						},
+					},
+					"ScopeId": {
+						CommonAlias: pointer.To("Scope"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewScopeResourceIDSegment("scope"),
+						},
+					},
+					"SubscriptionId": {
+						CommonAlias: pointer.To("Subscription"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+						},
+					},
+					"UserAssignedIdentityId": {
+						CommonAlias: pointer.To("UserAssignedIdentity"),
+						Segments: []resourcemanager.ResourceIdSegment{
+							NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+							NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+							NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							NewStaticValueResourceIDSegment("providers", "providers"),
+							NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+							NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+							NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"GetManagementGroup": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_GetManagementGroup",
+						ResourceIdName:      pointer.To("ManagementGroupId"),
+					},
+					"GetResourceGroup": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_GetResourceGroup",
+						ResourceIdName:      pointer.To("ResourceGroupId"),
+					},
+					"GetScope": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_GetScope",
+						ResourceIdName:      pointer.To("ScopeId"),
+					},
+					"GetSubscription": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_GetSubscription",
+						ResourceIdName:      pointer.To("SubscriptionId"),
+					},
+					"GetUserAssignedIdentity": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "HEAD",
+						OperationId:         "Example_GetUserAssignedIdentity",
+						ResourceIdName:      pointer.To("UserAssignedIdentityId"),
+					},
+				},
+			},
+		},
 	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
-
-	hello, ok := result.Resources["Example"]
-	if !ok {
-		t.Fatalf("no resources were output with the tag Example")
-	}
-
-	if len(hello.Constants) != 0 {
-		t.Fatalf("expected no Constants but got %d", len(hello.Constants))
-	}
-	if len(hello.Models) != 0 {
-		t.Fatalf("expected no Models but got %d", len(hello.Models))
-	}
-	if len(hello.Operations) != 5 {
-		t.Fatalf("expected 5 Operation but got %d", len(hello.Operations))
-	}
-	if len(hello.ResourceIds) != 5 {
-		t.Fatalf("expected 5 ResourceIds but got %d", len(hello.ResourceIds))
-	}
-
-	var checkId = func(t *testing.T, key string) {
-		idName := fmt.Sprintf("%sId", key)
-		id, found := hello.ResourceIds[idName]
-		if !found {
-			t.Fatalf("expected there to be a ResourceId named `%s` but didn't find one", idName)
-		}
-		if id.CommonAlias == nil {
-			t.Fatalf("expected the ResourceId `%s` to have a CommonAlias but it was nil", idName)
-		}
-		if *id.CommonAlias != key {
-			t.Fatalf("expected the ResourceId `%s` to have a CommonAlias of `%s` but it was %q", idName, key, *id.CommonAlias)
-		}
-	}
-	checkId(t, "ManagementGroup")
-	checkId(t, "ResourceGroup")
-	checkId(t, "Scope")
-	checkId(t, "Subscription")
-	checkId(t, "UserAssignedIdentity")
-}
-
-func validateResourceId(actualValue models.ParsedResourceId, expectedString string, expected models.ParsedResourceId) error {
-	if actualValue.String() != expectedString {
-		return fmt.Errorf("expected the ResourceId to be %q but got %q", expectedString, actualValue.String())
-	}
-
-	if len(actualValue.Segments) != len(expected.Segments) {
-		return fmt.Errorf("expected the ResourceId to have %d segments but got %d", len(expected.Segments), len(actualValue.Segments))
-	}
-	for i, expectedSegment := range expected.Segments {
-		actualSegment := actualValue.Segments[i]
-
-		if expectedSegment.Type != actualSegment.Type {
-			return fmt.Errorf("expected the Segment at index %d to have the Type %q but got %q", i, string(expectedSegment.Type), string(actualSegment.Type))
-		}
-
-		if expectedSegment.Name != actualSegment.Name {
-			return fmt.Errorf("expected the Segment at index %d to have the Name %q but got %q", i, expectedSegment.Name, actualSegment.Name)
-		}
-
-		if expectedSegment.ConstantReference != nil || actualSegment.ConstantReference != nil {
-			if expectedSegment.ConstantReference == nil {
-				return fmt.Errorf("expected the Segment at index %d to not have a ConstantReference but got %q", i, *actualSegment.ConstantReference)
-			}
-			if actualSegment.ConstantReference == nil {
-				return fmt.Errorf("expected the Segment at index %d to have a ConstantReference but didn't get one", i)
-			}
-
-			if *expectedSegment.ConstantReference != *actualSegment.ConstantReference {
-				return fmt.Errorf("expected the Segment at index %d's ConstantReference to be %q but got %q", i, *expectedSegment.ConstantReference, *actualSegment.ConstantReference)
-			}
-		}
-
-		if expectedSegment.FixedValue != nil || actualSegment.FixedValue != nil {
-			if expectedSegment.FixedValue == nil {
-				return fmt.Errorf("expected the Segment at index %d to not have a FixedValue but got %q", i, *actualSegment.FixedValue)
-			}
-			if actualSegment.FixedValue == nil {
-				return fmt.Errorf("expected the Segment at index %d to have a FixedValue but didn't get one", i)
-			}
-
-			if *expectedSegment.FixedValue != *actualSegment.FixedValue {
-				return fmt.Errorf("expected the Segment at index %d's FixedValue to be %q but got %q", i, *expectedSegment.FixedValue, *actualSegment.FixedValue)
-			}
-		}
-	}
-
-	if len(actualValue.Constants) != len(expected.Constants) {
-		return fmt.Errorf("expected there to be %d constants but got %d", len(expected.Constants), len(actualValue.Constants))
-	}
-	for k, expectedConstant := range expected.Constants {
-		actualConstant, ok := actualValue.Constants[k]
-		if !ok {
-			return fmt.Errorf("actual didn't contain the constant %q", k)
-		}
-
-		if !reflect.DeepEqual(expectedConstant, actualConstant) {
-			return fmt.Errorf("Constant %q didn't match - expected:\n\n%+v\n\nActual:\n\n%+v", k, expectedConstant, actualConstant)
-		}
-	}
-
-	return nil
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
@@ -3,113 +3,183 @@
 
 package parser
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
 
 func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_single_tag_different_casing.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_tag_different_casing.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 1 {
-		t.Fatalf("expected 1 resource but got %d", len(result.Resources))
-	}
 
-	resource, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatal("the Resource 'Hello' was not found")
-	}
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
 
-	// sanity checking
-	if len(resource.Constants) != 0 {
-		t.Fatalf("expected 0 constants but got %d", len(resource.Constants))
+					"First": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_First",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						// https://github.com/hashicorp/pandora/issues/3807
+						UriSuffix: pointer.To("/someotheruri"),
+					},
+					"PutBar": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutBar",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/bar"),
+					},
+					"PutFoo": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "hello_PutFoo",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/foo"),
+					},
+					"Second": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PATCH",
+						OperationId:         "hello_Second",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						// https://github.com/hashicorp/pandora/issues/3807
+						UriSuffix: pointer.To("/someotheruri"),
+					},
+				},
+			},
+		},
 	}
-	if len(resource.Models) != 1 {
-		t.Fatalf("expected 1 model but got %d", len(resource.Models))
-	}
-	if len(resource.Operations) != 4 {
-		t.Fatalf("expected 4 Operations but got %d", len(resource.Operations))
-	}
-	if len(resource.ResourceIds) != 0 {
-		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))
-	}
-	expectedOperations := []string{
-		"First",
-		"PutBar",
-		"PutFoo",
-		"Second",
-	}
-	for _, expected := range expectedOperations {
-		if _, ok := resource.Operations[expected]; !ok {
-			t.Fatalf("expected there to be an operation named %q but didn't get one", expected)
-		}
-	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
 func TestParsingOperationsOnResources(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "operations_on_resources.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_on_resources.json")
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
-	if result == nil {
-		t.Fatal("result was nil")
-	}
-	if len(result.Resources) != 2 {
-		t.Fatalf("expected 2 resource but got %d", len(result.Resources))
-	}
 
-	resource, ok := result.Resources["Hello"]
-	if !ok {
-		t.Fatal("the Resource 'Hello' was not found")
+	expected := models.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]models.AzureApiResource{
+			"Hello": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"First": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_First",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						// https://github.com/hashicorp/pandora/issues/3807
+						UriSuffix: pointer.To("/someotheruri"),
+					},
+					"PutBar": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						OperationId:         "Hello_PutBar",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/bar"),
+					},
+					"Second": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PATCH",
+						OperationId:         "hello_Second",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						// https://github.com/hashicorp/pandora/issues/3807
+						UriSuffix: pointer.To("/someotheruri"),
+					},
+				},
+			},
+			"HelloOperations": {
+				Models: map[string]models.ModelDetails{
+					"Example": {
+						Fields: map[string]models.FieldDetails{
+							"Name": {
+								JsonName: "name",
+								ObjectDefinition: &models.ObjectDefinition{
+									Type: models.ObjectDefinitionString,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.OperationDetails{
+					"HelloRestart": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "POST",
+						OperationId:         "Hello_Restart",
+						RequestObject: &models.ObjectDefinition{
+							ReferenceName: pointer.To("Example"),
+							Type:          models.ObjectDefinitionReference,
+						},
+						UriSuffix: pointer.To("/foo"),
+					},
+				},
+			},
+		},
 	}
-
-	// sanity checking
-	if len(resource.Constants) != 0 {
-		t.Fatalf("expected 0 constants but got %d", len(resource.Constants))
-	}
-	if len(resource.Models) != 1 {
-		t.Fatalf("expected 1 model but got %d", len(resource.Models))
-	}
-	if len(resource.Operations) != 3 {
-		t.Fatalf("expected 3 Operations but got %d", len(resource.Operations))
-	}
-	if len(resource.ResourceIds) != 0 {
-		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))
-	}
-	expectedOperations := []string{
-		"First",
-		"PutBar",
-		"Second",
-	}
-	for _, expected := range expectedOperations {
-		if _, ok := resource.Operations[expected]; !ok {
-			t.Fatalf("expected there to be an operation named %q but didn't get one", expected)
-		}
-	}
-
-	resourceOperation, ok := result.Resources["HelloOperations"]
-	if !ok {
-		t.Fatal("the Resource 'HelloOperations' was not found")
-	}
-
-	// sanity checking
-	if len(resourceOperation.Constants) != 0 {
-		t.Fatalf("expected 0 constants but got %d", len(resource.Constants))
-	}
-	if len(resourceOperation.Models) != 1 {
-		t.Fatalf("expected 1 model but got %d", len(resource.Models))
-	}
-	if len(resourceOperation.Operations) != 1 {
-		t.Fatalf("expected 1 Operations but got %d", len(resource.Operations))
-	}
-	if len(resourceOperation.ResourceIds) != 0 {
-		t.Fatalf("expected 0 Resource IDs but got %d", len(resource.ResourceIds))
-	}
-
-	if _, ok := resourceOperation.Operations["HelloRestart"]; !ok {
-		t.Fatalf("expected there to be an operation named `Restart` but didn't get one")
-	}
-
+	validateParsedSwaggerResultMatches(t, expected, actual)
 }

--- a/tools/importer-rest-api-specs/components/parser/temp_removed_after_sdk_migration.go
+++ b/tools/importer-rest-api-specs/components/parser/temp_removed_after_sdk_migration.go
@@ -1,0 +1,80 @@
+package parser
+
+import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
+)
+
+// NewConstantResourceIDSegment returns a configured ResourceIDSegment which represents
+// the value from a Constant. The user-provided value for this Resource ID Segment MUST
+// represent one of the values specified in the Constant.
+func NewConstantResourceIDSegment(name, constantReferenceName, exampleValue string) resourcemanager.ResourceIdSegment {
+	return resourcemanager.ResourceIdSegment{
+		ConstantReference: pointer.To(constantReferenceName),
+		ExampleValue:      exampleValue,
+		Name:              name,
+		Type:              resourcemanager.ConstantSegment,
+	}
+}
+
+// NewResourceGroupNameResourceIDSegment returns a configured ResourceIDSegment which represents
+// the value of a Resource Group Name.
+func NewResourceGroupNameResourceIDSegment(name string) resourcemanager.ResourceIdSegment {
+	return resourcemanager.ResourceIdSegment{
+		ExampleValue: "example-resources",
+		Name:         name,
+		Type:         resourcemanager.ResourceGroupSegment,
+	}
+}
+
+// NewResourceProviderResourceIDSegment returns a configured ResourceIDSegment which represents
+// the value of an Azure Resource Provider.
+func NewResourceProviderResourceIDSegment(name, resourceProviderName string) resourcemanager.ResourceIdSegment {
+	return resourcemanager.ResourceIdSegment{
+		ExampleValue: resourceProviderName,
+		FixedValue:   pointer.To(resourceProviderName),
+		Name:         name,
+		Type:         resourcemanager.ResourceProviderSegment,
+	}
+}
+
+// NewScopeResourceIDSegment returns a configured ResourceIDSegment which represents
+// the value of an Azure Resource Scope.
+func NewScopeResourceIDSegment(name string) resourcemanager.ResourceIdSegment {
+	return resourcemanager.ResourceIdSegment{
+		ExampleValue: "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/example-resources",
+		Name:         name,
+		Type:         resourcemanager.ScopeSegment,
+	}
+}
+
+// NewStaticValueResourceIDSegment returns a configured ResourceIDSegment which represents
+// a fixed/static value.
+func NewStaticValueResourceIDSegment(name, fixedValue string) resourcemanager.ResourceIdSegment {
+	return resourcemanager.ResourceIdSegment{
+		ExampleValue: fixedValue,
+		FixedValue:   pointer.To(fixedValue),
+		Name:         name,
+		Type:         resourcemanager.StaticSegment,
+	}
+}
+
+// NewSubscriptionIDResourceIDSegment returns a configured ResourceIDSegment which represents
+// the value of a Subscription ID.
+func NewSubscriptionIDResourceIDSegment(name string) resourcemanager.ResourceIdSegment {
+	return resourcemanager.ResourceIdSegment{
+		ExampleValue: "11112222-3333-4444-555566667777",
+		Name:         name,
+		Type:         resourcemanager.SubscriptionIdSegment,
+	}
+}
+
+// NewUserSpecifiedResourceIDSegment returns a configured ResourceIDSegment which represents
+// a User Specified value.
+func NewUserSpecifiedResourceIDSegment(name, exampleValue string) resourcemanager.ResourceIdSegment {
+	return resourcemanager.ResourceIdSegment{
+		ExampleValue: exampleValue,
+		Name:         name,
+		Type:         resourcemanager.UserSpecifiedSegment,
+	}
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/operation_content_types.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operation_content_types.json
@@ -27,37 +27,16 @@
         }
       }
     },
-    "/xml-request": {
+    "/jsonRequest": {
       "get": {
         "tags": [
           "Hello"
         ],
-        "operationId": "Hello_XmlRequest",
+        "operationId": "Hello_JsonRequest",
         "produces": [
-          "application/xml"
+          "application/json"
         ],
-        "description": "An operation using XML as a Content-Type. This intentionally only sets Produces and not Consumes since this shouldn't be set for Get.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "/xml-response": {
-      "put": {
-        "tags": [
-          "Hello"
-        ],
-        "operationId": "Hello_XmlResponse",
-        "consumes": [
-          "application/xml"
-        ],
-        "description": "An operation using XML as a Content-Type. This intentionally only sets Consumes and not Produces since this shouldn't be set for a PUT.",
+        "description": "An operation using JSON as a Content-Type. This intentionally only sets Produces and not Consumes since this shouldn't be set for Get.",
         "parameters": [
           {
             "name": "parameters",
@@ -71,6 +50,76 @@
         "responses": {
           "200": {
             "description": "Success."
+          }
+        }
+      }
+    },
+    "/jsonResponse": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_JsonResponse",
+        "consumes": [
+          "application/json"
+        ],
+        "description": "An operation using JSON as a Content-Type. This intentionally only sets Consumes and not Produces since this shouldn't be set for a PUT.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/xmlRequest": {
+      "get": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_XmlRequest",
+        "produces": [
+          "application/xml"
+        ],
+        "description": "An operation using XML as a Content-Type. This intentionally only sets Produces and not Consumes since this shouldn't be set for Get.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        }
+      }
+    },
+    "/xmlResponse": {
+      "put": {
+        "tags": [
+          "Hello"
+        ],
+        "operationId": "Hello_XmlResponse",
+        "consumes": [
+          "application/xml"
+        ],
+        "description": "An operation using XML as a Content-Type. This intentionally only sets Consumes and not Produces since this shouldn't be set for a PUT.",
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "type": "string"
+            }
           }
         }
       }

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_single_returning_a_list_of_list_of_model.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_single_returning_a_list_of_list_of_model.json
@@ -25,7 +25,7 @@
         ],
         "summary": "Returns a list of people from the API",
         "description": "Description for returns a list of people values from the API.",
-        "operationId": "Hello_GimmeAListOfListOfAModel",
+        "operationId": "Hello_GimmeAListOfListOfModels",
         "parameters": [],
         "responses": {
           "200": {

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_single_returning_a_list_of_model.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_single_returning_a_list_of_model.json
@@ -25,7 +25,7 @@
         ],
         "summary": "Returns a list of people from the API",
         "description": "Description for returns a list of people values from the API.",
-        "operationId": "Hello_GimmeAListOfModel",
+        "operationId": "Hello_GimmeAListOfModels",
         "parameters": [],
         "responses": {
           "200": {

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_single_returning_a_top_level_raw_object.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_single_returning_a_top_level_raw_object.json
@@ -18,7 +18,7 @@
   "security": [],
   "securityDefinitions": {},
   "paths": {
-    "/worlds": {
+    "/chuckle": {
       "get": {
         "tags": [
           "Hello"

--- a/tools/importer-rest-api-specs/components/parser/testdata/operations_single_with_querystring_options.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/operations_single_with_querystring_options.json
@@ -59,6 +59,14 @@
             }
           },
           {
+            "name": "decimalValue",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "format": "decimal",
+            "description": "Some Decimal Value which should be output as Float64"
+          },
+          {
             "name": "doubleValue",
             "in": "query",
             "required": true,


### PR DESCRIPTION
This PR updates some of the Swagger Parser tests over to using the new test helper tooling - which'll make refactoring this project over to using the new Data API SDK types easier in the future (and has the side-benefit of halving the amount of code needed per test).

Given the number of tests which need to be converted over I've opted to split this PR in two - with `constants` and `models` still to go.

Part of #3754 