### PR TITLE
`tools/wrapper-automation`: applying the same fix to the Go SDK Generator

### DIFF
--- a/tools/generator-go-sdk/main.go
+++ b/tools/generator-go-sdk/main.go
@@ -40,7 +40,7 @@ func run() error {
 	}
 	logging.Log = hclog.New(loggingOpts)
 
-	c := cli.NewCLI("generator-terraform", "1.0.0")
+	c := cli.NewCLI("generator-go-sdk", "1.0.0")
 	c.Args = args
 	c.Commands = map[string]cli.CommandFactory{
 		"generate": cmd.NewGenerateCommand(*sourceDataType),

--- a/tools/wrapper-automation/internal/pipeline/go_sdk_generator.go
+++ b/tools/wrapper-automation/internal/pipeline/go_sdk_generator.go
@@ -39,7 +39,8 @@ func (p *Pipeline) runGoSDKGenerator(opts Options) error {
 	}
 
 	args := []string{
-		// TODO: once Phase 6 is completed: string(opts.SourceDataType),
+		string(opts.SourceDataType),
+		"generate",
 		fmt.Sprintf("-data-api=%s", *p.endpoint),
 	}
 	if opts.OutputDirectory != "" {


### PR DESCRIPTION
I'd checked the scripts for these but apparently forgotten to enable this in the automation codebase itself now that https://github.com/hashicorp/pandora/pull/3802 has been merged 🤦 