### PR TITLE
`tools/importer-rest-api-specs`: fixing a couple bugs

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/filesystem.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/filesystem.go
@@ -71,6 +71,7 @@ func (f *fileSystem) stage(path filePath, body any) error {
 
 func persistFileSystem(workingDirectory string, dataType models.SourceDataType, serviceName string, input *fileSystem, logger hclog.Logger) error {
 	rootDir := filepath.Join(workingDirectory, string(dataType))
+	logger.Trace(fmt.Sprintf("Persisting files into %q", rootDir))
 
 	// Delete any existing directory with this service name
 	serviceDir := filepath.Join(rootDir, serviceName)
@@ -91,15 +92,15 @@ func persistFileSystem(workingDirectory string, dataType models.SourceDataType, 
 	}
 
 	// write the files
-	for filePath, fileBody := range input.f {
-		fileFullPath := filepath.Join(rootDir, filePath)
+	for path, body := range input.f {
+		fileFullPath := filepath.Join(rootDir, path)
 		logger.Trace(fmt.Sprintf("Writing file %q", fileFullPath))
 		file, err := os.Create(fileFullPath)
 		if err != nil {
 			return fmt.Errorf("opening %q: %+v", fileFullPath, err)
 		}
 
-		_, _ = file.Write(fileBody)
+		_, _ = file.Write(body)
 		_ = file.Close()
 	}
 

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/stage_models.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/stage_models.go
@@ -35,8 +35,10 @@ type generateModelsStage struct {
 
 func (g generateModelsStage) generate(input *fileSystem, logger hclog.Logger) error {
 	logger.Debug("Generating Models")
-	for modelName, modelValue := range g.models {
+	for modelName := range g.models {
 		logger.Trace(fmt.Sprintf("Generating Model %q..", modelName))
+		modelValue := g.models[modelName]
+
 		var parent *models.SDKModel
 		if modelValue.ParentTypeName != nil {
 			logger.Trace("Finding parent model %q..", *modelValue.ParentTypeName)

--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/stage_operations.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/stage_operations.go
@@ -39,8 +39,10 @@ type generateOperationsStage struct {
 
 func (g generateOperationsStage) generate(input *fileSystem, logger hclog.Logger) error {
 	logger.Debug("Generating Operations..")
-	for operationName, operationDetails := range g.operations {
+	for operationName := range g.operations {
 		logger.Trace(fmt.Sprintf("Generating Operation %q..", operationName))
+
+		operationDetails := g.operations[operationName]
 		mapped, err := transforms.MapSDKOperationToRepository(operationName, operationDetails, g.constants, g.models)
 		if err != nil {
 			return fmt.Errorf("mapping Operation %q: %+v", operationName, err)


### PR DESCRIPTION
This PR fixes a couple of bugs in `importer-rest-api-specs` where both the Fields/Operations were being used interchangeably - and the Service directories were being unintentionally created in `./api-definitions` rather than `./api-definitions/{sourceDataType}`