### PR TITLE
`tools/generator-go-sdk`: `SecurityInsights` now uses the new base layer

### DIFF
--- a/tools/generator-go-sdk/internal/cmd/generate.go
+++ b/tools/generator-go-sdk/internal/cmd/generate.go
@@ -65,7 +65,6 @@ func (g GenerateCommand) Run(args []string) int {
 		"Insights",
 		"RecoveryServicesBackup", // error: generating Service "RecoveryServicesBackup" / Version "2023-04-01" / Resource "Operation": generating methods: templating methods (using hashicorp/go-azure-sdk): templating: building methods: building response struct template: existing model "ValidateOperationResponse" conflicts with the operation response model for "Validate"
 		"Security",
-		"SecurityInsights",
 		"ServiceFabric",
 		"Subscription",
 


### PR DESCRIPTION
Reimplementing https://github.com/hashicorp/pandora/pull/3809 since there's a merge conflicts and this is quicker

Supersedes https://github.com/hashicorp/pandora/pull/3809