### PR TITLE
`tools/importer-rest-api-specs`: adding an import alias for the internal models package

### DIFF
--- a/tools/importer-rest-api-specs/cmd/schema.go
+++ b/tools/importer-rest-api-specs/cmd/schema.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/resources"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/schema"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/config/definitions"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 	"github.com/hashicorp/pandora/tools/sdk/services"
@@ -131,7 +131,7 @@ func run(input Input) error {
 
 				for resourceName, resource := range candidates.Resources {
 					logger.Trace(fmt.Sprintf("Found Resource %q..", resourceName))
-					schemaDefinition, mappings, err := builder.Build(resource, &models.ResourceBuildInfo{}, logger.Named(fmt.Sprintf("Resource %q", resourceName)))
+					schemaDefinition, mappings, err := builder.Build(resource, &importerModels.ResourceBuildInfo{}, logger.Named(fmt.Sprintf("Resource %q", resourceName)))
 					if err != nil {
 						return fmt.Errorf("processing schema for candidate %s: %+v", resourceName, err)
 					}

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_edge_zone.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_edge_zone.go
@@ -7,8 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = edgeZoneFieldMatcher{}
@@ -16,12 +15,12 @@ var _ customFieldMatcher = edgeZoneFieldMatcher{}
 type edgeZoneFieldMatcher struct {
 }
 
-func (e edgeZoneFieldMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeEdgeZone
+func (e edgeZoneFieldMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeEdgeZone
 }
 
-func (e edgeZoneFieldMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (e edgeZoneFieldMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -41,7 +40,7 @@ func (e edgeZoneFieldMatcher) IsMatch(_ models.FieldDetails, definition models.O
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_legacy_system_and_user_assigned_list.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_legacy_system_and_user_assigned_list.go
@@ -7,20 +7,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = legacySystemAndUserAssignedIdentityListMatcher{}
 
 type legacySystemAndUserAssignedIdentityListMatcher struct{}
 
-func (legacySystemAndUserAssignedIdentityListMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeLegacySystemAndUserAssignedIdentityList
+func (legacySystemAndUserAssignedIdentityListMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeLegacySystemAndUserAssignedIdentityList
 }
 
-func (legacySystemAndUserAssignedIdentityListMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (legacySystemAndUserAssignedIdentityListMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -48,10 +47,10 @@ func (legacySystemAndUserAssignedIdentityListMatcher) IsMatch(_ models.FieldDeta
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a List of Strings
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionList {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionList {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionString {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != importerModels.ObjectDefinitionString {
 				continue
 			}
 
@@ -60,7 +59,7 @@ func (legacySystemAndUserAssignedIdentityListMatcher) IsMatch(_ models.FieldDeta
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_legacy_system_and_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_legacy_system_and_user_assigned_map.go
@@ -7,20 +7,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = legacySystemAndUserAssignedIdentityMapMatcher{}
 
 type legacySystemAndUserAssignedIdentityMapMatcher struct{}
 
-func (legacySystemAndUserAssignedIdentityMapMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap
+func (legacySystemAndUserAssignedIdentityMapMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap
 }
 
-func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -51,7 +50,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetai
 			if fieldVal.ObjectDefinition == nil {
 				continue
 			}
-			if fieldVal.ObjectDefinition.Type == models.ObjectDefinitionDictionary {
+			if fieldVal.ObjectDefinition.Type == importerModels.ObjectDefinitionDictionary {
 				// however some Swaggers don't define the internals e.g. DataFactory
 				//type FactoryIdentity struct {
 				//	PrincipalId            *string                 `json:"principalId,omitempty"`
@@ -62,7 +61,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetai
 				hasUserAssignedIdentities = true
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 
@@ -78,7 +77,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetai
 					if innerVal.ObjectDefinition == nil {
 						continue
 					}
-					if innerVal.ObjectDefinition.Type != models.ObjectDefinitionString {
+					if innerVal.ObjectDefinition.Type != importerModels.ObjectDefinitionString {
 						continue
 					}
 
@@ -90,7 +89,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetai
 					if innerVal.ObjectDefinition == nil {
 						continue
 					}
-					if innerVal.ObjectDefinition.Type != models.ObjectDefinitionString {
+					if innerVal.ObjectDefinition.Type != importerModels.ObjectDefinitionString {
 						continue
 					}
 
@@ -106,7 +105,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetai
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_and_user_assigned_list.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_and_user_assigned_list.go
@@ -7,20 +7,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = systemAndUserAssignedIdentityListMatcher{}
 
 type systemAndUserAssignedIdentityListMatcher struct{}
 
-func (systemAndUserAssignedIdentityListMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeSystemAndUserAssignedIdentityList
+func (systemAndUserAssignedIdentityListMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeSystemAndUserAssignedIdentityList
 }
 
-func (systemAndUserAssignedIdentityListMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (systemAndUserAssignedIdentityListMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -48,10 +47,10 @@ func (systemAndUserAssignedIdentityListMatcher) IsMatch(_ models.FieldDetails, d
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a List of Strings
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionList {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionList {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionString {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != importerModels.ObjectDefinitionString {
 				continue
 			}
 
@@ -60,7 +59,7 @@ func (systemAndUserAssignedIdentityListMatcher) IsMatch(_ models.FieldDetails, d
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_and_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_and_user_assigned_map.go
@@ -7,20 +7,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = systemAndUserAssignedIdentityMapMatcher{}
 
 type systemAndUserAssignedIdentityMapMatcher struct{}
 
-func (systemAndUserAssignedIdentityMapMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeSystemAndUserAssignedIdentityMap
+func (systemAndUserAssignedIdentityMapMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeSystemAndUserAssignedIdentityMap
 }
 
-func (systemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (systemAndUserAssignedIdentityMapMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -48,10 +47,10 @@ func (systemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, de
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a Map of an Object containing ClientId/PrincipalId
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionDictionary {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionDictionary {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 
@@ -67,7 +66,7 @@ func (systemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, de
 					if innerVal.ObjectDefinition == nil {
 						continue
 					}
-					if innerVal.ObjectDefinition.Type != models.ObjectDefinitionString {
+					if innerVal.ObjectDefinition.Type != importerModels.ObjectDefinitionString {
 						continue
 					}
 
@@ -79,7 +78,7 @@ func (systemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, de
 					if innerVal.ObjectDefinition == nil {
 						continue
 					}
-					if innerVal.ObjectDefinition.Type != models.ObjectDefinitionString {
+					if innerVal.ObjectDefinition.Type != importerModels.ObjectDefinitionString {
 						continue
 					}
 
@@ -95,7 +94,7 @@ func (systemAndUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, de
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_assigned.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_assigned.go
@@ -8,21 +8,20 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = systemAssignedIdentityMatcher{}
 
 type systemAssignedIdentityMatcher struct{}
 
-func (systemAssignedIdentityMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeSystemAssignedIdentity
+func (systemAssignedIdentityMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeSystemAssignedIdentity
 }
 
-func (systemAssignedIdentityMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (systemAssignedIdentityMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -48,7 +47,7 @@ func (systemAssignedIdentityMatcher) IsMatch(_ models.FieldDetails, definition m
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_or_user_assigned_list.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_or_user_assigned_list.go
@@ -7,20 +7,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = systemOrUserAssignedIdentityListMatcher{}
 
 type systemOrUserAssignedIdentityListMatcher struct{}
 
-func (systemOrUserAssignedIdentityListMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeSystemOrUserAssignedIdentityList
+func (systemOrUserAssignedIdentityListMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeSystemOrUserAssignedIdentityList
 }
 
-func (systemOrUserAssignedIdentityListMatcher) IsMatch(field models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (systemOrUserAssignedIdentityListMatcher) IsMatch(field importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -48,10 +47,10 @@ func (systemOrUserAssignedIdentityListMatcher) IsMatch(field models.FieldDetails
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a List of Strings
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionList {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionList {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionString {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != importerModels.ObjectDefinitionString {
 				continue
 			}
 
@@ -60,7 +59,7 @@ func (systemOrUserAssignedIdentityListMatcher) IsMatch(field models.FieldDetails
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_or_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_or_user_assigned_map.go
@@ -7,20 +7,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = systemOrUserAssignedIdentityMapMatcher{}
 
 type systemOrUserAssignedIdentityMapMatcher struct{}
 
-func (systemOrUserAssignedIdentityMapMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeSystemOrUserAssignedIdentityMap
+func (systemOrUserAssignedIdentityMapMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeSystemOrUserAssignedIdentityMap
 }
 
-func (systemOrUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (systemOrUserAssignedIdentityMapMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -48,10 +47,10 @@ func (systemOrUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, def
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a Map of an Object containing ClientId/PrincipalId
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionDictionary {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionDictionary {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 
@@ -67,7 +66,7 @@ func (systemOrUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, def
 					if innerVal.ObjectDefinition == nil {
 						continue
 					}
-					if innerVal.ObjectDefinition.Type != models.ObjectDefinitionString {
+					if innerVal.ObjectDefinition.Type != importerModels.ObjectDefinitionString {
 						continue
 					}
 
@@ -79,7 +78,7 @@ func (systemOrUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, def
 					if innerVal.ObjectDefinition == nil {
 						continue
 					}
-					if innerVal.ObjectDefinition.Type != models.ObjectDefinitionString {
+					if innerVal.ObjectDefinition.Type != importerModels.ObjectDefinitionString {
 						continue
 					}
 
@@ -95,7 +94,7 @@ func (systemOrUserAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, def
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_list.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_list.go
@@ -7,20 +7,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = userAssignedIdentityListMatcher{}
 
 type userAssignedIdentityListMatcher struct{}
 
-func (userAssignedIdentityListMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeUserAssignedIdentityList
+func (userAssignedIdentityListMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeUserAssignedIdentityList
 }
 
-func (userAssignedIdentityListMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (userAssignedIdentityListMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -35,10 +34,10 @@ func (userAssignedIdentityListMatcher) IsMatch(_ models.FieldDetails, definition
 	for fieldName, fieldVal := range model.Fields {
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a List of Strings
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionList {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionList {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionString {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != importerModels.ObjectDefinitionString {
 				continue
 			}
 
@@ -50,7 +49,7 @@ func (userAssignedIdentityListMatcher) IsMatch(_ models.FieldDetails, definition
 		// https://github.com/Azure/azure-rest-api-specs/blob/c803720c6bcfcb0fcf4c97f3463ec33a18f9e55c/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabricManagedClusters/stable/2021-05-01/nodetype.json#L763
 		// as such we're only concerned if it's defined and doesn't match
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_map.go
@@ -7,20 +7,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = userAssignedIdentityMapMatcher{}
 
 type userAssignedIdentityMapMatcher struct{}
 
-func (userAssignedIdentityMapMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeUserAssignedIdentityMap
+func (userAssignedIdentityMapMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeUserAssignedIdentityMap
 }
 
-func (userAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (userAssignedIdentityMapMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -36,10 +35,10 @@ func (userAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition 
 	for fieldName, fieldVal := range model.Fields {
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a Map of an Object containing ClientId/PrincipalId
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionDictionary {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionDictionary {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 
@@ -55,7 +54,7 @@ func (userAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition 
 					if innerVal.ObjectDefinition == nil {
 						continue
 					}
-					if innerVal.ObjectDefinition.Type != models.ObjectDefinitionString {
+					if innerVal.ObjectDefinition.Type != importerModels.ObjectDefinitionString {
 						continue
 					}
 
@@ -67,7 +66,7 @@ func (userAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition 
 					if innerVal.ObjectDefinition == nil {
 						continue
 					}
-					if innerVal.ObjectDefinition.Type != models.ObjectDefinitionString {
+					if innerVal.ObjectDefinition.Type != importerModels.ObjectDefinitionString {
 						continue
 					}
 
@@ -84,7 +83,7 @@ func (userAssignedIdentityMapMatcher) IsMatch(_ models.FieldDetails, definition 
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_location.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_location.go
@@ -7,18 +7,17 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = locationMatcher{}
 
 type locationMatcher struct{}
 
-func (l locationMatcher) IsMatch(field models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	return strings.EqualFold(field.JsonName, "location") && definition.Type == models.ObjectDefinitionString
+func (l locationMatcher) IsMatch(field importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	return strings.EqualFold(field.JsonName, "location") && definition.Type == importerModels.ObjectDefinitionString
 }
 
-func (locationMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeLocation
+func (locationMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeLocation
 }

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_system_data.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_system_data.go
@@ -8,21 +8,20 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = systemDataMatcher{}
 
 type systemDataMatcher struct{}
 
-func (systemDataMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeSystemData
+func (systemDataMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeSystemData
 }
 
-func (systemDataMatcher) IsMatch(_ models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	if definition.Type != models.ObjectDefinitionReference {
+func (systemDataMatcher) IsMatch(_ importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	if definition.Type != importerModels.ObjectDefinitionReference {
 		return false
 	}
 
@@ -62,16 +61,16 @@ func (systemDataMatcher) IsMatch(_ models.FieldDetails, definition models.Object
 		}
 
 		if strings.EqualFold(fieldName, "CreatedByType") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 
-			if fieldVal.ObjectDefinition.Type == models.ObjectDefinitionString {
+			if fieldVal.ObjectDefinition.Type == importerModels.ObjectDefinitionString {
 				// Sometimes this field is a string.
 				// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/stable/2021-05-01/managedcluster.json#L1322-L1325
 				hasCreatedByType = true
 				continue
-			} else if fieldVal.ObjectDefinition.Type == models.ObjectDefinitionReference {
+			} else if fieldVal.ObjectDefinition.Type == importerModels.ObjectDefinitionReference {
 				// Sometimes it's not ...
 				// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/azurearcdata/resource-manager/Microsoft.AzureArcData/stable/2021-08-01/azurearcdata.json#L1294-L1297
 				expected := map[string]string{
@@ -91,15 +90,15 @@ func (systemDataMatcher) IsMatch(_ models.FieldDetails, definition models.Object
 		}
 
 		if strings.EqualFold(fieldName, "LastModifiedByType") {
-			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != models.ObjectDefinitionReference {
+			if fieldVal.ObjectDefinition == nil || fieldVal.ObjectDefinition.Type != importerModels.ObjectDefinitionReference {
 				continue
 			}
 
 			// Sometimes this field is a string.
 			// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/stable/2021-05-01/managedcluster.json#L1322-L1325
-			if fieldVal.ObjectDefinition.Type == models.ObjectDefinitionString {
+			if fieldVal.ObjectDefinition.Type == importerModels.ObjectDefinitionString {
 				hasLastModifiedbyType = true
-			} else if fieldVal.ObjectDefinition.Type == models.ObjectDefinitionReference {
+			} else if fieldVal.ObjectDefinition.Type == importerModels.ObjectDefinitionReference {
 				// Sometimes it's not ...
 				// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/azurearcdata/resource-manager/Microsoft.AzureArcData/stable/2021-08-01/azurearcdata.json#L1294-L1297
 				expected := map[string]string{

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_tags.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_tags.go
@@ -7,18 +7,17 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = tagsMatcher{}
 
 type tagsMatcher struct{}
 
-func (tagsMatcher) IsMatch(field models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool {
-	return strings.EqualFold(field.JsonName, "tags") && definition.Type == models.ObjectDefinitionDictionary && definition.NestedItem.Type == models.ObjectDefinitionString
+func (tagsMatcher) IsMatch(field importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool {
+	return strings.EqualFold(field.JsonName, "tags") && definition.Type == importerModels.ObjectDefinitionDictionary && definition.NestedItem.Type == importerModels.ObjectDefinitionString
 }
 
-func (tagsMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeTags
+func (tagsMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeTags
 }

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_zone.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_zone.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = zoneFieldMatcher{}
@@ -15,12 +15,12 @@ var _ customFieldMatcher = zoneFieldMatcher{}
 type zoneFieldMatcher struct {
 }
 
-func (e zoneFieldMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeZone
+func (e zoneFieldMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeZone
 }
 
-func (e zoneFieldMatcher) IsMatch(field models.FieldDetails, definition models.ObjectDefinition, _ internal.ParseResult) bool {
+func (e zoneFieldMatcher) IsMatch(field importerModels.FieldDetails, definition importerModels.ObjectDefinition, _ internal.ParseResult) bool {
 	nameMatches := strings.EqualFold(field.JsonName, "availabilityZone") || strings.EqualFold(field.JsonName, "zone")
-	typeMatches := definition.Type == models.ObjectDefinitionString
+	typeMatches := definition.Type == importerModels.ObjectDefinitionString
 	return nameMatches && typeMatches
 }

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_zones.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_zones.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ customFieldMatcher = zonesFieldMatcher{}
@@ -15,12 +15,12 @@ var _ customFieldMatcher = zonesFieldMatcher{}
 type zonesFieldMatcher struct {
 }
 
-func (e zonesFieldMatcher) CustomFieldType() models.CustomFieldType {
-	return models.CustomFieldTypeZones
+func (e zonesFieldMatcher) CustomFieldType() importerModels.CustomFieldType {
+	return importerModels.CustomFieldTypeZones
 }
 
-func (e zonesFieldMatcher) IsMatch(field models.FieldDetails, definition models.ObjectDefinition, _ internal.ParseResult) bool {
+func (e zonesFieldMatcher) IsMatch(field importerModels.FieldDetails, definition importerModels.ObjectDefinition, _ internal.ParseResult) bool {
 	nameMatches := strings.EqualFold(field.JsonName, "availabilityZones") || strings.EqualFold(field.JsonName, "zones")
-	typesMatch := definition.Type == models.ObjectDefinitionList && definition.NestedItem != nil && definition.NestedItem.Type == models.ObjectDefinitionString
+	typesMatch := definition.Type == importerModels.ObjectDefinitionList && definition.NestedItem != nil && definition.NestedItem.Type == importerModels.ObjectDefinitionString
 	return nameMatches && typesMatch
 }

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_fields.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_fields.go
@@ -5,16 +5,16 @@ package commonschema
 
 import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 type customFieldMatcher interface {
 	// CustomFieldType is the Custom Field Type which should be used when this Matcher matches
-	CustomFieldType() models.CustomFieldType
+	CustomFieldType() importerModels.CustomFieldType
 
 	// IsMatch returns whether the field and definition provided match this Custom Field Matcher
 	// meaning that the types should be replaced with the CustomFieldType found in customFieldType
-	IsMatch(field models.FieldDetails, definition models.ObjectDefinition, known internal.ParseResult) bool
+	IsMatch(field importerModels.FieldDetails, definition importerModels.ObjectDefinition, known internal.ParseResult) bool
 }
 
 var CustomFieldMatchers = []customFieldMatcher{

--- a/tools/importer-rest-api-specs/components/parser/constants_test.go
+++ b/tools/importer-rest-api-specs/components/parser/constants_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -18,10 +18,10 @@ func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -34,29 +34,29 @@ func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -75,10 +75,10 @@ func TestParseConstantsIntegersTopLevelAsIntsWithDisplayName(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -90,29 +90,29 @@ func TestParseConstantsIntegersTopLevelAsIntsWithDisplayName(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -130,10 +130,10 @@ func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -145,29 +145,29 @@ func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -185,10 +185,10 @@ func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -200,29 +200,29 @@ func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -241,10 +241,10 @@ func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -256,29 +256,29 @@ func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -296,10 +296,10 @@ func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -311,29 +311,29 @@ func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -351,10 +351,10 @@ func TestParseConstantsFloatsTopLevelAsFloats(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -366,29 +366,29 @@ func TestParseConstantsFloatsTopLevelAsFloats(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -406,10 +406,10 @@ func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -421,29 +421,29 @@ func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -461,10 +461,10 @@ func TestParseConstantsFloatsInlinedAsFloats(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -476,29 +476,29 @@ func TestParseConstantsFloatsInlinedAsFloats(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -516,10 +516,10 @@ func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -531,29 +531,29 @@ func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -570,10 +570,10 @@ func TestParseConstantsStringsTopLevel(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"AnimalType": {
@@ -586,29 +586,29 @@ func TestParseConstantsStringsTopLevel(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -628,10 +628,10 @@ func TestParseConstantsStringsTopLevelAsNonStrings(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"AnimalType": {
@@ -643,29 +643,29 @@ func TestParseConstantsStringsTopLevelAsNonStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -682,10 +682,10 @@ func TestParseConstantsStringsInlined(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"AnimalType": {
@@ -697,29 +697,29 @@ func TestParseConstantsStringsInlined(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -736,10 +736,10 @@ func TestParseConstantsStringsInlinedAsNonStrings(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"AnimalType": {
@@ -751,29 +751,29 @@ func TestParseConstantsStringsInlinedAsNonStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -791,10 +791,10 @@ func TestParseConstantsStringsTopLevelContainingFloats(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -806,29 +806,29 @@ func TestParseConstantsStringsTopLevelContainingFloats(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -846,10 +846,10 @@ func TestParseConstantsStringsInlinedContainingFloats(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"TableNumber": {
@@ -861,29 +861,29 @@ func TestParseConstantsStringsInlinedContainingFloats(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/interface.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/interface.go
@@ -4,16 +4,16 @@
 package dataworkarounds
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 type workaround interface {
 	// IsApplicable determines whether this workaround is applicable for this AzureApiDefinition
-	IsApplicable(apiDefinition *models.AzureApiDefinition) bool
+	IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool
 
 	// Name returns the Service Name and associated Pull Request number
 	Name() string
 
 	// Process takes the apiDefinition and applies the Workaround to this AzureApiDefinition
-	Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error)
+	Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error)
 }

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_automation_25108.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_automation_25108.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundAutomation25108{}
@@ -14,7 +14,7 @@ var _ workaround = workaroundAutomation25108{}
 type workaroundAutomation25108 struct {
 }
 
-func (workaroundAutomation25108) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundAutomation25108) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	serviceMatches := apiDefinition.ServiceName == "Automation"
 	apiVersionMatches := apiDefinition.ApiVersion == "2022-08-08" || apiDefinition.ApiVersion == "2023-11-01"
 	return serviceMatches && apiVersionMatches
@@ -24,7 +24,7 @@ func (workaroundAutomation25108) Name() string {
 	return "Automation / 25108"
 }
 
-func (workaroundAutomation25108) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundAutomation25108) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["ListAllHybridRunbookWorkerGroupInAutomationAccount"]
 	if !ok {
 		return nil, fmt.Errorf("expected a Resource named `ListAllHybridRunbookWorkerGroupInAutomationAccount`")

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_automation_25435.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_automation_25435.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundAutomation25435{}
@@ -16,7 +16,7 @@ var _ workaround = workaroundAutomation25435{}
 type workaroundAutomation25435 struct {
 }
 
-func (workaroundAutomation25435) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundAutomation25435) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	serviceMatches := apiDefinition.ServiceName == "Automation"
 	apiVersionMatches := apiDefinition.ApiVersion == "2022-08-08" || apiDefinition.ApiVersion == "2023-11-01"
 	return serviceMatches && apiVersionMatches
@@ -26,7 +26,7 @@ func (workaroundAutomation25435) Name() string {
 	return "Automation / 25434"
 }
 
-func (workaroundAutomation25435) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundAutomation25435) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["Python3Package"]
 	if !ok {
 		return nil, fmt.Errorf("expected a Resource named `Python3Package`")

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_batch_21291.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_batch_21291.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundBatch21291{}
@@ -17,7 +17,7 @@ var _ workaround = workaroundBatch21291{}
 type workaroundBatch21291 struct {
 }
 
-func (workaroundBatch21291) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundBatch21291) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	serviceMatches := apiDefinition.ServiceName == "Batch"
 	apiVersionMatches := apiDefinition.ApiVersion == "2022-01-01" || apiDefinition.ApiVersion == "2022-10-01" || apiDefinition.ApiVersion == "2023-05-01"
 	return serviceMatches && apiVersionMatches
@@ -27,7 +27,7 @@ func (workaroundBatch21291) Name() string {
 	return "Batch / 21291"
 }
 
-func (workaroundBatch21291) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundBatch21291) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["BatchAccount"]
 	if !ok {
 		return nil, fmt.Errorf("couldn't find API Resource BatchAccount")

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -16,7 +16,7 @@ var _ workaround = workaroundBotService27351{}
 type workaroundBotService27351 struct {
 }
 
-func (workaroundBotService27351) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundBotService27351) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	// This workaround fixes an issue where the BotService Channel URI is defined using two subtly different Resource IDs.
 	// Fix: https://github.com/Azure/azure-rest-api-specs/pull/27351
 	//
@@ -45,7 +45,7 @@ func (workaroundBotService27351) Name() string {
 	return "BotService / 27351"
 }
 
-func (workaroundBotService27351) Process(input models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundBotService27351) Process(input importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	output := input
 
 	resource, ok := output.Resources["Channel"]

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_containerservice_21394.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_containerservice_21394.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundContainerService21394{}
@@ -15,7 +15,7 @@ var _ workaround = workaroundContainerService21394{}
 // Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/21394
 type workaroundContainerService21394 struct{}
 
-func (workaroundContainerService21394) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundContainerService21394) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	return apiDefinition.ServiceName == "ContainerService" && apiDefinition.ApiVersion == "2022-09-02-preview"
 }
 
@@ -23,7 +23,7 @@ func (workaroundContainerService21394) Name() string {
 	return "ContainerService / 21394"
 }
 
-func (workaroundContainerService21394) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundContainerService21394) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["Fleets"]
 	if !ok {
 		return nil, fmt.Errorf("couldn't find API Resource Fleets")

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_datafactory_23013.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_datafactory_23013.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundDataFactory23013{}
@@ -17,7 +17,7 @@ var _ workaround = workaroundDataFactory23013{}
 // Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/23013
 type workaroundDataFactory23013 struct{}
 
-func (workaroundDataFactory23013) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundDataFactory23013) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	return apiDefinition.ServiceName == "DataFactory" && apiDefinition.ApiVersion == "2018-06-01"
 }
 
@@ -25,19 +25,19 @@ func (workaroundDataFactory23013) Name() string {
 	return "DataFactory / 23013"
 }
 
-func (workaroundDataFactory23013) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundDataFactory23013) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["DataFlowDebugSession"]
 	if !ok {
 		return nil, fmt.Errorf("couldn't find API Resource DataFlowDebugSession")
 	}
 
 	// add the new discriminated parent type
-	resource.Models["Reference"] = models.ModelDetails{
+	resource.Models["Reference"] = importerModels.ModelDetails{
 		TypeHintIn: pointer.To("Type"),
-		Fields: map[string]models.FieldDetails{
+		Fields: map[string]importerModels.FieldDetails{
 			"Type": {
-				ObjectDefinition: &models.ObjectDefinition{
-					Type: models.ObjectDefinitionString,
+				ObjectDefinition: &importerModels.ObjectDefinition{
+					Type: importerModels.ObjectDefinitionString,
 				},
 				Required: true,
 				JsonName: "type",
@@ -45,7 +45,7 @@ func (workaroundDataFactory23013) Process(apiDefinition models.AzureApiDefinitio
 		},
 	}
 
-	// update the existing models to be discriminated types and remove the `type` field from them
+	// update the existing importerModels to be discriminated types and remove the `type` field from them
 	modelNames := []string{
 		"IntegrationRuntimeReference",
 		"LinkedServiceReference",

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_devcenter_26189.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_devcenter_26189.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 // This workaround fixes an issue in DevCenter where the field `DevCenterUri` is not
@@ -25,7 +25,7 @@ var _ workaround = workaroundDevCenter26189{}
 type workaroundDevCenter26189 struct {
 }
 
-func (workaroundDevCenter26189) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundDevCenter26189) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	return apiDefinition.ServiceName == "DevCenter" && apiDefinition.ApiVersion == "2023-04-01"
 }
 
@@ -33,7 +33,7 @@ func (workaroundDevCenter26189) Name() string {
 	return "DevCenter / 26189"
 }
 
-func (workaroundDevCenter26189) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundDevCenter26189) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	// First we need to patch the DevCenters issue (marking DevCenterUri as required)
 	devCentersResource, ok := apiDefinition.Resources["DevCenters"]
 	if !ok {

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_digitaltwins_25120.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_digitaltwins_25120.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundDigitalTwins25120{}
@@ -14,7 +14,7 @@ var _ workaround = workaroundDigitalTwins25120{}
 // Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/21520
 type workaroundDigitalTwins25120 struct{}
 
-func (workaroundDigitalTwins25120) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundDigitalTwins25120) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	// API Defines a Constant with the string values `"true"` and `"false`:
 	// RecordPropertyAndItemRemovals           *RecordPropertyAndItemRemovals `json:"recordPropertyAndItemRemovals,omitempty"`
 	// but the API returns a boolean:
@@ -26,7 +26,7 @@ func (workaroundDigitalTwins25120) Name() string {
 	return "DigitalTwins / 25120"
 }
 
-func (workaroundDigitalTwins25120) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundDigitalTwins25120) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["TimeSeriesDatabaseConnections"]
 	if !ok {
 		return nil, fmt.Errorf("expected a Resource named `TimeSeriesDatabaseConnections`")
@@ -40,8 +40,8 @@ func (workaroundDigitalTwins25120) Process(apiDefinition models.AzureApiDefiniti
 	if !ok {
 		return nil, fmt.Errorf("expected a Field named `RecordPropertyAndItemRemovals`")
 	}
-	field.ObjectDefinition = &models.ObjectDefinition{
-		Type: models.ObjectDefinitionBoolean,
+	field.ObjectDefinition = &importerModels.ObjectDefinition{
+		Type: importerModels.ObjectDefinitionBoolean,
 	}
 	model.Fields["RecordPropertyAndItemRemovals"] = field
 	resource.Models["AzureDataExplorerConnectionProperties"] = model

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -16,7 +16,7 @@ var _ workaround = workaroundHDInsight26838{}
 // Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/26838
 type workaroundHDInsight26838 struct{}
 
-func (workaroundHDInsight26838) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundHDInsight26838) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	// The field `kind` is a constant within the API but isn't documented as such - whilst
 	// we've previously been using this as a String - since we need to recase the value as
 	// the API returns this inconsistently - and there's a fixed list of possible values
@@ -40,7 +40,7 @@ func (workaroundHDInsight26838) Name() string {
 	return "HDInsight / 26838"
 }
 
-func (workaroundHDInsight26838) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundHDInsight26838) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["Clusters"]
 	if !ok {
 		return nil, fmt.Errorf("expected a Resource named `Clusters`")
@@ -54,8 +54,8 @@ func (workaroundHDInsight26838) Process(apiDefinition models.AzureApiDefinition)
 	if !ok {
 		return nil, fmt.Errorf("expected a Field named `Kind`")
 	}
-	field.ObjectDefinition = &models.ObjectDefinition{
-		Type:          models.ObjectDefinitionReference,
+	field.ObjectDefinition = &importerModels.ObjectDefinition{
+		Type:          importerModels.ObjectDefinitionReference,
 		ReferenceName: pointer.To("ClusterKind"),
 	}
 	model.Fields["Kind"] = field

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -16,7 +16,7 @@ var _ workaround = workaroundInconsistentlyDefinedSegments{}
 
 type workaroundInconsistentlyDefinedSegments struct{}
 
-func (workaroundInconsistentlyDefinedSegments) IsApplicable(_ *models.AzureApiDefinition) bool {
+func (workaroundInconsistentlyDefinedSegments) IsApplicable(_ *importerModels.AzureApiDefinition) bool {
 	return true
 }
 
@@ -24,12 +24,12 @@ func (workaroundInconsistentlyDefinedSegments) Name() string {
 	return "Workaround Inconsistently Defined Resource ID Segments"
 }
 
-func (workaroundInconsistentlyDefinedSegments) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
-	resources := make(map[string]models.AzureApiResource, 0)
+func (workaroundInconsistentlyDefinedSegments) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
+	resources := make(map[string]importerModels.AzureApiResource, 0)
 	for resourceName := range apiDefinition.Resources {
 		resource := apiDefinition.Resources[resourceName]
 
-		ids := make(map[string]models.ParsedResourceId, 0)
+		ids := make(map[string]importerModels.ParsedResourceId, 0)
 		for key := range resource.ResourceIds {
 			id := resource.ResourceIds[key]
 			segments := make([]resourcemanager.ResourceIdSegment, 0)

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_invalid_go_package_names.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_invalid_go_package_names.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundInvalidGoPackageNames{}
 
 type workaroundInvalidGoPackageNames struct{}
 
-func (workaroundInvalidGoPackageNames) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundInvalidGoPackageNames) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	for key := range apiDefinition.Resources {
 		if strings.EqualFold(key, "documentation") {
 			return true
@@ -27,8 +27,8 @@ func (workaroundInvalidGoPackageNames) Name() string {
 	return "Workaround Invalid Go Package Names"
 }
 
-func (workaroundInvalidGoPackageNames) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
-	resources := make(map[string]models.AzureApiResource, 0)
+func (workaroundInvalidGoPackageNames) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
+	resources := make(map[string]importerModels.AzureApiResource, 0)
 
 	for resourceName := range apiDefinition.Resources {
 		originalName := resourceName

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_loadtest_20961.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_loadtest_20961.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundLoadTest20961{}
@@ -17,7 +17,7 @@ var _ workaround = workaroundLoadTest20961{}
 type workaroundLoadTest20961 struct {
 }
 
-func (workaroundLoadTest20961) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundLoadTest20961) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	serviceMatches := apiDefinition.ServiceName == "LoadTestService"
 	apiVersionMatches := apiDefinition.ApiVersion == "2021-12-01-preview" || apiDefinition.ApiVersion == "2022-04-15-preview" || apiDefinition.ApiVersion == "2022-12-01"
 	return serviceMatches && apiVersionMatches
@@ -27,7 +27,7 @@ func (workaroundLoadTest20961) Name() string {
 	return "LoadTest / 20961"
 }
 
-func (workaroundLoadTest20961) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundLoadTest20961) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["LoadTests"]
 	if !ok {
 		return nil, fmt.Errorf("couldn't find API Resource LoadTests")
@@ -40,7 +40,7 @@ func (workaroundLoadTest20961) Process(apiDefinition models.AzureApiDefinition) 
 	if !ok {
 		return nil, fmt.Errorf("couldn't find field Tags within model LoadTestResourcePatchRequestBody")
 	}
-	tagsType := models.CustomFieldTypeTags
+	tagsType := importerModels.CustomFieldTypeTags
 	field.CustomFieldType = &tagsType
 	field.ObjectDefinition = nil
 

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_machinelearning_25142.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_machinelearning_25142.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundMachineLearning25142{}
@@ -17,7 +17,7 @@ var _ workaround = workaroundMachineLearning25142{}
 type workaroundMachineLearning25142 struct {
 }
 
-func (workaroundMachineLearning25142) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundMachineLearning25142) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	serviceMatches := apiDefinition.ServiceName == "MachineLearningServices"
 	apiVersionMatches := apiDefinition.ApiVersion == "2023-04-01"
 	return serviceMatches && apiVersionMatches
@@ -27,7 +27,7 @@ func (workaroundMachineLearning25142) Name() string {
 	return "MachineLearningServices / 25142"
 }
 
-func (workaroundMachineLearning25142) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundMachineLearning25142) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["RegistryManagement"]
 	if !ok {
 		return nil, fmt.Errorf("couldn't find API Resource RegistryManagement")

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_26678.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_26678.go
@@ -6,14 +6,14 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundOperationalinsights26678{}
 
 type workaroundOperationalinsights26678 struct{}
 
-func (workaroundOperationalinsights26678) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundOperationalinsights26678) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	return apiDefinition.ServiceName == "OperationalInsights" && apiDefinition.ApiVersion == "2021-06-01"
 }
 
@@ -21,7 +21,7 @@ func (workaroundOperationalinsights26678) Name() string {
 	return "OperationalInsights / 26678"
 }
 
-func (workaroundOperationalinsights26678) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundOperationalinsights26678) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["Clusters"]
 	if !ok {
 		return nil, fmt.Errorf("expected a Resource named `Cluster` but didn't get one")

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_27524.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_operationalinsights_27524.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundOperationalinsights27524{}
@@ -15,7 +15,7 @@ var _ workaround = workaroundOperationalinsights27524{}
 // Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/27524
 type workaroundOperationalinsights27524 struct{}
 
-func (workaroundOperationalinsights27524) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (workaroundOperationalinsights27524) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	return apiDefinition.ServiceName == "OperationalInsights" && apiDefinition.ApiVersion == "2019-09-01"
 }
 
@@ -23,7 +23,7 @@ func (workaroundOperationalinsights27524) Name() string {
 	return "OperationalInsights / 27524"
 }
 
-func (workaroundOperationalinsights27524) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (workaroundOperationalinsights27524) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["QueryPacks"]
 	if !ok {
 		return nil, fmt.Errorf("expected a Resource named `QueryPacks` but didn't get one")

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_recoveryservicessiterecovery_26680.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_recoveryservicessiterecovery_26680.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundRecoveryServicesSiteRecovery26680{}
@@ -20,7 +20,7 @@ var _ workaround = workaroundRecoveryServicesSiteRecovery26680{}
 type workaroundRecoveryServicesSiteRecovery26680 struct {
 }
 
-func (w workaroundRecoveryServicesSiteRecovery26680) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (w workaroundRecoveryServicesSiteRecovery26680) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	if apiDefinition.ServiceName != "RecoveryServicesSiteRecovery" {
 		return false
 	}
@@ -47,20 +47,20 @@ func (w workaroundRecoveryServicesSiteRecovery26680) Name() string {
 	return "RecoveryServicesSiteRecovery / 26680"
 }
 
-func (w workaroundRecoveryServicesSiteRecovery26680) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (w workaroundRecoveryServicesSiteRecovery26680) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := apiDefinition.Resources["VaultCertificates"]
 	if !ok {
 		return nil, fmt.Errorf("expected a Resource named `VaultCertificates` but didn't get one")
 	}
 
 	// 1. Add the missing model
-	resource.Models["CertificateCreateOptions"] = models.ModelDetails{
-		Fields: map[string]models.FieldDetails{
+	resource.Models["CertificateCreateOptions"] = importerModels.ModelDetails{
+		Fields: map[string]importerModels.FieldDetails{
 			"ValidityInHours": {
 				Required: false,
 				JsonName: "validityInHours",
-				ObjectDefinition: &models.ObjectDefinition{
-					Type: models.ObjectDefinitionInteger,
+				ObjectDefinition: &importerModels.ObjectDefinition{
+					Type: importerModels.ObjectDefinitionInteger,
 				},
 			},
 		},
@@ -71,16 +71,16 @@ func (w workaroundRecoveryServicesSiteRecovery26680) Process(apiDefinition model
 	if !ok {
 		return nil, fmt.Errorf("expected a Model named `CertificateRequest` but didn't get one")
 	}
-	model.Fields["CertificateCreateOptions"] = models.FieldDetails{
+	model.Fields["CertificateCreateOptions"] = importerModels.FieldDetails{
 		Required:        false,
 		ReadOnly:        false,
 		Sensitive:       false,
 		JsonName:        "certificateCreateOptions",
 		Description:     "",
 		CustomFieldType: nil,
-		ObjectDefinition: &models.ObjectDefinition{
+		ObjectDefinition: &importerModels.ObjectDefinition{
 			ReferenceName: pointer.To("CertificateCreateOptions"),
-			Type:          models.ObjectDefinitionReference,
+			Type:          importerModels.ObjectDefinitionReference,
 		},
 	}
 	resource.Models["CertificateRequest"] = model

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_redis_22407.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_redis_22407.go
@@ -4,13 +4,13 @@
 package dataworkarounds
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 type workaroundRedis22407 struct {
 }
 
-func (w workaroundRedis22407) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (w workaroundRedis22407) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	serviceMatches := apiDefinition.ServiceName == "Redis"
 	apiVersionMatches := apiDefinition.ApiVersion == "2022-06-01" || apiDefinition.ApiVersion == "2023-04-01" || apiDefinition.ApiVersion == "2023-08-01"
 	return serviceMatches && apiVersionMatches
@@ -20,19 +20,19 @@ func (w workaroundRedis22407) Name() string {
 	return "Redis / 22407"
 }
 
-func (w workaroundRedis22407) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (w workaroundRedis22407) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	if resource, ok := apiDefinition.Resources["Redis"]; ok {
 		if model, ok := resource.Models["RedisCommonPropertiesRedisConfiguration"]; ok {
 
 			if _, ok := model.Fields["NotifyKeyspaceEvents"]; !ok {
-				model.Fields["NotifyKeyspaceEvents"] = models.FieldDetails{
+				model.Fields["NotifyKeyspaceEvents"] = importerModels.FieldDetails{
 					Required:    false,
 					ReadOnly:    false,
 					Sensitive:   false,
 					JsonName:    "notify-keyspace-events",
 					Description: "The KeySpace Events which should be monitored.",
-					ObjectDefinition: &models.ObjectDefinition{
-						Type: models.ObjectDefinitionString,
+					ObjectDefinition: &importerModels.ObjectDefinition{
+						Type: importerModels.ObjectDefinitionString,
 					},
 				}
 			}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_streamanalytics_27577.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_streamanalytics_27577.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 // workaroundStreamAnalytics27577 is a workaround to account for StreamAnalytics containing its own
@@ -17,7 +17,7 @@ import (
 type workaroundStreamAnalytics27577 struct {
 }
 
-func (w workaroundStreamAnalytics27577) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (w workaroundStreamAnalytics27577) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	serviceMatches := apiDefinition.ServiceName == "StreamAnalytics"
 	apiVersionMatches := apiDefinition.ApiVersion == "2020-03-01" || apiDefinition.ApiVersion == "2021-10-01-preview"
 	return serviceMatches && apiVersionMatches
@@ -27,7 +27,7 @@ func (w workaroundStreamAnalytics27577) Name() string {
 	return "StreamAnalytics / 27577"
 }
 
-func (w workaroundStreamAnalytics27577) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (w workaroundStreamAnalytics27577) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	apiResourcesToFix := []string{
 		"StreamingJobs",
 	}
@@ -54,10 +54,10 @@ func (w workaroundStreamAnalytics27577) Process(apiDefinition models.AzureApiDef
 		}
 
 		// update the reference to be a System OR UserAssigned identity
-		field.CustomFieldType = pointer.To(models.CustomFieldTypeSystemOrUserAssignedIdentityMap)
+		field.CustomFieldType = pointer.To(importerModels.CustomFieldTypeSystemOrUserAssignedIdentityMap)
 		if apiDefinition.ApiVersion == "2020-03-01" {
 			// however API version 2020-03-01 only supports SystemAssigned
-			field.CustomFieldType = pointer.To(models.CustomFieldTypeSystemAssignedIdentity)
+			field.CustomFieldType = pointer.To(importerModels.CustomFieldTypeSystemAssignedIdentity)
 		}
 		field.ObjectDefinition = nil
 

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var workarounds = []workaround{
@@ -38,8 +38,8 @@ var workarounds = []workaround{
 	workaroundOperationalinsights27524{},
 }
 
-func ApplyWorkarounds(input []models.AzureApiDefinition, logger hclog.Logger) (*[]models.AzureApiDefinition, error) {
-	output := make([]models.AzureApiDefinition, 0)
+func ApplyWorkarounds(input []importerModels.AzureApiDefinition, logger hclog.Logger) (*[]importerModels.AzureApiDefinition, error) {
+	output := make([]importerModels.AzureApiDefinition, 0)
 	logger.Trace("Processing Swagger Data Workarounds..")
 	for _, item := range input {
 		for _, fix := range workarounds {

--- a/tools/importer-rest-api-specs/components/parser/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
-
 	"github.com/go-openapi/spec"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 func fragmentNameFromReference(input spec.Ref) *string {
@@ -50,7 +49,7 @@ func operationMatchesTag(operation *spec.Operation, tag *string) bool {
 }
 
 // topLevelObjectDefinition returns the top level object definition, that is a Constant or Model (or simple type) directly
-func topLevelObjectDefinition(input models.ObjectDefinition) models.ObjectDefinition {
+func topLevelObjectDefinition(input importerModels.ObjectDefinition) importerModels.ObjectDefinition {
 	if input.NestedItem != nil {
 		return topLevelObjectDefinition(*input.NestedItem)
 	}

--- a/tools/importer-rest-api-specs/components/parser/internal/structs.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/structs.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 type ParseResult struct {
 	Constants map[string]resourcemanager.ConstantDetails
-	Models    map[string]models.ModelDetails
+	Models    map[string]importerModels.ModelDetails
 }
 
 func (r *ParseResult) Append(other ParseResult) error {
@@ -27,7 +27,7 @@ func (r *ParseResult) Append(other ParseResult) error {
 	}
 
 	if r.Models == nil {
-		r.Models = make(map[string]models.ModelDetails)
+		r.Models = make(map[string]importerModels.ModelDetails)
 	}
 	if err := r.AppendModels(other.Models); err != nil {
 		return fmt.Errorf("appending models: %+v", err)
@@ -56,7 +56,7 @@ func (r *ParseResult) AppendConstants(other map[string]resourcemanager.ConstantD
 	return nil
 }
 
-func (r *ParseResult) AppendModels(other map[string]models.ModelDetails) error {
+func (r *ParseResult) AppendModels(other map[string]importerModels.ModelDetails) error {
 	for k, v := range other {
 		existing, hasExisting := r.Models[k]
 		if !hasExisting {
@@ -82,7 +82,7 @@ func (r *ParseResult) AppendModels(other map[string]models.ModelDetails) error {
 	return nil
 }
 
-func compareFields(first map[string]models.FieldDetails, second map[string]models.FieldDetails) error {
+func compareFields(first map[string]importerModels.FieldDetails, second map[string]importerModels.FieldDetails) error {
 	if len(first) != len(second) {
 		return fmt.Errorf("first had %d fields but second had %d fields", len(first), len(second))
 	}
@@ -115,7 +115,7 @@ func compareFields(first map[string]models.FieldDetails, second map[string]model
 	return nil
 }
 
-func objectDefinitionsMatch(first *models.ObjectDefinition, second *models.ObjectDefinition) error {
+func objectDefinitionsMatch(first *importerModels.ObjectDefinition, second *importerModels.ObjectDefinition) error {
 	if first == nil && second == nil {
 		return nil
 	}
@@ -147,7 +147,7 @@ func objectDefinitionsMatch(first *models.ObjectDefinition, second *models.Objec
 	return nil
 }
 
-func customFieldTypesMatch(first *models.CustomFieldType, second *models.CustomFieldType) error {
+func customFieldTypesMatch(first *importerModels.CustomFieldType, second *importerModels.CustomFieldType) error {
 	if first == nil && second == nil {
 		return nil
 	}

--- a/tools/importer-rest-api-specs/components/parser/load_and_parse.go
+++ b/tools/importer-rest-api-specs/components/parser/load_and_parse.go
@@ -10,15 +10,15 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/dataworkarounds"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVersion string, resourceProvider *string, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVersion string, resourceProvider *string, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
 	// Some Services have been deprecated or should otherwise be ignored - check before proceeding
 	if serviceShouldBeIgnored(serviceName) {
 		logger.Debug(fmt.Sprintf("Service %q should be ignored - skipping", serviceName))
 
-		return &models.AzureApiDefinition{}, nil
+		return &importerModels.AzureApiDefinition{}, nil
 	}
 
 	// First go through and parse all of the Resource ID's across all of the files
@@ -43,7 +43,7 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 		}
 	}
 
-	parsed := make(map[string]models.AzureApiDefinition, 0)
+	parsed := make(map[string]importerModels.AzureApiDefinition, 0)
 	for _, file := range fileNames {
 		swaggerFile := file2Swagger[file]
 
@@ -52,7 +52,7 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 			return nil, fmt.Errorf("parsing definition: %+v", err)
 		}
 
-		data := models.AzureApiDefinition{
+		data := importerModels.AzureApiDefinition{
 			ServiceName: definition.ServiceName,
 			ApiVersion:  definition.ApiVersion,
 			Resources:   definition.Resources,
@@ -73,7 +73,7 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 		parsed[key] = data
 	}
 
-	out := make([]models.AzureApiDefinition, 0)
+	out := make([]importerModels.AzureApiDefinition, 0)
 	for _, v := range parsed {
 		// the Data API expects that an API Version will contain at least 1 Resource - avoid bad data here
 		if len(v.Resources) == 0 {
@@ -120,6 +120,6 @@ func serviceShouldBeIgnored(name string) bool {
 	return false
 }
 
-func keyForAzureApiDefinition(input models.AzureApiDefinition) string {
+func keyForAzureApiDefinition(input importerModels.AzureApiDefinition) string {
 	return fmt.Sprintf("%s-%s", input.ServiceName, input.ApiVersion)
 }

--- a/tools/importer-rest-api-specs/components/parser/models_commonschema_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_commonschema_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 // TODO: Edge Zones
@@ -22,38 +22,38 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedList(t *test
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeLegacySystemAndUserAssignedIdentityList),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeLegacySystemAndUserAssignedIdentityList),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -70,38 +70,38 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap(t *testi
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -120,38 +120,38 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap_ExtraFie
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -168,38 +168,38 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap_GenericD
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeLegacySystemAndUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -216,38 +216,38 @@ func TestParseModel_CommonSchema_IdentitySystemAssigned(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeSystemAssignedIdentity),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeSystemAssignedIdentity),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -264,38 +264,38 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedList(t *testing.T)
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeSystemAndUserAssignedIdentityList),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeSystemAndUserAssignedIdentityList),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -312,38 +312,38 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedMap(t *testing.T) 
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeSystemAndUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeSystemAndUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -362,38 +362,38 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedMap_ExtraFields(t 
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeSystemAndUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeSystemAndUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -410,38 +410,38 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedList(t *testing.T) 
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeSystemOrUserAssignedIdentityList),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeSystemOrUserAssignedIdentityList),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -458,38 +458,38 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeSystemOrUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeSystemOrUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -508,38 +508,38 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap_DelegatedResour
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeSystemOrUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeSystemOrUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -558,38 +558,38 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap_ExtraFields(t *
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeSystemOrUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeSystemOrUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -606,38 +606,38 @@ func TestParseModel_CommonSchema_IdentityUserAssignedList(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeUserAssignedIdentityList),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeUserAssignedIdentityList),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -654,38 +654,38 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -702,38 +702,38 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap_PrincipalID(t *testing.
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -750,38 +750,38 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap_TenantID(t *testing.T) 
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Identity": {
 								JsonName:        "identity",
-								CustomFieldType: pointer.To(models.CustomFieldTypeUserAssignedIdentityMap),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeUserAssignedIdentityMap),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -798,38 +798,38 @@ func TestParseModel_CommonSchema_Location(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Resource": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Location": {
 								JsonName:        "location",
-								CustomFieldType: pointer.To(models.CustomFieldTypeLocation),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeLocation),
 								Required:        false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Resource_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},

--- a/tools/importer-rest-api-specs/components/parser/models_dictionaries_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_dictionaries_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 func TestParseModelWithADictionaryOfIntegers(t *testing.T) {
@@ -16,27 +16,27 @@ func TestParseModelWithADictionaryOfIntegers(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Hello": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionDictionary,
-									NestedItem: &models.ObjectDefinition{
-										Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionDictionary,
+									NestedItem: &importerModels.ObjectDefinition{
+										Type: importerModels.ObjectDefinitionInteger,
 									},
 								},
 								Required: false,
@@ -44,15 +44,15 @@ func TestParseModelWithADictionaryOfIntegers(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Hello_GetWorld",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/things"),
 					},
@@ -69,27 +69,27 @@ func TestParseModelWithADictionaryOfIntegersInlined(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Hello": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionDictionary,
-									NestedItem: &models.ObjectDefinition{
-										Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionDictionary,
+									NestedItem: &importerModels.ObjectDefinition{
+										Type: importerModels.ObjectDefinitionInteger,
 									},
 								},
 								Required: false,
@@ -97,15 +97,15 @@ func TestParseModelWithADictionaryOfIntegersInlined(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Hello_GetWorld",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/things"),
 					},
@@ -122,76 +122,76 @@ func TestParseModelWithADictionaryOfAnObject(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Hello": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("MapFieldProperties"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionDictionary,
+									Type: importerModels.ObjectDefinitionDictionary,
 								},
 								Required: false,
 							},
 						},
 					},
 					"MapFieldProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Line1": {
 								JsonName: "line1",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Line2": {
 								JsonName: "line2",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"City": {
 								JsonName: "city",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Hello_GetWorld",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/things"),
 					},
@@ -208,76 +208,76 @@ func TestParseModelWithADictionaryOfAnObjectInlined(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Hello": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("MapFieldProperties"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionDictionary,
+									Type: importerModels.ObjectDefinitionDictionary,
 								},
 								Required: false,
 							},
 						},
 					},
 					"MapFieldProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Line1": {
 								JsonName: "line1",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Line2": {
 								JsonName: "line2",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"City": {
 								JsonName: "city",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Hello_GetWorld",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/things"),
 					},
@@ -294,27 +294,27 @@ func TestParseModelWithADictionaryOfString(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Hello": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionDictionary,
-									NestedItem: &models.ObjectDefinition{
-										Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionDictionary,
+									NestedItem: &importerModels.ObjectDefinition{
+										Type: importerModels.ObjectDefinitionString,
 									},
 								},
 								Required: false,
@@ -322,15 +322,15 @@ func TestParseModelWithADictionaryOfString(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Hello_GetWorld",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/things"),
 					},
@@ -347,27 +347,27 @@ func TestParseModelWithADictionaryOfStringInlined(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Hello": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionDictionary,
-									NestedItem: &models.ObjectDefinition{
-										Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionDictionary,
+									NestedItem: &importerModels.ObjectDefinition{
+										Type: importerModels.ObjectDefinitionString,
 									},
 								},
 								Required: false,
@@ -375,15 +375,15 @@ func TestParseModelWithADictionaryOfStringInlined(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Hello_GetWorld",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/things"),
 					},

--- a/tools/importer-rest-api-specs/components/parser/models_discriminators_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_discriminators_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 func TestParseDiscriminatorsTopLevel(t *testing.T) {
@@ -16,30 +16,30 @@ func TestParseDiscriminatorsTopLevel(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("Animal"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: true,
 							},
 						},
 					},
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -50,18 +50,18 @@ func TestParseDiscriminatorsTopLevel(t *testing.T) {
 						ParentTypeName: pointer.To("Animal"),
 						TypeHintIn:     pointer.To("AnimalType"),
 						TypeHintValue:  pointer.To("cat"),
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -71,33 +71,33 @@ func TestParseDiscriminatorsTopLevel(t *testing.T) {
 						ParentTypeName: pointer.To("Animal"),
 						TypeHintIn:     pointer.To("AnimalType"),
 						TypeHintValue:  pointer.To("dog"),
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -114,33 +114,33 @@ func TestParseDiscriminatorsWithinArray(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"BiologicalEntities": {
 								JsonName: "biologicalEntities",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("BiologicalEntity"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: true,
 							},
 						},
 					},
 					"BiologicalEntity": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -151,18 +151,18 @@ func TestParseDiscriminatorsWithinArray(t *testing.T) {
 						ParentTypeName: pointer.To("BiologicalEntity"),
 						TypeHintIn:     pointer.To("TypeName"),
 						TypeHintValue:  pointer.To("cat"),
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -172,40 +172,40 @@ func TestParseDiscriminatorsWithinArray(t *testing.T) {
 						ParentTypeName: pointer.To("BiologicalEntity"),
 						TypeHintIn:     pointer.To("TypeName"),
 						TypeHintValue:  pointer.To("human"),
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -222,26 +222,26 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"FavouriteToy": {
 								JsonName: "favouriteToy",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("Toy"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
@@ -249,18 +249,18 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						TypeHintIn: pointer.To("AnimalType"),
 					},
 					"Bone": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Length": {
 								JsonName: "length",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionFloat,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionFloat,
 								},
 								Required: true,
 							},
 							"ToyType": {
 								JsonName: "toyType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -273,26 +273,26 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						ParentTypeName: pointer.To("Animal"),
 						TypeHintIn:     pointer.To("AnimalType"),
 						TypeHintValue:  pointer.To("cat"),
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"FavouriteToy": {
 								JsonName: "favouriteToy",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("Toy"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -302,63 +302,63 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						ParentTypeName: pointer.To("Animal"),
 						TypeHintIn:     pointer.To("AnimalType"),
 						TypeHintValue:  pointer.To("dog"),
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"FavouriteToy": {
 								JsonName: "favouriteToy",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("Toy"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 						},
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("Animal"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: true,
 							},
 						},
 					},
 					"LaserBeam": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Colour": {
 								JsonName: "colour",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Intensity": {
 								JsonName: "intensity",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: false,
 							},
 							"ToyType": {
 								JsonName: "toyType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -368,11 +368,11 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						TypeHintValue:  pointer.To("laser-beam"),
 					},
 					"Toy": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"ToyType": {
 								JsonName: "toyType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -380,15 +380,15 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						TypeHintIn: pointer.To("ToyType"),
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -408,33 +408,33 @@ func TestParseDiscriminatedParentTypeThatShouldntBe(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Animal"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -454,33 +454,33 @@ func TestParseDiscriminatedChildTypeThatShouldntBe(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Dog": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Dog"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -500,18 +500,18 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -519,18 +519,18 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 						TypeHintIn: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -540,18 +540,18 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 						TypeHintValue:  pointer.To("cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -561,27 +561,27 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 						TypeHintValue:  pointer.To("dog"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("Dog"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -598,18 +598,18 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -617,18 +617,18 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 						TypeHintIn: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -638,25 +638,25 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 						TypeHintValue:  pointer.To("cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -666,27 +666,27 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 						TypeHintValue:  pointer.To("dog"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("Animal"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -703,25 +703,25 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"IsPlantEater": {
 								JsonName: "isPlantEater",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -731,11 +731,11 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						TypeHintValue:  pointer.To("animal"),
 					},
 					"BiologicalEntity": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -743,25 +743,25 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						TypeHintIn: pointer.To("TypeName"),
 					},
 					"Carnivore": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"IsPlantEater": {
 								JsonName: "isPlantEater",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"IsPredator": {
 								JsonName: "isPredator",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -771,32 +771,32 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						TypeHintValue:  pointer.To("carnivore"),
 					},
 					"Cat": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"IsPlantEater": {
 								JsonName: "isPlantEater",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: false,
 							},
 							"IsPredator": {
 								JsonName: "isPredator",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -806,12 +806,12 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						TypeHintValue:  pointer.To("cat"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"BiologicalEntity": {
 								JsonName: "biologicalEntity",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("BiologicalEntity"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: true,
 							},
@@ -821,54 +821,54 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						ParentTypeName: pointer.To("BiologicalEntity"),
 						TypeHintIn:     pointer.To("TypeName"),
 						TypeHintValue:  pointer.To("persian-cat"),
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"IsFriendly": {
 								JsonName: "isFriendly",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"IsPlantEater": {
 								JsonName: "isPlantEater",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: false,
 							},
 							"IsPredator": {
 								JsonName: "isPredator",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -887,25 +887,25 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"BiologicalEntity": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -913,39 +913,39 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 						TypeHintIn: pointer.To("TypeName"),
 					},
 					"Cat": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -955,51 +955,51 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 						TypeHintValue:  pointer.To("cat"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Item": {
 								JsonName: "item",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("BiologicalEntity"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: true,
 							},
 						},
 					},
 					"Human": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: true,
 							},
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -1012,15 +1012,15 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 					// it's just an abstract type (defining the shared fields for Car and Human), rather than
 					// being directly used.
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1039,25 +1039,25 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Discriminator": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"BiologicalEntity": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -1065,39 +1065,39 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 						TypeHintIn: pointer.To("TypeName"),
 					},
 					"Cat": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -1107,54 +1107,54 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 						TypeHintValue:  pointer.To("cat"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Items": {
 								JsonName: "items",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("BiologicalEntity"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: true,
 							},
 						},
 					},
 					"Human": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: true,
 							},
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -1167,15 +1167,15 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 					// it's just an abstract type (defining the shared fields for Car and Human), rather than
 					// being directly used.
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Discriminator_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1192,21 +1192,21 @@ func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			// NOTE: since there's no Operations defined the Models are placed into an APIResource based on the
 			// File Name. Whilst in a normal scenario this would make sense - for testing purposes it leads to
 			// some unexpectedly named data, but this is fine providing the APIResource we're expecting exists.
 			"ModelDiscriminatorsOrphanedChildren": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -1214,18 +1214,18 @@ func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
 						TypeHintIn: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -1235,18 +1235,18 @@ func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
 						TypeHintValue:  pointer.To("cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -1269,21 +1269,21 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			// NOTE: since there's no Operations defined the Models are placed into an APIResource based on the
 			// File Name. Whilst in a normal scenario this would make sense - for testing purposes it leads to
 			// some unexpectedly named data, but this is fine providing the APIResource we're expecting exists.
 			"ModelDiscriminatorsOrphanedChildWithNestedModels": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
@@ -1291,18 +1291,18 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 						TypeHintIn: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
@@ -1312,29 +1312,29 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 						TypeHintValue:  pointer.To("cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"Parameters": {
 								JsonName: "parameters",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("KeyValuePair"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
@@ -1345,18 +1345,18 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 					},
 					// ExampleWrapper is present in the Swagger but unused
 					"KeyValuePair": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Key": {
 								JsonName: "key",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Value": {
 								JsonName: "value",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -19,70 +19,70 @@ func TestParseModelTopLevel(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: false,
 							},
 							"Height": {
 								JsonName: "height",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionFloat,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionFloat,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Tags": {
-								CustomFieldType: pointer.To(models.CustomFieldTypeTags),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeTags),
 								JsonName:        "tags",
 								Required:        false,
 							},
 							"Value": {
 								JsonName: "value",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionRawObject,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionRawObject,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -99,22 +99,22 @@ func TestParseModelTopLevelWithRawFile(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
-							Type: models.ObjectDefinitionRawFile,
+						RequestObject: &importerModels.ObjectDefinition{
+							Type: importerModels.ObjectDefinitionRawFile,
 						},
-						ResponseObject: &models.ObjectDefinition{
-							Type: models.ObjectDefinitionRawFile,
+						ResponseObject: &importerModels.ObjectDefinition{
+							Type: importerModels.ObjectDefinitionRawFile,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -131,89 +131,89 @@ func TestParseModelTopLevelWithInlinedModel(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Properties": {
 								JsonName: "properties",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("ModelProperties"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ModelProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: false,
 							},
 							"Height": {
 								JsonName: "height",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionFloat,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionFloat,
 								},
 								Required: false,
 							},
 							"Nickname": {
 								JsonName: "nickname",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Tags": {
-								CustomFieldType: pointer.To(models.CustomFieldTypeTags),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeTags),
 								JsonName:        "tags",
 								Required:        false,
 							},
 							"Value": {
 								JsonName: "value",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionRawObject,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionRawObject,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -230,37 +230,37 @@ func TestParseModelWithDateTimeNoType(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"SomeDateValue": {
 								JsonName: "someDateValue",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionDateTime,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionDateTime,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -277,70 +277,70 @@ func TestParseModelWithInlinedObject(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"ThingProps": {
 								JsonName: "thingProps",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("ThingProperties"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ThingProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"KeyName": {
 								JsonName: "keyName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"UserAssignedIdentities": {
 								JsonName: "userAssignedIdentities",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("UserAssignedIdentitiesProperties"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionDictionary,
+									Type: importerModels.ObjectDefinitionDictionary,
 								},
 								Required: false,
 							},
 						},
 					},
 					"UserAssignedIdentitiesProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"ClientId": {
 								JsonName: "clientId",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								ReadOnly: true,
 								Required: false,
 							},
 							"PrincipalId": {
 								JsonName: "principalId",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								ReadOnly: true,
 								Required: false,
@@ -348,15 +348,15 @@ func TestParseModelWithInlinedObject(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -373,40 +373,40 @@ func TestParseModelWithNumberPrefixedField(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Five0PercentDone": {
 								JsonName: "50PercentDone",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -423,74 +423,74 @@ func TestParseModelWithReference(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"ThingProps": {
 								JsonName: "thingProps",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("ThingProperties"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ThingProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"KeyName": {
 								JsonName: "keyName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("UserAssignedIdentityProperties"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 					"UserAssignedIdentityProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"UserAssignedIdentity": {
 								JsonName: "userAssignedIdentity",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -507,60 +507,60 @@ func TestParseModelWithReferenceToArray(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Pets": {
 								JsonName: "pets",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("Pet"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 
 										// note: these change substantially in the sdk swap
 										Minimum:     pointer.To(1),
 										Maximum:     pointer.To(2),
 										UniqueItems: pointer.To(true),
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 						},
 					},
 					"Pet": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -577,10 +577,10 @@ func TestParseModelWithReferenceToConstant(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"AnimalType": {
@@ -591,58 +591,58 @@ func TestParseModelWithReferenceToConstant(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"ThingProps": {
 								JsonName: "thingProps",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("ThingProperties"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ThingProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Animal": {
 								JsonName: "animal",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"KeyName": {
 								JsonName: "keyName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -659,62 +659,62 @@ func TestParseModelWithReferenceToString(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"ThingProps": {
 								JsonName: "thingProps",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("ThingProperties"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ThingProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FullyQualifiedDomainName": {
 								JsonName: "fullyQualifiedDomainName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"KeyName": {
 								JsonName: "keyName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -731,93 +731,93 @@ func TestParseModelWithCircularReferences(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"FavouriteHouse": {
 								JsonName: "favouriteHouse",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("House"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"FavouriteHuman": {
 								JsonName: "favouriteHuman",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("Human"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 					"House": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Address": {
 								JsonName: "address",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Residents": {
 								JsonName: "residents",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("Human"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 						},
 					},
 					"Human": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Pets": {
 								JsonName: "pets",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("Animal"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("House"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -834,35 +834,35 @@ func TestParseModelInheritingFromObjectWithNoExtraFields(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"FirstObject": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							// whilst the response model references SecondObject, it's only inheriting from FirstObject
 							// and doesn't contain any new fields, so it should be switched out
 							ReferenceName: pointer.To("FirstObject"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -879,52 +879,52 @@ func TestParseModelInheritingFromObjectWithNoExtraFieldsInlined(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"FirstObject": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Endpoints": {
 								JsonName: "endpoints",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("SecondObject"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 					"SecondObject": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("FirstObject"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -941,35 +941,35 @@ func TestParseModelInheritingFromObjectWithOnlyDescription(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"FirstObject": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							// whilst the response model references SecondObject, it's only inheriting from FirstObject
 							// and doesn't contain any new fields, so it should be switched out
 							ReferenceName: pointer.To("FirstObject"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -991,36 +991,36 @@ func TestParseModelInheritingFromObjectWithPropertiesWithinAllOf(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"SecondObject": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							// SecondObject is referenced as the Response Object, but because it inherits from one Model
 							// (FirstObject) and uses another (ThirdObject) it shouldn't be flattened into the parent type(s)
 							// and should instead remain `SecondObject`.
 							ReferenceName: pointer.To("SecondObject"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1037,44 +1037,44 @@ func TestParseModelContainingAllOfToTypeObject(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1091,44 +1091,44 @@ func TestParseModelContainingAllOfToTypeObjectWithProperties(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1145,70 +1145,70 @@ func TestParseModelContainingAllOfWithinProperties(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Properties": {
 								JsonName: "properties",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("ModelProperties"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ModelProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"MoreNested": {
 								JsonName: "moreNested",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1225,82 +1225,82 @@ func TestParseModelContainingMultipleAllOfWithinProperties(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Options": {
 								JsonName: "options",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("ResourceWithLocation"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"Resource": {
 								JsonName: "resource",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("ModelResource"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ModelResource": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"MoreNested": {
 								JsonName: "moreNested",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ResourceWithLocation": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1317,77 +1317,77 @@ func TestParseModelContainingLists(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Animals": {
 								JsonName: "animals",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("Animal"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Plants": {
 								JsonName: "plants",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
-										Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
+										Type: importerModels.ObjectDefinitionString,
 
 										// NOTE: these change substantially in the new SDK
 										Maximum:     pointer.To(10),
 										Minimum:     pointer.To(1),
 										UniqueItems: pointer.To(true),
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 						},
 					},
 					"Animal": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1404,48 +1404,48 @@ func TestParseModelInlinedWithNoName(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Container": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Planets": {
 								JsonName: "planets",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("ContainerPlanetsInlined"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionList,
+									Type: importerModels.ObjectDefinitionList,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ContainerPlanetsInlined": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"ExampleField": {
 								JsonName: "exampleField",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Test",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Container"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1462,63 +1462,63 @@ func TestParseModelInheritingFromParent(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Model": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: true,
 							},
 							"Height": {
 								JsonName: "height",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionFloat,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionFloat,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Tags": {
 								JsonName:        "tags",
-								CustomFieldType: pointer.To(models.CustomFieldTypeTags),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeTags),
 								Required:        true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Test",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1535,82 +1535,82 @@ func TestParseModelMultipleTopLevelModelsAndOperations(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"GetExample": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Tags": {
 								JsonName:        "tags",
-								CustomFieldType: pointer.To(models.CustomFieldTypeTags),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeTags),
 								Required:        false,
 							},
 						},
 					},
 					"PutExample": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionInteger,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionInteger,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionBoolean,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionBoolean,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: true,
 							},
 							"Tags": {
 								JsonName:        "tags",
-								CustomFieldType: pointer.To(models.CustomFieldTypeTags),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeTags),
 								Required:        false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Get": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						OperationId:         "Example_Get",
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("GetExample"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1619,13 +1619,13 @@ func TestParseModelMultipleTopLevelModelsAndOperations(t *testing.T) {
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_Put",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("PutExample"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("PutExample"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/example"),
 					},
@@ -1642,26 +1642,26 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"EnvironmentRole": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Description": {
 								JsonName: "description",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								ReadOnly: true,
 								Required: false,
 							},
 							"RoleName": {
 								JsonName: "roleName",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								ReadOnly: true,
 								Required: false,
@@ -1669,154 +1669,154 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 						},
 					},
 					"ExampleEnvironment": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Location": {
 								JsonName:        "location",
-								CustomFieldType: pointer.To(models.CustomFieldTypeLocation),
+								CustomFieldType: pointer.To(importerModels.CustomFieldTypeLocation),
 								Required:        false,
 							},
 							"Properties": {
 								JsonName: "properties",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("ExampleEnvironmentProperties"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ExampleEnvironmentProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"CreatorRoleAssignment": {
 								JsonName: "creatorRoleAssignment",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("ExampleEnvironmentUpdatePropertiesCreatorRoleAssignment"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"DeploymentTargetId": {
 								JsonName: "deploymentTargetId",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"ProvisioningState": {
 								JsonName: "provisioningState",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								ReadOnly: true,
 								Required: false,
 							},
 							"UserRoleAssignments": {
 								JsonName: "userRoleAssignments",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("UserRoleAssignment"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionDictionary,
+									Type: importerModels.ObjectDefinitionDictionary,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ExampleEnvironmentUpdate": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Example": {
 								JsonName: "example",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"Properties": {
 								JsonName: "properties",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("ExampleEnvironmentUpdateProperties"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ExampleEnvironmentUpdateProperties": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"CreatorRoleAssignment": {
 								JsonName: "creatorRoleAssignment",
-								ObjectDefinition: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
 									ReferenceName: pointer.To("ExampleEnvironmentUpdatePropertiesCreatorRoleAssignment"),
-									Type:          models.ObjectDefinitionReference,
+									Type:          importerModels.ObjectDefinitionReference,
 								},
 								Required: false,
 							},
 							"DeploymentTargetId": {
 								JsonName: "deploymentTargetId",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 							"UserRoleAssignments": {
 								JsonName: "userRoleAssignments",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("UserRoleAssignment"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionDictionary,
+									Type: importerModels.ObjectDefinitionDictionary,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ExampleEnvironmentUpdatePropertiesCreatorRoleAssignment": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Roles": {
 								JsonName: "roles",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("EnvironmentRole"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionDictionary,
+									Type: importerModels.ObjectDefinitionDictionary,
 								},
 								Required: false,
 							},
 						},
 					},
 					"UserRoleAssignment": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Roles": {
 								JsonName: "roles",
-								ObjectDefinition: &models.ObjectDefinition{
-									NestedItem: &models.ObjectDefinition{
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									NestedItem: &importerModels.ObjectDefinition{
 										ReferenceName: pointer.To("EnvironmentRole"),
-										Type:          models.ObjectDefinitionReference,
+										Type:          importerModels.ObjectDefinitionReference,
 									},
-									Type: models.ObjectDefinitionDictionary,
+									Type: importerModels.ObjectDefinitionDictionary,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"CreateOrUpdate": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Example_CreateOrUpdate",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironment"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						ResourceIdName: pointer.To("EnvironmentId"),
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironment"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 					},
 					"Get": {
@@ -1825,9 +1825,9 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 						Method:              "GET",
 						OperationId:         "Example_Get",
 						ResourceIdName:      pointer.To("EnvironmentId"),
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironment"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 					},
 					"Update": {
@@ -1835,18 +1835,18 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 						ExpectedStatusCodes: []int{200},
 						Method:              "PATCH",
 						OperationId:         "Example_Update",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironmentUpdate"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						ResourceIdName: pointer.To("EnvironmentId"),
-						ResponseObject: &models.ObjectDefinition{
+						ResponseObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironment"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 					},
 				},
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"EnvironmentId": {
 						Segments: []resourcemanager.ResourceIdSegment{
 							NewStaticValueResourceIDSegment("staticEnvironments", "environments"),

--- a/tools/importer-rest-api-specs/components/parser/parse_data.go
+++ b/tools/importer-rest-api-specs/components/parser/parse_data.go
@@ -6,12 +6,12 @@ package parser
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func combineResourcesWith(first models.AzureApiDefinition, other map[string]models.AzureApiResource) (*map[string]models.AzureApiResource, error) {
-	resources := make(map[string]models.AzureApiResource)
+func combineResourcesWith(first importerModels.AzureApiDefinition, other map[string]importerModels.AzureApiResource) (*map[string]importerModels.AzureApiResource, error) {
+	resources := make(map[string]importerModels.AzureApiResource)
 	for k, v := range first.Resources {
 		resources[k] = v
 	}
@@ -81,8 +81,8 @@ func combineConstants(first map[string]resourcemanager.ConstantDetails, second m
 	return &constants, nil
 }
 
-func combineModels(first map[string]models.ModelDetails, second map[string]models.ModelDetails) (*map[string]models.ModelDetails, error) {
-	output := make(map[string]models.ModelDetails)
+func combineModels(first map[string]importerModels.ModelDetails, second map[string]importerModels.ModelDetails) (*map[string]importerModels.ModelDetails, error) {
+	output := make(map[string]importerModels.ModelDetails)
 
 	for k, v := range first {
 		output[k] = v
@@ -118,8 +118,8 @@ func combineModels(first map[string]models.ModelDetails, second map[string]model
 	return &output, nil
 }
 
-func combineOperations(first map[string]models.OperationDetails, second map[string]models.OperationDetails) (*map[string]models.OperationDetails, error) {
-	output := make(map[string]models.OperationDetails, 0)
+func combineOperations(first map[string]importerModels.OperationDetails, second map[string]importerModels.OperationDetails) (*map[string]importerModels.OperationDetails, error) {
+	output := make(map[string]importerModels.OperationDetails, 0)
 
 	for k, v := range first {
 		output[k] = v
@@ -138,8 +138,8 @@ func combineOperations(first map[string]models.OperationDetails, second map[stri
 	return &output, nil
 }
 
-func combineResourceIds(first map[string]models.ParsedResourceId, second map[string]models.ParsedResourceId) (*map[string]models.ParsedResourceId, error) {
-	output := make(map[string]models.ParsedResourceId, 0)
+func combineResourceIds(first map[string]importerModels.ParsedResourceId, second map[string]importerModels.ParsedResourceId) (*map[string]importerModels.ParsedResourceId, error) {
+	output := make(map[string]importerModels.ParsedResourceId, 0)
 
 	for k, v := range first {
 		output[k] = v

--- a/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -17,12 +17,12 @@ func TestParseResourceIdBasic(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ServerId": {
 						Segments: []resourcemanager.ResourceIdSegment{
 							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
@@ -36,7 +36,7 @@ func TestParseResourceIdBasic(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -57,10 +57,10 @@ func TestParseResourceIdContainingAConstant(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
 				Constants: map[string]resourcemanager.ConstantDetails{
 					"Planet": {
@@ -73,7 +73,7 @@ func TestParseResourceIdContainingAConstant(t *testing.T) {
 						},
 					},
 				},
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"PlanetId": {
 						Constants: map[string]resourcemanager.ConstantDetails{
 							"Planet": {
@@ -92,7 +92,7 @@ func TestParseResourceIdContainingAConstant(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"OperationContainingAConstant": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -113,12 +113,12 @@ func TestParseResourceIdContainingAScope(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ScopedVirtualMachineId": {
 						Segments: []resourcemanager.ResourceIdSegment{
 							NewScopeResourceIDSegment("scope"),
@@ -129,7 +129,7 @@ func TestParseResourceIdContainingAScope(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"OperationContainingAScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -159,12 +159,12 @@ func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
 				t.Fatalf("parsing: %+v", err)
 			}
 
-			expected := models.AzureApiDefinition{
+			expected := importerModels.AzureApiDefinition{
 				ServiceName: "Example",
 				ApiVersion:  "2020-01-01",
-				Resources: map[string]models.AzureApiResource{
+				Resources: map[string]importerModels.AzureApiResource{
 					"Example": {
-						ResourceIds: map[string]models.ParsedResourceId{
+						ResourceIds: map[string]importerModels.ParsedResourceId{
 							"ScopeId": {
 								CommonAlias: pointer.To("Scope"),
 								Segments: []resourcemanager.ResourceIdSegment{
@@ -172,7 +172,7 @@ func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
 								},
 							},
 						},
-						Operations: map[string]models.OperationDetails{
+						Operations: map[string]importerModels.OperationDetails{
 							"OperationContainingAHiddenScope": {
 								ContentType:         "application/json",
 								ExpectedStatusCodes: []int{200},
@@ -196,12 +196,12 @@ func TestParseResourceIdContainingAHiddenScopeWithExtraSegment(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ScopeId": {
 						CommonAlias: pointer.To("Scope"),
 						Segments: []resourcemanager.ResourceIdSegment{
@@ -209,7 +209,7 @@ func TestParseResourceIdContainingAHiddenScopeWithExtraSegment(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"OperationContainingAHiddenScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -230,12 +230,12 @@ func TestParseResourceIdContainingAHiddenScopeWithSuffix(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ScopeId": {
 						CommonAlias: pointer.To("Scope"),
 						Segments: []resourcemanager.ResourceIdSegment{
@@ -243,7 +243,7 @@ func TestParseResourceIdContainingAHiddenScopeWithSuffix(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"OperationContainingAHiddenScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -274,12 +274,12 @@ func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
 				t.Fatalf("parsing: %+v", err)
 			}
 
-			expected := models.AzureApiDefinition{
+			expected := importerModels.AzureApiDefinition{
 				ServiceName: "Example",
 				ApiVersion:  "2020-01-01",
-				Resources: map[string]models.AzureApiResource{
+				Resources: map[string]importerModels.AzureApiResource{
 					"Example": {
-						ResourceIds: map[string]models.ParsedResourceId{
+						ResourceIds: map[string]importerModels.ParsedResourceId{
 							"ScopeId": {
 								CommonAlias: pointer.To("Scope"),
 								Segments: []resourcemanager.ResourceIdSegment{
@@ -287,7 +287,7 @@ func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
 								},
 							},
 						},
-						Operations: map[string]models.OperationDetails{
+						Operations: map[string]importerModels.OperationDetails{
 							"OperationContainingAHiddenScope": {
 								ContentType:         "application/json",
 								ExpectedStatusCodes: []int{200},
@@ -310,12 +310,12 @@ func TestParseResourceIdContainingAHiddenScopeNestedWithExtraSegment(t *testing.
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ScopeId": {
 						CommonAlias: pointer.To("Scope"),
 						Segments: []resourcemanager.ResourceIdSegment{
@@ -323,7 +323,7 @@ func TestParseResourceIdContainingAHiddenScopeNestedWithExtraSegment(t *testing.
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"OperationContainingAHiddenScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -344,12 +344,12 @@ func TestParseResourceIdContainingAHiddenScopeNestedWithSuffix(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ScopeId": {
 						CommonAlias: pointer.To("Scope"),
 						Segments: []resourcemanager.ResourceIdSegment{
@@ -357,7 +357,7 @@ func TestParseResourceIdContainingAHiddenScopeNestedWithSuffix(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"OperationContainingAHiddenScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -379,12 +379,12 @@ func TestParseResourceIdWithJustUriSuffix(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"JustSuffix": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -405,12 +405,12 @@ func TestParseResourceIdWithResourceIdAndUriSuffix(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ServerId": {
 						Segments: []resourcemanager.ResourceIdSegment{
 							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
@@ -424,7 +424,7 @@ func TestParseResourceIdWithResourceIdAndUriSuffix(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -446,12 +446,12 @@ func TestParseResourceIdWithResourceIdAndUriSuffixForMultipleUris(t *testing.T) 
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ServerId": {
 						Segments: []resourcemanager.ResourceIdSegment{
 							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
@@ -465,7 +465,7 @@ func TestParseResourceIdWithResourceIdAndUriSuffixForMultipleUris(t *testing.T) 
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Restart": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -502,12 +502,12 @@ func TestParseResourceIdContainingResourceProviderShouldGetTitleCased(t *testing
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ServerId": {
 						Segments: []resourcemanager.ResourceIdSegment{
 							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
@@ -521,7 +521,7 @@ func TestParseResourceIdContainingResourceProviderShouldGetTitleCased(t *testing
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -542,12 +542,12 @@ func TestParseResourceIdContainingTheSameResourceIdWithDifferentSegments(t *test
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"VirtualMachineId": {
 						Segments: []resourcemanager.ResourceIdSegment{
 							NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
@@ -561,7 +561,7 @@ func TestParseResourceIdContainingTheSameResourceIdWithDifferentSegments(t *test
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Restart": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -590,12 +590,12 @@ func TestParseResourceIdContainingTheSegmentsNamedTheSame(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"BillingPeriodId": {
 						Segments: []resourcemanager.ResourceIdSegment{
 							NewStaticValueResourceIDSegment("staticProviders", "providers"),
@@ -609,7 +609,7 @@ func TestParseResourceIdContainingTheSegmentsNamedTheSame(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -644,10 +644,10 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 			t.Fatalf("parsing: %+v", err)
 		}
 
-		expected := models.AzureApiDefinition{
+		expected := importerModels.AzureApiDefinition{
 			ServiceName: "Example",
 			ApiVersion:  "2020-01-01",
-			Resources: map[string]models.AzureApiResource{
+			Resources: map[string]importerModels.AzureApiResource{
 				"Hello": {
 					Constants: map[string]resourcemanager.ConstantDetails{
 						"PlanetNames": {
@@ -658,7 +658,7 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 							},
 						},
 					},
-					ResourceIds: map[string]models.ParsedResourceId{
+					ResourceIds: map[string]importerModels.ParsedResourceId{
 						"GalaxyId": {
 							Segments: []resourcemanager.ResourceIdSegment{
 								NewStaticValueResourceIDSegment("staticGalaxies", "galaxies"),
@@ -683,7 +683,7 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 							},
 						},
 					},
-					Operations: map[string]models.OperationDetails{
+					Operations: map[string]importerModels.OperationDetails{
 						"Delete": {
 							ContentType:         "application/json",
 							ExpectedStatusCodes: []int{200},
@@ -713,12 +713,12 @@ func TestParseResourceIdsCommon(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				ResourceIds: map[string]models.ParsedResourceId{
+				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"ManagementGroupId": {
 						CommonAlias: pointer.To("ManagementGroup"),
 						Segments: []resourcemanager.ResourceIdSegment{
@@ -764,7 +764,7 @@ func TestParseResourceIdsCommon(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"GetManagementGroup": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdAppService{}
 
 type commonIdAppService struct{}
 
-func (c commonIdAppService) id() models.ParsedResourceId {
+func (c commonIdAppService) id() importerModels.ParsedResourceId {
 	name := "AppService"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
-			models.StaticResourceIDSegment("sites", "sites"),
-			models.UserSpecifiedResourceIDSegment("siteName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			importerModels.StaticResourceIDSegment("sites", "sites"),
+			importerModels.UserSpecifiedResourceIDSegment("siteName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_environment.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_environment.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdAppServiceEnvironment{}
 
 type commonIdAppServiceEnvironment struct{}
 
-func (c commonIdAppServiceEnvironment) id() models.ParsedResourceId {
+func (c commonIdAppServiceEnvironment) id() importerModels.ParsedResourceId {
 	name := "AppServiceEnvironment"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
-			models.StaticResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
-			models.UserSpecifiedResourceIDSegment("hostingEnvironmentName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			importerModels.StaticResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
+			importerModels.UserSpecifiedResourceIDSegment("hostingEnvironmentName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_plan.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_plan.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdAppServicePlan{}
 
 type commonIdAppServicePlan struct{}
 
-func (c commonIdAppServicePlan) id() models.ParsedResourceId {
+func (c commonIdAppServicePlan) id() importerModels.ParsedResourceId {
 	name := "AppServicePlan"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
-			models.StaticResourceIDSegment("serverFarms", "serverFarms"),
-			models.UserSpecifiedResourceIDSegment("serverFarmName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			importerModels.StaticResourceIDSegment("serverFarms", "serverFarms"),
+			importerModels.UserSpecifiedResourceIDSegment("serverFarmName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_automation_compilation_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_automation_compilation_job.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdAutomationCompilationJob{}
 
 type commonIdAutomationCompilationJob struct{}
 
-func (c commonIdAutomationCompilationJob) id() models.ParsedResourceId {
+func (c commonIdAutomationCompilationJob) id() importerModels.ParsedResourceId {
 	name := "AutomationCompilationJob"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Automation"),
-			models.StaticResourceIDSegment("automationAccounts", "automationAccounts"),
-			models.UserSpecifiedResourceIDSegment("automationAccountName"),
-			models.StaticResourceIDSegment("compilationJobs", "compilationJobs"),
-			models.UserSpecifiedResourceIDSegment("compilationJobId"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Automation"),
+			importerModels.StaticResourceIDSegment("automationAccounts", "automationAccounts"),
+			importerModels.UserSpecifiedResourceIDSegment("automationAccountName"),
+			importerModels.StaticResourceIDSegment("compilationJobs", "compilationJobs"),
+			importerModels.UserSpecifiedResourceIDSegment("compilationJobId"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_availability_set.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_availability_set.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdAvailabilitySet{}
 
 type commonIdAvailabilitySet struct{}
 
-func (c commonIdAvailabilitySet) id() models.ParsedResourceId {
+func (c commonIdAvailabilitySet) id() importerModels.ParsedResourceId {
 	name := "AvailabilitySet"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("availabilitySets", "availabilitySets"),
-			models.UserSpecifiedResourceIDSegment("availabilitySetName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("availabilitySets", "availabilitySets"),
+			importerModels.UserSpecifiedResourceIDSegment("availabilitySetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdBotService{}
 
 type commonIdBotService struct{}
 
-func (commonIdBotService) id() models.ParsedResourceId {
+func (commonIdBotService) id() importerModels.ParsedResourceId {
 	name := "BotService"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("staticProviders", "providers"),
-			models.ResourceProviderResourceIDSegment("staticMicrosoftBotService", "Microsoft.BotService"),
-			models.StaticResourceIDSegment("staticBotServices", "botServices"),
-			models.UserSpecifiedResourceIDSegment("botServiceName"),
+			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("staticProviders", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("staticMicrosoftBotService", "Microsoft.BotService"),
+			importerModels.StaticResourceIDSegment("staticBotServices", "botServices"),
+			importerModels.UserSpecifiedResourceIDSegment("botServiceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service_channel.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service_channel.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,9 +12,9 @@ var _ commonIdMatcher = commonIdBotServiceChannel{}
 
 type commonIdBotServiceChannel struct{}
 
-func (commonIdBotServiceChannel) id() models.ParsedResourceId {
+func (commonIdBotServiceChannel) id() importerModels.ParsedResourceId {
 	name := "BotServiceChannel"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants: map[string]resourcemanager.ConstantDetails{
 			"BotServiceChannelType": {
@@ -44,16 +44,16 @@ func (commonIdBotServiceChannel) id() models.ParsedResourceId {
 			},
 		},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("staticProviders", "providers"),
-			models.ResourceProviderResourceIDSegment("staticMicrosoftBotService", "Microsoft.BotService"),
-			models.StaticResourceIDSegment("staticBotServices", "botServices"),
-			models.UserSpecifiedResourceIDSegment("botServiceName"),
-			models.StaticResourceIDSegment("staticChannels", "channels"),
-			models.ConstantResourceIDSegment("channelType", "BotServiceChannelType"),
+			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("staticProviders", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("staticMicrosoftBotService", "Microsoft.BotService"),
+			importerModels.StaticResourceIDSegment("staticBotServices", "botServices"),
+			importerModels.UserSpecifiedResourceIDSegment("botServiceName"),
+			importerModels.StaticResourceIDSegment("staticChannels", "channels"),
+			importerModels.ConstantResourceIDSegment("channelType", "BotServiceChannelType"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_capability.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_capability.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,19 +12,19 @@ var _ commonIdMatcher = commonIdChaosStudioCapability{}
 
 type commonIdChaosStudioCapability struct{}
 
-func (commonIdChaosStudioCapability) id() models.ParsedResourceId {
+func (commonIdChaosStudioCapability) id() importerModels.ParsedResourceId {
 	name := "ChaosStudioCapability"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.ScopeResourceIDSegment("scope"),
-			models.StaticResourceIDSegment("staticProviders", "providers"),
-			models.ResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
-			models.StaticResourceIDSegment("staticTargets", "targets"),
-			models.UserSpecifiedResourceIDSegment("targetName"),
-			models.StaticResourceIDSegment("staticCapabilities", "capabilities"),
-			models.UserSpecifiedResourceIDSegment("capabilityName"),
+			importerModels.ScopeResourceIDSegment("scope"),
+			importerModels.StaticResourceIDSegment("staticProviders", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
+			importerModels.StaticResourceIDSegment("staticTargets", "targets"),
+			importerModels.UserSpecifiedResourceIDSegment("targetName"),
+			importerModels.StaticResourceIDSegment("staticCapabilities", "capabilities"),
+			importerModels.UserSpecifiedResourceIDSegment("capabilityName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_target.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_target.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,17 +12,17 @@ var _ commonIdMatcher = commonIdChaosStudioTarget{}
 
 type commonIdChaosStudioTarget struct{}
 
-func (commonIdChaosStudioTarget) id() models.ParsedResourceId {
+func (commonIdChaosStudioTarget) id() importerModels.ParsedResourceId {
 	name := "ChaosStudioTarget"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.ScopeResourceIDSegment("scope"),
-			models.StaticResourceIDSegment("staticProviders", "providers"),
-			models.ResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
-			models.StaticResourceIDSegment("staticTargets", "targets"),
-			models.UserSpecifiedResourceIDSegment("targetName"),
+			importerModels.ScopeResourceIDSegment("scope"),
+			importerModels.StaticResourceIDSegment("staticProviders", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
+			importerModels.StaticResourceIDSegment("staticTargets", "targets"),
+			importerModels.UserSpecifiedResourceIDSegment("targetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_ip_configuration.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,26 +12,26 @@ var _ commonIdMatcher = commonIdCloudServicesIPConfiguration{}
 
 type commonIdCloudServicesIPConfiguration struct{}
 
-func (c commonIdCloudServicesIPConfiguration) id() models.ParsedResourceId {
+func (c commonIdCloudServicesIPConfiguration) id() importerModels.ParsedResourceId {
 	name := "CloudServicesIPConfiguration"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("cloudServices", "cloudServices"),
-			models.UserSpecifiedResourceIDSegment("cloudServiceName"),
-			models.StaticResourceIDSegment("roleInstances", "roleInstances"),
-			models.UserSpecifiedResourceIDSegment("roleInstanceName"),
-			models.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.UserSpecifiedResourceIDSegment("networkInterfaceName"),
-			models.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.UserSpecifiedResourceIDSegment("ipConfigurationName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("cloudServices", "cloudServices"),
+			importerModels.UserSpecifiedResourceIDSegment("cloudServiceName"),
+			importerModels.StaticResourceIDSegment("roleInstances", "roleInstances"),
+			importerModels.UserSpecifiedResourceIDSegment("roleInstanceName"),
+			importerModels.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			importerModels.UserSpecifiedResourceIDSegment("networkInterfaceName"),
+			importerModels.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			importerModels.UserSpecifiedResourceIDSegment("ipConfigurationName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_public_ip_address.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,28 +12,28 @@ var _ commonIdMatcher = commonIdCloudServicesPublicIPAddress{}
 
 type commonIdCloudServicesPublicIPAddress struct{}
 
-func (c commonIdCloudServicesPublicIPAddress) id() models.ParsedResourceId {
+func (c commonIdCloudServicesPublicIPAddress) id() importerModels.ParsedResourceId {
 	name := "CloudServicesPublicIPAddress"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("cloudServices", "cloudServices"),
-			models.UserSpecifiedResourceIDSegment("cloudServiceName"),
-			models.StaticResourceIDSegment("roleInstances", "roleInstances"),
-			models.UserSpecifiedResourceIDSegment("roleInstanceName"),
-			models.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.UserSpecifiedResourceIDSegment("networkInterfaceName"),
-			models.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.UserSpecifiedResourceIDSegment("ipConfigurationName"),
-			models.StaticResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
-			models.UserSpecifiedResourceIDSegment("publicIPAddressName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("cloudServices", "cloudServices"),
+			importerModels.UserSpecifiedResourceIDSegment("cloudServiceName"),
+			importerModels.StaticResourceIDSegment("roleInstances", "roleInstances"),
+			importerModels.UserSpecifiedResourceIDSegment("roleInstanceName"),
+			importerModels.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			importerModels.UserSpecifiedResourceIDSegment("networkInterfaceName"),
+			importerModels.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			importerModels.UserSpecifiedResourceIDSegment("ipConfigurationName"),
+			importerModels.StaticResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
+			importerModels.UserSpecifiedResourceIDSegment("publicIPAddressName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdDedicatedHost{}
 
 type commonIdDedicatedHost struct{}
 
-func (c commonIdDedicatedHost) id() models.ParsedResourceId {
+func (c commonIdDedicatedHost) id() importerModels.ParsedResourceId {
 	name := "DedicatedHost"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("hostGroups", "hostGroups"),
-			models.UserSpecifiedResourceIDSegment("hostGroupName"),
-			models.StaticResourceIDSegment("hosts", "hosts"),
-			models.UserSpecifiedResourceIDSegment("hostName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("hostGroups", "hostGroups"),
+			importerModels.UserSpecifiedResourceIDSegment("hostGroupName"),
+			importerModels.StaticResourceIDSegment("hosts", "hosts"),
+			importerModels.UserSpecifiedResourceIDSegment("hostName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host_group.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdDedicatedHostGroup{}
 
 type commonIdDedicatedHostGroup struct{}
 
-func (c commonIdDedicatedHostGroup) id() models.ParsedResourceId {
+func (c commonIdDedicatedHostGroup) id() importerModels.ParsedResourceId {
 	name := "DedicatedHostGroup"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("hostGroups", "hostGroups"),
-			models.UserSpecifiedResourceIDSegment("hostGroupName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("hostGroups", "hostGroups"),
+			importerModels.UserSpecifiedResourceIDSegment("hostGroupName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_disk_encryption_set.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_disk_encryption_set.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdDiskEncryptionSet{}
 
 type commonIdDiskEncryptionSet struct{}
 
-func (c commonIdDiskEncryptionSet) id() models.ParsedResourceId {
+func (c commonIdDiskEncryptionSet) id() importerModels.ParsedResourceId {
 	name := "DiskEncryptionSet"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("diskEncryptionSets", "diskEncryptionSets"),
-			models.UserSpecifiedResourceIDSegment("diskEncryptionSetName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("diskEncryptionSets", "diskEncryptionSets"),
+			importerModels.UserSpecifiedResourceIDSegment("diskEncryptionSetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_expressroute_circuit_peering.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_expressroute_circuit_peering.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdExpressRouteCircuitPeering{}
 
 type commonIdExpressRouteCircuitPeering struct{}
 
-func (c commonIdExpressRouteCircuitPeering) id() models.ParsedResourceId {
+func (c commonIdExpressRouteCircuitPeering) id() importerModels.ParsedResourceId {
 	name := "ExpressRouteCircuitPeering"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("expressRouteCircuits", "expressRouteCircuits"),
-			models.UserSpecifiedResourceIDSegment("circuitName"),
-			models.StaticResourceIDSegment("peerings", "peerings"),
-			models.UserSpecifiedResourceIDSegment("peeringName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("expressRouteCircuits", "expressRouteCircuits"),
+			importerModels.UserSpecifiedResourceIDSegment("circuitName"),
+			importerModels.StaticResourceIDSegment("peerings", "peerings"),
+			importerModels.UserSpecifiedResourceIDSegment("peeringName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hdinsight_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hdinsight_cluster.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdHDInsightCluster{}
 
 type commonIdHDInsightCluster struct{}
 
-func (c commonIdHDInsightCluster) id() models.ParsedResourceId {
+func (c commonIdHDInsightCluster) id() importerModels.ParsedResourceId {
 	name := "HDInsightCluster"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.HDInsight"),
-			models.StaticResourceIDSegment("clusters", "clusters"),
-			models.UserSpecifiedResourceIDSegment("clusterName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.HDInsight"),
+			importerModels.StaticResourceIDSegment("clusters", "clusters"),
+			importerModels.UserSpecifiedResourceIDSegment("clusterName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_job.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdHyperVSiteJob{}
 
 type commonIdHyperVSiteJob struct{}
 
-func (c commonIdHyperVSiteJob) id() models.ParsedResourceId {
+func (c commonIdHyperVSiteJob) id() importerModels.ParsedResourceId {
 	name := "HyperVSiteJob"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.StaticResourceIDSegment("hyperVSites", "hyperVSites"),
-			models.UserSpecifiedResourceIDSegment("hyperVSiteName"),
-			models.StaticResourceIDSegment("jobs", "jobs"),
-			models.UserSpecifiedResourceIDSegment("jobName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			importerModels.StaticResourceIDSegment("hyperVSites", "hyperVSites"),
+			importerModels.UserSpecifiedResourceIDSegment("hyperVSiteName"),
+			importerModels.StaticResourceIDSegment("jobs", "jobs"),
+			importerModels.UserSpecifiedResourceIDSegment("jobName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_machine.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_machine.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdHyperVSiteMachine{}
 
 type commonIdHyperVSiteMachine struct{}
 
-func (c commonIdHyperVSiteMachine) id() models.ParsedResourceId {
+func (c commonIdHyperVSiteMachine) id() importerModels.ParsedResourceId {
 	name := "HyperVSiteMachine"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.StaticResourceIDSegment("hyperVSites", "hyperVSites"),
-			models.UserSpecifiedResourceIDSegment("hyperVSiteName"),
-			models.StaticResourceIDSegment("machines", "machines"),
-			models.UserSpecifiedResourceIDSegment("machineName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			importerModels.StaticResourceIDSegment("hyperVSites", "hyperVSites"),
+			importerModels.UserSpecifiedResourceIDSegment("hyperVSiteName"),
+			importerModels.StaticResourceIDSegment("machines", "machines"),
+			importerModels.UserSpecifiedResourceIDSegment("machineName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_runasaccount.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_runasaccount.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdHyperVSiteRunAsAccount{}
 
 type commonIdHyperVSiteRunAsAccount struct{}
 
-func (c commonIdHyperVSiteRunAsAccount) id() models.ParsedResourceId {
+func (c commonIdHyperVSiteRunAsAccount) id() importerModels.ParsedResourceId {
 	name := "HyperVSiteRunAsAccount"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.StaticResourceIDSegment("hyperVSites", "hyperVSites"),
-			models.UserSpecifiedResourceIDSegment("hyperVSiteName"),
-			models.StaticResourceIDSegment("runAsAccounts", "runAsAccounts"),
-			models.UserSpecifiedResourceIDSegment("runAsAccountName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			importerModels.StaticResourceIDSegment("hyperVSites", "hyperVSites"),
+			importerModels.UserSpecifiedResourceIDSegment("hyperVSiteName"),
+			importerModels.StaticResourceIDSegment("runAsAccounts", "runAsAccounts"),
+			importerModels.UserSpecifiedResourceIDSegment("runAsAccountName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdKeyVault{}
 
 type commonIdKeyVault struct{}
 
-func (c commonIdKeyVault) id() models.ParsedResourceId {
+func (c commonIdKeyVault) id() importerModels.ParsedResourceId {
 	name := "KeyVault"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
-			models.StaticResourceIDSegment("vaults", "vaults"),
-			models.UserSpecifiedResourceIDSegment("vaultName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			importerModels.StaticResourceIDSegment("vaults", "vaults"),
+			importerModels.UserSpecifiedResourceIDSegment("vaultName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdKeyVaultKey{}
 
 type commonIdKeyVaultKey struct{}
 
-func (c commonIdKeyVaultKey) id() models.ParsedResourceId {
+func (c commonIdKeyVaultKey) id() importerModels.ParsedResourceId {
 	name := "KeyVaultKey"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
-			models.StaticResourceIDSegment("vaults", "vaults"),
-			models.UserSpecifiedResourceIDSegment("vaultName"),
-			models.StaticResourceIDSegment("keys", "keys"),
-			models.UserSpecifiedResourceIDSegment("keyName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			importerModels.StaticResourceIDSegment("vaults", "vaults"),
+			importerModels.UserSpecifiedResourceIDSegment("vaultName"),
+			importerModels.StaticResourceIDSegment("keys", "keys"),
+			importerModels.UserSpecifiedResourceIDSegment("keyName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key_version.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key_version.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,24 +12,24 @@ var _ commonIdMatcher = commonIdKeyVaultKeyVersion{}
 
 type commonIdKeyVaultKeyVersion struct{}
 
-func (c commonIdKeyVaultKeyVersion) id() models.ParsedResourceId {
+func (c commonIdKeyVaultKeyVersion) id() importerModels.ParsedResourceId {
 	name := "KeyVaultKeyVersion"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
-			models.StaticResourceIDSegment("vaults", "vaults"),
-			models.UserSpecifiedResourceIDSegment("vaultName"),
-			models.StaticResourceIDSegment("keys", "keys"),
-			models.UserSpecifiedResourceIDSegment("keyName"),
-			models.StaticResourceIDSegment("versions", "versions"),
-			models.UserSpecifiedResourceIDSegment("versionName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			importerModels.StaticResourceIDSegment("vaults", "vaults"),
+			importerModels.UserSpecifiedResourceIDSegment("vaultName"),
+			importerModels.StaticResourceIDSegment("keys", "keys"),
+			importerModels.UserSpecifiedResourceIDSegment("keyName"),
+			importerModels.StaticResourceIDSegment("versions", "versions"),
+			importerModels.UserSpecifiedResourceIDSegment("versionName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_private_endpoint_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_private_endpoint_connection.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdKeyVaultPrivateEndpointConnection{}
 
 type commonIdKeyVaultPrivateEndpointConnection struct{}
 
-func (c commonIdKeyVaultPrivateEndpointConnection) id() models.ParsedResourceId {
+func (c commonIdKeyVaultPrivateEndpointConnection) id() importerModels.ParsedResourceId {
 	name := "KeyVaultPrivateEndpointConnection"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
-			models.StaticResourceIDSegment("vaults", "vaults"),
-			models.UserSpecifiedResourceIDSegment("vaultName"),
-			models.StaticResourceIDSegment("privateEndpointConnections", "privateEndpointConnections"),
-			models.UserSpecifiedResourceIDSegment("privateEndpointConnectionName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			importerModels.StaticResourceIDSegment("vaults", "vaults"),
+			importerModels.UserSpecifiedResourceIDSegment("vaultName"),
+			importerModels.StaticResourceIDSegment("privateEndpointConnections", "privateEndpointConnections"),
+			importerModels.UserSpecifiedResourceIDSegment("privateEndpointConnectionName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdKubernetesCluster{}
 
 type commonIdKubernetesCluster struct{}
 
-func (c commonIdKubernetesCluster) id() models.ParsedResourceId {
+func (c commonIdKubernetesCluster) id() importerModels.ParsedResourceId {
 	name := "KubernetesCluster"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ContainerService"),
-			models.StaticResourceIDSegment("managedClusters", "managedClusters"),
-			models.UserSpecifiedResourceIDSegment("managedClusterName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ContainerService"),
+			importerModels.StaticResourceIDSegment("managedClusters", "managedClusters"),
+			importerModels.UserSpecifiedResourceIDSegment("managedClusterName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_fleet.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_fleet.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdKubernetesFleet{}
 
 type commonIdKubernetesFleet struct{}
 
-func (c commonIdKubernetesFleet) id() models.ParsedResourceId {
+func (c commonIdKubernetesFleet) id() importerModels.ParsedResourceId {
 	name := "KubernetesFleet"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ContainerService"),
-			models.StaticResourceIDSegment("fleets", "fleets"),
-			models.UserSpecifiedResourceIDSegment("fleetName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ContainerService"),
+			importerModels.StaticResourceIDSegment("fleets", "fleets"),
+			importerModels.UserSpecifiedResourceIDSegment("fleetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_cluster.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdKustoCluster{}
 
 type commonIdKustoCluster struct{}
 
-func (c commonIdKustoCluster) id() models.ParsedResourceId {
+func (c commonIdKustoCluster) id() importerModels.ParsedResourceId {
 	name := "KustoCluster"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("staticProviders", "providers"),
-			models.ResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
-			models.StaticResourceIDSegment("staticClusters", "clusters"),
-			models.UserSpecifiedResourceIDSegment("kustoClusterName"),
+			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("staticProviders", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
+			importerModels.StaticResourceIDSegment("staticClusters", "clusters"),
+			importerModels.UserSpecifiedResourceIDSegment("kustoClusterName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_database.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdKustoDatabase{}
 
 type commonIdKustoDatabase struct{}
 
-func (c commonIdKustoDatabase) id() models.ParsedResourceId {
+func (c commonIdKustoDatabase) id() importerModels.ParsedResourceId {
 	name := "KustoDatabase"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("staticProviders", "providers"),
-			models.ResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
-			models.StaticResourceIDSegment("staticClusters", "clusters"),
-			models.UserSpecifiedResourceIDSegment("kustoClusterName"),
-			models.StaticResourceIDSegment("staticDatabases", "databases"),
-			models.UserSpecifiedResourceIDSegment("kustoDatabaseName"),
+			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("staticProviders", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
+			importerModels.StaticResourceIDSegment("staticClusters", "clusters"),
+			importerModels.UserSpecifiedResourceIDSegment("kustoClusterName"),
+			importerModels.StaticResourceIDSegment("staticDatabases", "databases"),
+			importerModels.UserSpecifiedResourceIDSegment("kustoDatabaseName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_managed_disk.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_managed_disk.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdManagedDisk{}
 
 type commonIdManagedDisk struct{}
 
-func (c commonIdManagedDisk) id() models.ParsedResourceId {
+func (c commonIdManagedDisk) id() importerModels.ParsedResourceId {
 	name := "ManagedDisk"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("disks", "disks"),
-			models.UserSpecifiedResourceIDSegment("diskName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("disks", "disks"),
+			importerModels.UserSpecifiedResourceIDSegment("diskName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,16 +12,16 @@ var _ commonIdMatcher = commonIdManagementGroupMatcher{}
 
 type commonIdManagementGroupMatcher struct{}
 
-func (commonIdManagementGroupMatcher) id() models.ParsedResourceId {
+func (commonIdManagementGroupMatcher) id() importerModels.ParsedResourceId {
 	name := "ManagementGroup"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
-			models.StaticResourceIDSegment("managementGroups", "managementGroups"),
-			models.UserSpecifiedResourceIDSegment("groupId"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
+			importerModels.StaticResourceIDSegment("managementGroups", "managementGroups"),
+			importerModels.UserSpecifiedResourceIDSegment("groupId"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group_test.go
@@ -6,32 +6,32 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_ManagementGroup(t *testing.T) {
-	valid := models.ParsedResourceId{
+	valid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
-			models.StaticResourceIDSegment("managementGroups", "managementGroups"),
-			models.UserSpecifiedResourceIDSegment("groupId"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
+			importerModels.StaticResourceIDSegment("managementGroups", "managementGroups"),
+			importerModels.UserSpecifiedResourceIDSegment("groupId"),
 		},
 	}
-	invalid := models.ParsedResourceId{
+	invalid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
-			models.StaticResourceIDSegment("managementGroups", "managementGroups"),
-			models.UserSpecifiedResourceIDSegment("groupId"),
-			models.StaticResourceIDSegment("someResource", "someResource"),
-			models.UserSpecifiedResourceIDSegment("resourceName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
+			importerModels.StaticResourceIDSegment("managementGroups", "managementGroups"),
+			importerModels.UserSpecifiedResourceIDSegment("groupId"),
+			importerModels.StaticResourceIDSegment("someResource", "someResource"),
+			importerModels.UserSpecifiedResourceIDSegment("resourceName"),
 		},
 	}
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		valid,
 		invalid,
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdNetworkInterface{}
 
 type commonIdNetworkInterface struct{}
 
-func (c commonIdNetworkInterface) id() models.ParsedResourceId {
+func (c commonIdNetworkInterface) id() importerModels.ParsedResourceId {
 	name := "NetworkInterface"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.UserSpecifiedResourceIDSegment("networkInterfaceName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			importerModels.UserSpecifiedResourceIDSegment("networkInterfaceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface_ip_configuration.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdNetworkInterfaceIPConfiguration{}
 
 type commonIdNetworkInterfaceIPConfiguration struct{}
 
-func (c commonIdNetworkInterfaceIPConfiguration) id() models.ParsedResourceId {
+func (c commonIdNetworkInterfaceIPConfiguration) id() importerModels.ParsedResourceId {
 	name := "NetworkInterfaceIPConfiguration"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.UserSpecifiedResourceIDSegment("networkInterfaceName"),
-			models.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.UserSpecifiedResourceIDSegment("ipConfigurationName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			importerModels.UserSpecifiedResourceIDSegment("networkInterfaceName"),
+			importerModels.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			importerModels.UserSpecifiedResourceIDSegment("ipConfigurationName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_provisioning_service_id.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_provisioning_service_id.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdProvisioningService{}
 
 type commonIdProvisioningService struct{}
 
-func (c commonIdProvisioningService) id() models.ParsedResourceId {
+func (c commonIdProvisioningService) id() importerModels.ParsedResourceId {
 	name := "ProvisioningService"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Devices"),
-			models.StaticResourceIDSegment("provisioningServices", "provisioningServices"),
-			models.UserSpecifiedResourceIDSegment("provisioningServiceName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Devices"),
+			importerModels.StaticResourceIDSegment("provisioningServices", "provisioningServices"),
+			importerModels.UserSpecifiedResourceIDSegment("provisioningServiceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_ip_address.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdPublicIPAddress{}
 
 type commonIdPublicIPAddress struct{}
 
-func (c commonIdPublicIPAddress) id() models.ParsedResourceId {
+func (c commonIdPublicIPAddress) id() importerModels.ParsedResourceId {
 	name := "PublicIPAddress"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
-			models.UserSpecifiedResourceIDSegment("publicIPAddressesName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
+			importerModels.UserSpecifiedResourceIDSegment("publicIPAddressesName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_p2s_vpn_gateway.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_p2s_vpn_gateway.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdP2sVPNGateway{}
 
 type commonIdP2sVPNGateway struct{}
 
-func (c commonIdP2sVPNGateway) id() models.ParsedResourceId {
+func (c commonIdP2sVPNGateway) id() importerModels.ParsedResourceId {
 	name := "P2sVPNGateway"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("p2sVpnGateways", "p2sVpnGateways"),
-			models.UserSpecifiedResourceIDSegment("gatewayName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("p2sVpnGateways", "p2sVpnGateways"),
+			importerModels.UserSpecifiedResourceIDSegment("gatewayName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,16 +12,16 @@ var _ commonIdMatcher = commonIdResourceGroupMatcher{}
 
 type commonIdResourceGroupMatcher struct{}
 
-func (commonIdResourceGroupMatcher) id() models.ParsedResourceId {
+func (commonIdResourceGroupMatcher) id() importerModels.ParsedResourceId {
 	name := "ResourceGroup"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
@@ -6,32 +6,32 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_ResourceGroup(t *testing.T) {
-	valid := models.ParsedResourceId{
+	valid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
 		},
 	}
-	invalid := models.ParsedResourceId{
+	invalid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("someResource", "someResource"),
-			models.UserSpecifiedResourceIDSegment("resourceName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("someResource", "someResource"),
+			importerModels.UserSpecifiedResourceIDSegment("resourceName"),
 		},
 	}
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		valid,
 		invalid,
 	}
@@ -60,23 +60,23 @@ func TestCommonResourceID_ResourceGroup(t *testing.T) {
 }
 
 func TestCommonResourceID_ResourceGroupIncorrectSegment(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		{
 			Constants: map[string]resourcemanager.ConstantDetails{},
 			Segments: []resourcemanager.ResourceIdSegment{
-				models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-				models.SubscriptionIDResourceIDSegment("subscriptionId"),
-				models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-				models.ResourceGroupResourceIDSegment("resourceGroupName"),
+				importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+				importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+				importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+				importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
 			},
 		},
 		{
 			Constants: map[string]resourcemanager.ConstantDetails{},
 			Segments: []resourcemanager.ResourceIdSegment{
-				models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-				models.SubscriptionIDResourceIDSegment("subscriptionId"),
-				models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-				models.ResourceGroupResourceIDSegment("sourceResourceGroupName"),
+				importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+				importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+				importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+				importerModels.ResourceGroupResourceIDSegment("sourceResourceGroupName"),
 			},
 		},
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,13 +12,13 @@ var _ commonIdMatcher = commonIdScopeMatcher{}
 
 type commonIdScopeMatcher struct{}
 
-func (commonIdScopeMatcher) id() models.ParsedResourceId {
+func (commonIdScopeMatcher) id() importerModels.ParsedResourceId {
 	name := "Scope"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.ScopeResourceIDSegment("scope"),
+			importerModels.ScopeResourceIDSegment("scope"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope_test.go
@@ -6,26 +6,26 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_Scope(t *testing.T) {
-	valid := models.ParsedResourceId{
+	valid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.ScopeResourceIDSegment("resourcePath"),
+			importerModels.ScopeResourceIDSegment("resourcePath"),
 		},
 	}
-	invalid := models.ParsedResourceId{
+	invalid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.ScopeResourceIDSegment("scope"),
-			models.StaticResourceIDSegment("someResource", "someResource"),
-			models.UserSpecifiedResourceIDSegment("resourceName"),
+			importerModels.ScopeResourceIDSegment("scope"),
+			importerModels.StaticResourceIDSegment("someResource", "someResource"),
+			importerModels.UserSpecifiedResourceIDSegment("resourceName"),
 		},
 	}
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		valid,
 		invalid,
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_shared_image_gallery.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_shared_image_gallery.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdSharedImageGallery{}
 
 type commonIdSharedImageGallery struct{}
 
-func (c commonIdSharedImageGallery) id() models.ParsedResourceId {
+func (c commonIdSharedImageGallery) id() importerModels.ParsedResourceId {
 	name := "SharedImageGallery"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("galleries", "galleries"),
-			models.UserSpecifiedResourceIDSegment("galleryName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("galleries", "galleries"),
+			importerModels.UserSpecifiedResourceIDSegment("galleryName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_spring_cloud_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_spring_cloud_service.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdSpringCloudService{}
 
 type commonIdSpringCloudService struct{}
 
-func (c commonIdSpringCloudService) id() models.ParsedResourceId {
+func (c commonIdSpringCloudService) id() importerModels.ParsedResourceId {
 	name := "SpringCloudService"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("staticProviders", "providers"),
-			models.ResourceProviderResourceIDSegment("staticMicrosoftAppPlatform", "Microsoft.AppPlatform"),
-			models.StaticResourceIDSegment("staticSpring", "spring"),
-			models.UserSpecifiedResourceIDSegment("serviceName"),
+			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("staticProviders", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("staticMicrosoftAppPlatform", "Microsoft.AppPlatform"),
+			importerModels.StaticResourceIDSegment("staticSpring", "spring"),
+			importerModels.UserSpecifiedResourceIDSegment("serviceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_database.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdSqlDatabase{}
 
 type commonIdSqlDatabase struct{}
 
-func (c commonIdSqlDatabase) id() models.ParsedResourceId {
+func (c commonIdSqlDatabase) id() importerModels.ParsedResourceId {
 	name := "SqlDatabase"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.StaticResourceIDSegment("servers", "servers"),
-			models.UserSpecifiedResourceIDSegment("serverName"),
-			models.StaticResourceIDSegment("databases", "databases"),
-			models.UserSpecifiedResourceIDSegment("databaseName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			importerModels.StaticResourceIDSegment("servers", "servers"),
+			importerModels.UserSpecifiedResourceIDSegment("serverName"),
+			importerModels.StaticResourceIDSegment("databases", "databases"),
+			importerModels.UserSpecifiedResourceIDSegment("databaseName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_elastic_pool.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_elastic_pool.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdSqlElasticPool{}
 
 type commonIdSqlElasticPool struct{}
 
-func (c commonIdSqlElasticPool) id() models.ParsedResourceId {
+func (c commonIdSqlElasticPool) id() importerModels.ParsedResourceId {
 	name := "SqlElasticPool"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.StaticResourceIDSegment("servers", "servers"),
-			models.UserSpecifiedResourceIDSegment("serverName"),
-			models.StaticResourceIDSegment("elasticPools", "elasticPools"),
-			models.UserSpecifiedResourceIDSegment("elasticPoolName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			importerModels.StaticResourceIDSegment("servers", "servers"),
+			importerModels.UserSpecifiedResourceIDSegment("serverName"),
+			importerModels.StaticResourceIDSegment("elasticPools", "elasticPools"),
+			importerModels.UserSpecifiedResourceIDSegment("elasticPoolName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdSqlManagedInstance{}
 
 type commonIdSqlManagedInstance struct{}
 
-func (c commonIdSqlManagedInstance) id() models.ParsedResourceId {
+func (c commonIdSqlManagedInstance) id() importerModels.ParsedResourceId {
 	name := "SqlManagedInstance"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.StaticResourceIDSegment("managedInstances", "managedInstances"),
-			models.UserSpecifiedResourceIDSegment("managedInstanceName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			importerModels.StaticResourceIDSegment("managedInstances", "managedInstances"),
+			importerModels.UserSpecifiedResourceIDSegment("managedInstanceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance_database.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdSqlManagedInstanceDatabase{}
 
 type commonIdSqlManagedInstanceDatabase struct{}
 
-func (c commonIdSqlManagedInstanceDatabase) id() models.ParsedResourceId {
+func (c commonIdSqlManagedInstanceDatabase) id() importerModels.ParsedResourceId {
 	name := "SqlManagedInstanceDatabase"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.StaticResourceIDSegment("managedInstances", "managedInstances"),
-			models.UserSpecifiedResourceIDSegment("managedInstanceName"),
-			models.StaticResourceIDSegment("databases", "databases"),
-			models.UserSpecifiedResourceIDSegment("databaseName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			importerModels.StaticResourceIDSegment("managedInstances", "managedInstances"),
+			importerModels.UserSpecifiedResourceIDSegment("managedInstanceName"),
+			importerModels.StaticResourceIDSegment("databases", "databases"),
+			importerModels.UserSpecifiedResourceIDSegment("databaseName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_server.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_server.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdSqlServer{}
 
 type commonIdSqlServer struct{}
 
-func (c commonIdSqlServer) id() models.ParsedResourceId {
+func (c commonIdSqlServer) id() importerModels.ParsedResourceId {
 	name := "SqlServer"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.StaticResourceIDSegment("servers", "servers"),
-			models.UserSpecifiedResourceIDSegment("serverName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			importerModels.StaticResourceIDSegment("servers", "servers"),
+			importerModels.UserSpecifiedResourceIDSegment("serverName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_account.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_account.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdStorageAccount{}
 
 type commonIdStorageAccount struct{}
 
-func (c commonIdStorageAccount) id() models.ParsedResourceId {
+func (c commonIdStorageAccount) id() importerModels.ParsedResourceId {
 	name := "StorageAccount"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
-			models.StaticResourceIDSegment("storageAccounts", "storageAccounts"),
-			models.UserSpecifiedResourceIDSegment("storageAccountName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
+			importerModels.StaticResourceIDSegment("storageAccounts", "storageAccounts"),
+			importerModels.UserSpecifiedResourceIDSegment("storageAccountName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_container.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_container.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,24 +12,24 @@ var _ commonIdMatcher = commonIdStorageContainer{}
 
 type commonIdStorageContainer struct{}
 
-func (c commonIdStorageContainer) id() models.ParsedResourceId {
+func (c commonIdStorageContainer) id() importerModels.ParsedResourceId {
 	name := "StorageContainer"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
-			models.StaticResourceIDSegment("storageAccounts", "storageAccounts"),
-			models.UserSpecifiedResourceIDSegment("storageAccountName"),
-			models.StaticResourceIDSegment("blobServices", "blobServices"),
-			models.StaticResourceIDSegment("default", "default"),
-			models.StaticResourceIDSegment("containers", "containers"),
-			models.UserSpecifiedResourceIDSegment("containerName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
+			importerModels.StaticResourceIDSegment("storageAccounts", "storageAccounts"),
+			importerModels.UserSpecifiedResourceIDSegment("storageAccountName"),
+			importerModels.StaticResourceIDSegment("blobServices", "blobServices"),
+			importerModels.StaticResourceIDSegment("default", "default"),
+			importerModels.StaticResourceIDSegment("containers", "containers"),
+			importerModels.UserSpecifiedResourceIDSegment("containerName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subnet.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subnet.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdSubnet{}
 
 type commonIdSubnet struct{}
 
-func (c commonIdSubnet) id() models.ParsedResourceId {
+func (c commonIdSubnet) id() importerModels.ParsedResourceId {
 	name := "Subnet"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("virtualNetworks", "virtualNetworks"),
-			models.UserSpecifiedResourceIDSegment("virtualNetworkName"),
-			models.StaticResourceIDSegment("subnets", "subnets"),
-			models.UserSpecifiedResourceIDSegment("subnetName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("virtualNetworks", "virtualNetworks"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualNetworkName"),
+			importerModels.StaticResourceIDSegment("subnets", "subnets"),
+			importerModels.UserSpecifiedResourceIDSegment("subnetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,14 +12,14 @@ var _ commonIdMatcher = commonIdSubscriptionMatcher{}
 
 type commonIdSubscriptionMatcher struct{}
 
-func (commonIdSubscriptionMatcher) id() models.ParsedResourceId {
+func (commonIdSubscriptionMatcher) id() importerModels.ParsedResourceId {
 	name := "Subscription"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription_test.go
@@ -6,28 +6,28 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_Subscription(t *testing.T) {
-	valid := models.ParsedResourceId{
+	valid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
 		},
 	}
-	invalid := models.ParsedResourceId{
+	invalid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("someResource", "someResource"),
-			models.UserSpecifiedResourceIDSegment("resourceName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("someResource", "someResource"),
+			importerModels.UserSpecifiedResourceIDSegment("resourceName"),
 		},
 	}
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		valid,
 		invalid,
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdUserAssignedIdentity{}
 
 type commonIdUserAssignedIdentity struct{}
 
-func (commonIdUserAssignedIdentity) id() models.ParsedResourceId {
+func (commonIdUserAssignedIdentity) id() importerModels.ParsedResourceId {
 	name := "UserAssignedIdentity"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-			models.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+			importerModels.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+			importerModels.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity_test.go
@@ -6,40 +6,40 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_UserAssignedIdentity(t *testing.T) {
-	valid := models.ParsedResourceId{
+	valid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-			models.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+			importerModels.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+			importerModels.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
 		},
 	}
-	invalid := models.ParsedResourceId{
+	invalid := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-			models.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
-			models.StaticResourceIDSegment("someResource", "someResource"),
-			models.UserSpecifiedResourceIDSegment("resourceName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+			importerModels.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+			importerModels.UserSpecifiedResourceIDSegment("userAssignedIdentityName"),
+			importerModels.StaticResourceIDSegment("someResource", "someResource"),
+			importerModels.UserSpecifiedResourceIDSegment("resourceName"),
 		},
 	}
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		valid,
 		invalid,
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_hub_bgp_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_hub_bgp_connection.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdVirtualHubBGPConnection{}
 
 type commonIdVirtualHubBGPConnection struct{}
 
-func (c commonIdVirtualHubBGPConnection) id() models.ParsedResourceId {
+func (c commonIdVirtualHubBGPConnection) id() importerModels.ParsedResourceId {
 	name := "VirtualHubBGPConnection"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("virtualHubs", "virtualHubs"),
-			models.UserSpecifiedResourceIDSegment("hubName"),
-			models.StaticResourceIDSegment("bgpConnections", "bgpConnections"),
-			models.UserSpecifiedResourceIDSegment("connectionName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("virtualHubs", "virtualHubs"),
+			importerModels.UserSpecifiedResourceIDSegment("hubName"),
+			importerModels.StaticResourceIDSegment("bgpConnections", "bgpConnections"),
+			importerModels.UserSpecifiedResourceIDSegment("connectionName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_ip_configuration.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,26 +12,26 @@ var _ commonIdMatcher = commonIdVirtualMachineScaleSetIPConfiguration{}
 
 type commonIdVirtualMachineScaleSetIPConfiguration struct{}
 
-func (c commonIdVirtualMachineScaleSetIPConfiguration) id() models.ParsedResourceId {
+func (c commonIdVirtualMachineScaleSetIPConfiguration) id() importerModels.ParsedResourceId {
 	name := "VirtualMachineScaleSetIPConfiguration"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
-			models.UserSpecifiedResourceIDSegment("virtualMachineScaleSetName"),
-			models.StaticResourceIDSegment("virtualMachines", "virtualMachines"),
-			models.UserSpecifiedResourceIDSegment("virtualMachineIndex"),
-			models.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.UserSpecifiedResourceIDSegment("networkInterfaceName"),
-			models.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.UserSpecifiedResourceIDSegment("ipConfigurationName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualMachineScaleSetName"),
+			importerModels.StaticResourceIDSegment("virtualMachines", "virtualMachines"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualMachineIndex"),
+			importerModels.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			importerModels.UserSpecifiedResourceIDSegment("networkInterfaceName"),
+			importerModels.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			importerModels.UserSpecifiedResourceIDSegment("ipConfigurationName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_network_interface.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_network_interface.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,24 +12,24 @@ var _ commonIdMatcher = commonIdVirtualMachineScaleSetNetworkInterface{}
 
 type commonIdVirtualMachineScaleSetNetworkInterface struct{}
 
-func (c commonIdVirtualMachineScaleSetNetworkInterface) id() models.ParsedResourceId {
+func (c commonIdVirtualMachineScaleSetNetworkInterface) id() importerModels.ParsedResourceId {
 	name := "VirtualMachineScaleSetNetworkInterface"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
-			models.UserSpecifiedResourceIDSegment("virtualMachineScaleSetName"),
-			models.StaticResourceIDSegment("virtualMachines", "virtualMachines"),
-			models.UserSpecifiedResourceIDSegment("virtualMachineIndex"),
-			models.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.UserSpecifiedResourceIDSegment("networkInterfaceName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualMachineScaleSetName"),
+			importerModels.StaticResourceIDSegment("virtualMachines", "virtualMachines"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualMachineIndex"),
+			importerModels.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			importerModels.UserSpecifiedResourceIDSegment("networkInterfaceName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_public_ip_address.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,28 +12,28 @@ var _ commonIdMatcher = commonIdVirtualMachineScaleSetPublicIPAddress{}
 
 type commonIdVirtualMachineScaleSetPublicIPAddress struct{}
 
-func (c commonIdVirtualMachineScaleSetPublicIPAddress) id() models.ParsedResourceId {
+func (c commonIdVirtualMachineScaleSetPublicIPAddress) id() importerModels.ParsedResourceId {
 	name := "VirtualMachineScaleSetPublicIPAddress"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.StaticResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
-			models.UserSpecifiedResourceIDSegment("virtualMachineScaleSetName"),
-			models.StaticResourceIDSegment("virtualMachines", "virtualMachines"),
-			models.UserSpecifiedResourceIDSegment("virtualMachineIndex"),
-			models.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.UserSpecifiedResourceIDSegment("networkInterfaceName"),
-			models.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.UserSpecifiedResourceIDSegment("ipConfigurationName"),
-			models.StaticResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
-			models.UserSpecifiedResourceIDSegment("publicIpAddressName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			importerModels.StaticResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualMachineScaleSetName"),
+			importerModels.StaticResourceIDSegment("virtualMachines", "virtualMachines"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualMachineIndex"),
+			importerModels.StaticResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			importerModels.UserSpecifiedResourceIDSegment("networkInterfaceName"),
+			importerModels.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			importerModels.UserSpecifiedResourceIDSegment("ipConfigurationName"),
+			importerModels.StaticResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
+			importerModels.UserSpecifiedResourceIDSegment("publicIpAddressName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_network.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_network.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdVirtualNetwork{}
 
 type commonIdVirtualNetwork struct{}
 
-func (c commonIdVirtualNetwork) id() models.ParsedResourceId {
+func (c commonIdVirtualNetwork) id() importerModels.ParsedResourceId {
 	name := "VirtualNetwork"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("virtualNetworks", "virtualNetworks"),
-			models.UserSpecifiedResourceIDSegment("virtualNetworkName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("virtualNetworks", "virtualNetworks"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualNetworkName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_router_peering.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_router_peering.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdVirtualRouterPeering{}
 
 type commonIdVirtualRouterPeering struct{}
 
-func (c commonIdVirtualRouterPeering) id() models.ParsedResourceId {
+func (c commonIdVirtualRouterPeering) id() importerModels.ParsedResourceId {
 	name := "VirtualRouterPeering"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("virtualRouters", "virtualRouters"),
-			models.UserSpecifiedResourceIDSegment("virtualRouterName"),
-			models.StaticResourceIDSegment("peerings", "peerings"),
-			models.UserSpecifiedResourceIDSegment("peeringName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("virtualRouters", "virtualRouters"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualRouterName"),
+			importerModels.StaticResourceIDSegment("peerings", "peerings"),
+			importerModels.UserSpecifiedResourceIDSegment("peeringName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_wan_p2s_vpn_gateway.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_wan_p2s_vpn_gateway.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,20 +12,20 @@ var _ commonIdMatcher = commonIdVirtualWANP2SVPNGateway{}
 
 type commonIdVirtualWANP2SVPNGateway struct{}
 
-func (c commonIdVirtualWANP2SVPNGateway) id() models.ParsedResourceId {
+func (c commonIdVirtualWANP2SVPNGateway) id() importerModels.ParsedResourceId {
 	name := "VirtualWANP2SVPNGateway"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("p2sVpnGateways", "p2sVpnGateways"),
-			models.UserSpecifiedResourceIDSegment("gatewayName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("p2sVpnGateways", "p2sVpnGateways"),
+			importerModels.UserSpecifiedResourceIDSegment("gatewayName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtualhub_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtualhub_ip_configuration.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdVirtualHubIPConfiguration{}
 
 type commonIdVirtualHubIPConfiguration struct{}
 
-func (c commonIdVirtualHubIPConfiguration) id() models.ParsedResourceId {
+func (c commonIdVirtualHubIPConfiguration) id() importerModels.ParsedResourceId {
 	name := "VirtualHubIPConfiguration"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("virtualHubs", "virtualHubs"),
-			models.UserSpecifiedResourceIDSegment("virtualHubName"),
-			models.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.UserSpecifiedResourceIDSegment("ipConfigName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("virtualHubs", "virtualHubs"),
+			importerModels.UserSpecifiedResourceIDSegment("virtualHubName"),
+			importerModels.StaticResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			importerModels.UserSpecifiedResourceIDSegment("ipConfigName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_job.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -13,22 +13,22 @@ var _ commonIdMatcher = commonIdVMwareSiteJob{}
 type commonIdVMwareSiteJob struct {
 }
 
-func (c commonIdVMwareSiteJob) id() models.ParsedResourceId {
+func (c commonIdVMwareSiteJob) id() importerModels.ParsedResourceId {
 	name := "VMwareSiteJob"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.StaticResourceIDSegment("vmwareSites", "vmwareSites"),
-			models.UserSpecifiedResourceIDSegment("vmwareSiteName"),
-			models.StaticResourceIDSegment("jobs", "jobs"),
-			models.UserSpecifiedResourceIDSegment("jobName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			importerModels.StaticResourceIDSegment("vmwareSites", "vmwareSites"),
+			importerModels.UserSpecifiedResourceIDSegment("vmwareSiteName"),
+			importerModels.StaticResourceIDSegment("jobs", "jobs"),
+			importerModels.UserSpecifiedResourceIDSegment("jobName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_machine.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_machine.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -13,22 +13,22 @@ var _ commonIdMatcher = commonIdVMwareSiteMachine{}
 type commonIdVMwareSiteMachine struct {
 }
 
-func (c commonIdVMwareSiteMachine) id() models.ParsedResourceId {
+func (c commonIdVMwareSiteMachine) id() importerModels.ParsedResourceId {
 	name := "VMwareSiteMachine"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.StaticResourceIDSegment("vmwareSites", "vmwareSites"),
-			models.UserSpecifiedResourceIDSegment("vmwareSiteName"),
-			models.StaticResourceIDSegment("machines", "machines"),
-			models.UserSpecifiedResourceIDSegment("machineName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			importerModels.StaticResourceIDSegment("vmwareSites", "vmwareSites"),
+			importerModels.UserSpecifiedResourceIDSegment("vmwareSiteName"),
+			importerModels.StaticResourceIDSegment("machines", "machines"),
+			importerModels.UserSpecifiedResourceIDSegment("machineName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_runasaccount.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_runasaccount.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -13,22 +13,22 @@ var _ commonIdMatcher = commonIdVMwareSiteRunAsAccount{}
 type commonIdVMwareSiteRunAsAccount struct {
 }
 
-func (c commonIdVMwareSiteRunAsAccount) id() models.ParsedResourceId {
+func (c commonIdVMwareSiteRunAsAccount) id() importerModels.ParsedResourceId {
 	name := "VMwareSiteRunAsAccount"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.StaticResourceIDSegment("vmwareSites", "vmwareSites"),
-			models.UserSpecifiedResourceIDSegment("vmwareSiteName"),
-			models.StaticResourceIDSegment("runAsAccounts", "runAsAccounts"),
-			models.UserSpecifiedResourceIDSegment("runAsAccountName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			importerModels.StaticResourceIDSegment("vmwareSites", "vmwareSites"),
+			importerModels.UserSpecifiedResourceIDSegment("vmwareSiteName"),
+			importerModels.StaticResourceIDSegment("runAsAccounts", "runAsAccounts"),
+			importerModels.UserSpecifiedResourceIDSegment("runAsAccountName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vpn_gateway_vpn_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vpn_gateway_vpn_connection.go
@@ -4,7 +4,7 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -12,22 +12,22 @@ var _ commonIdMatcher = commonIdVPNConnection{}
 
 type commonIdVPNConnection struct{}
 
-func (c commonIdVPNConnection) id() models.ParsedResourceId {
+func (c commonIdVPNConnection) id() importerModels.ParsedResourceId {
 	name := "VPNConnection"
-	return models.ParsedResourceId{
+	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
 		Constants:   map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
-			models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-			models.SubscriptionIDResourceIDSegment("subscriptionId"),
-			models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.ResourceGroupResourceIDSegment("resourceGroupName"),
-			models.StaticResourceIDSegment("providers", "providers"),
-			models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.StaticResourceIDSegment("vpnGateways", "vpnGateways"),
-			models.UserSpecifiedResourceIDSegment("gatewayName"),
-			models.StaticResourceIDSegment("vpnConnections", "vpnConnections"),
-			models.UserSpecifiedResourceIDSegment("connectionName"),
+			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+			importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+			importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+			importerModels.StaticResourceIDSegment("providers", "providers"),
+			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			importerModels.StaticResourceIDSegment("vpnGateways", "vpnGateways"),
+			importerModels.UserSpecifiedResourceIDSegment("gatewayName"),
+			importerModels.StaticResourceIDSegment("vpnConnections", "vpnConnections"),
+			importerModels.UserSpecifiedResourceIDSegment("connectionName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -4,12 +4,12 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 type commonIdMatcher interface {
 	// id returns the Resource ID for this Common ID
-	id() models.ParsedResourceId
+	id() importerModels.ParsedResourceId
 }
 
 var commonIdTypes = []commonIdMatcher{
@@ -106,8 +106,8 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdSharedImageGallery{},
 }
 
-func switchOutCommonResourceIDsAsNeeded(input []models.ParsedResourceId) []models.ParsedResourceId {
-	output := make([]models.ParsedResourceId, 0)
+func switchOutCommonResourceIDsAsNeeded(input []importerModels.ParsedResourceId) []importerModels.ParsedResourceId {
+	output := make([]importerModels.ParsedResourceId, 0)
 
 	for _, value := range input {
 		for _, commonId := range commonIdTypes {

--- a/tools/importer-rest-api-specs/components/parser/resourceids/distinct_constants.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/distinct_constants.go
@@ -5,11 +5,11 @@ package resourceids
 
 import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func (p *Parser) findDistinctConstants(input map[string]models.ParsedResourceId) (*map[string]resourcemanager.ConstantDetails, error) {
+func (p *Parser) findDistinctConstants(input map[string]importerModels.ParsedResourceId) (*map[string]resourcemanager.ConstantDetails, error) {
 	intermediate := internal.ParseResult{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/distinct_resource_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/distinct_resource_ids.go
@@ -3,17 +3,17 @@
 
 package resourceids
 
-import "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+import importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 
-func (p *Parser) distinctResourceIds(input map[string]processedResourceId) []models.ParsedResourceId {
-	out := make([]models.ParsedResourceId, 0)
+func (p *Parser) distinctResourceIds(input map[string]processedResourceId) []importerModels.ParsedResourceId {
+	out := make([]importerModels.ParsedResourceId, 0)
 
 	for _, operation := range input {
 		if operation.segments == nil {
 			continue
 		}
 
-		item := models.ParsedResourceId{
+		item := importerModels.ParsedResourceId{
 			CommonAlias: nil,
 			Constants:   operation.constants,
 			Segments:    *operation.segments,

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names.go
@@ -9,22 +9,22 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func (p *Parser) generateNamesForResourceIds(input []models.ParsedResourceId, uriToResourceId map[string]ParsedOperation) (*map[string]models.ParsedResourceId, error) {
+func (p *Parser) generateNamesForResourceIds(input []importerModels.ParsedResourceId, uriToResourceId map[string]ParsedOperation) (*map[string]importerModels.ParsedResourceId, error) {
 	return generateNamesForResourceIds(input, uriToResourceId)
 }
 
-func generateNamesForResourceIds(input []models.ParsedResourceId, uriToResourceId map[string]ParsedOperation) (*map[string]models.ParsedResourceId, error) {
+func generateNamesForResourceIds(input []importerModels.ParsedResourceId, uriToResourceId map[string]ParsedOperation) (*map[string]importerModels.ParsedResourceId, error) {
 	// now that we have all of the Resource ID's, we then need to go through and determine Unique ID's for those
 	// we need all of them here to avoid conflicts, e.g. AuthorizationRule which can be a NamespaceAuthorizationRule
 	// or an EventHubAuthorizationRule, but is named AuthorizationRule in both
 
 	// Before we do anything else, let's go through remove any containing uri suffixes (since these are duplicated without
 	// where they contain a Resource ID - and then sort them short -> long for consistency
-	uniqueUris := make(map[string]models.ParsedResourceId, 0)
+	uniqueUris := make(map[string]importerModels.ParsedResourceId, 0)
 	sortedUris := make([]string, 0)
 	for i := range input {
 		resourceId := input[i]
@@ -40,8 +40,8 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, uriToResourceI
 		return len(sortedUris[x]) < len(sortedUris[y])
 	})
 
-	candidateNamesToUris := make(map[string]models.ParsedResourceId, 0)
-	conflictingNamesToUris := make(map[string][]models.ParsedResourceId, 0)
+	candidateNamesToUris := make(map[string]importerModels.ParsedResourceId, 0)
+	conflictingNamesToUris := make(map[string][]importerModels.ParsedResourceId, 0)
 
 	// first detect any CommonIDs and output those, to save the names
 	urisThatAreCommonIds := make(map[string]struct{})
@@ -89,7 +89,7 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, uriToResourceI
 
 		// if there's an existing candidate name for this key, move both this URI and that one to the Conflicts
 		if existingUri, existing := candidateNamesToUris[candidateSegmentName]; existing {
-			conflictingNamesToUris[candidateSegmentName] = []models.ParsedResourceId{existingUri, resourceId}
+			conflictingNamesToUris[candidateSegmentName] = []importerModels.ParsedResourceId{existingUri, resourceId}
 			delete(candidateNamesToUris, candidateSegmentName)
 			continue
 		}
@@ -119,7 +119,7 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, uriToResourceI
 	}
 
 	// now we have unique ID's, we should go through and suffix `Id` onto the end of each of them
-	outputNamesToUris := make(map[string]models.ParsedResourceId)
+	outputNamesToUris := make(map[string]importerModels.ParsedResourceId)
 	for k, v := range candidateNamesToUris {
 		key := fmt.Sprintf("%sId", cleanup.NormalizeName(k))
 		outputNamesToUris[key] = v
@@ -137,8 +137,8 @@ func generateNamesForResourceIds(input []models.ParsedResourceId, uriToResourceI
 	return &outputNamesToUris, nil
 }
 
-func determineUniqueNamesFor(conflictingUris []models.ParsedResourceId, existingCandidateNames map[string]models.ParsedResourceId) (*map[string]models.ParsedResourceId, error) {
-	proposedNames := make(map[string]models.ParsedResourceId)
+func determineUniqueNamesFor(conflictingUris []importerModels.ParsedResourceId, existingCandidateNames map[string]importerModels.ParsedResourceId) (*map[string]importerModels.ParsedResourceId, error) {
+	proposedNames := make(map[string]importerModels.ParsedResourceId)
 	for _, resourceId := range conflictingUris {
 		availableSegments := SegmentsAvailableForNaming(resourceId)
 
@@ -190,7 +190,7 @@ func determineUniqueNamesFor(conflictingUris []models.ParsedResourceId, existing
 	return &proposedNames, nil
 }
 
-func SegmentsAvailableForNaming(pri models.ParsedResourceId) []string {
+func SegmentsAvailableForNaming(pri importerModels.ParsedResourceId) []string {
 	// first reverse the segments, since we want to take from right -> left
 	reversedSegments := make([]resourcemanager.ResourceIdSegment, 0)
 	for i := len(pri.Segments); i > 0; i-- {

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-var subscriptionResourceId = models.ParsedResourceId{
+var subscriptionResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -26,7 +26,7 @@ var subscriptionResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var resourceGroupResourceId = models.ParsedResourceId{
+var resourceGroupResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -49,7 +49,7 @@ var resourceGroupResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var managementGroupResourceId = models.ParsedResourceId{
+var managementGroupResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -73,7 +73,7 @@ var managementGroupResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var virtualMachineResourceId = models.ParsedResourceId{
+var virtualMachineResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -115,7 +115,7 @@ var virtualMachineResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var virtualMachineExtensionResourceId = models.ParsedResourceId{
+var virtualMachineExtensionResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -166,7 +166,7 @@ var virtualMachineExtensionResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var virtualNetworkExtensionResourceId = models.ParsedResourceId{
+var virtualNetworkExtensionResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -208,7 +208,7 @@ var virtualNetworkExtensionResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var scopedMonitorResourceId = models.ParsedResourceId{
+var scopedMonitorResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -236,7 +236,7 @@ var scopedMonitorResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var signalRResourceId = models.ParsedResourceId{
+var signalRResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -278,7 +278,7 @@ var signalRResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var eventHubSkuResourceId = models.ParsedResourceId{
+var eventHubSkuResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
@@ -312,7 +312,7 @@ var eventHubSkuResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var trafficManagerProfileResourceId = models.ParsedResourceId{
+var trafficManagerProfileResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{
 		"EndpointType": {
 			Type: resourcemanager.StringConstant,
@@ -374,7 +374,7 @@ var trafficManagerProfileResourceId = models.ParsedResourceId{
 		},
 	},
 }
-var redisPatchSchedulesResourceId = models.ParsedResourceId{
+var redisPatchSchedulesResourceId = importerModels.ParsedResourceId{
 	Constants: map[string]resourcemanager.ConstantDetails{
 		"Default": {
 			Type: resourcemanager.StringConstant,
@@ -437,7 +437,7 @@ var redisPatchSchedulesResourceId = models.ParsedResourceId{
 
 func TestResourceIDNamingEmpty(t *testing.T) {
 	uriToParsedOperation := map[string]ParsedOperation{}
-	actualNamesToIds, err := generateNamesForResourceIds([]models.ParsedResourceId{}, uriToParsedOperation)
+	actualNamesToIds, err := generateNamesForResourceIds([]importerModels.ParsedResourceId{}, uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -449,10 +449,10 @@ func TestResourceIDNamingEmpty(t *testing.T) {
 }
 
 func TestResourceIDNamingSubscriptionId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		subscriptionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"SubscriptionId": subscriptionResourceId,
 	}
 
@@ -469,12 +469,12 @@ func TestResourceIDNamingSubscriptionId(t *testing.T) {
 }
 
 func TestResourceIDNamingSubscriptionIdAndSuffix(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		// intentionally here twice
 		subscriptionResourceId,
 		subscriptionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"SubscriptionId": subscriptionResourceId,
 	}
 
@@ -491,10 +491,10 @@ func TestResourceIDNamingSubscriptionIdAndSuffix(t *testing.T) {
 }
 
 func TestResourceIDNamingResourceGroupId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		resourceGroupResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"ResourceGroupId": resourceGroupResourceId,
 	}
 
@@ -511,12 +511,12 @@ func TestResourceIDNamingResourceGroupId(t *testing.T) {
 }
 
 func TestResourceIDNamingResourceGroupIdAndSuffix(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		// intentionally in here twice
 		resourceGroupResourceId,
 		resourceGroupResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"ResourceGroupId": resourceGroupResourceId,
 	}
 
@@ -533,10 +533,10 @@ func TestResourceIDNamingResourceGroupIdAndSuffix(t *testing.T) {
 }
 
 func TestResourceIDNamingManagementGroupId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		managementGroupResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"ManagementGroupId": managementGroupResourceId,
 	}
 
@@ -553,12 +553,12 @@ func TestResourceIDNamingManagementGroupId(t *testing.T) {
 }
 
 func TestResourceIDNamingManagementGroupIdAndSuffix(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		// intentionally here twice
 		managementGroupResourceId,
 		managementGroupResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"ManagementGroupId": managementGroupResourceId,
 	}
 
@@ -575,10 +575,10 @@ func TestResourceIDNamingManagementGroupIdAndSuffix(t *testing.T) {
 }
 
 func TestResourceIDNamingEventHubSkuId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		eventHubSkuResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"SkuId": eventHubSkuResourceId,
 	}
 
@@ -595,7 +595,7 @@ func TestResourceIDNamingEventHubSkuId(t *testing.T) {
 }
 
 func TestResourceIDNamingTopLevelScope(t *testing.T) {
-	scopeResourceId := models.ParsedResourceId{
+	scopeResourceId := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
@@ -605,10 +605,10 @@ func TestResourceIDNamingTopLevelScope(t *testing.T) {
 		},
 	}
 
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		scopeResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"ScopeId": scopeResourceId,
 	}
 
@@ -625,7 +625,7 @@ func TestResourceIDNamingTopLevelScope(t *testing.T) {
 }
 
 func TestResourceIDNamingContainingAConstant(t *testing.T) {
-	dnsResourceId := models.ParsedResourceId{
+	dnsResourceId := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{
 			"DnsRecordType": {
 				Type: resourcemanager.StringConstant,
@@ -676,10 +676,10 @@ func TestResourceIDNamingContainingAConstant(t *testing.T) {
 		},
 	}
 
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		dnsResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"RecordTypeId": dnsResourceId,
 	}
 
@@ -696,7 +696,7 @@ func TestResourceIDNamingContainingAConstant(t *testing.T) {
 }
 
 func TestResourceIDNamingContainingAConstantAndSuffix(t *testing.T) {
-	dnsResourceId := models.ParsedResourceId{
+	dnsResourceId := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{
 			"DnsRecordType": {
 				Type: resourcemanager.StringConstant,
@@ -747,12 +747,12 @@ func TestResourceIDNamingContainingAConstantAndSuffix(t *testing.T) {
 		},
 	}
 
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		// intentionally in here twice
 		dnsResourceId,
 		dnsResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"RecordTypeId": dnsResourceId,
 	}
 
@@ -769,10 +769,10 @@ func TestResourceIDNamingContainingAConstantAndSuffix(t *testing.T) {
 }
 
 func TestResourceIdNamingTopLevelResourceId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		virtualMachineResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"VirtualMachineId": virtualMachineResourceId,
 	}
 
@@ -789,11 +789,11 @@ func TestResourceIdNamingTopLevelResourceId(t *testing.T) {
 }
 
 func TestResourceIdNamingTopLevelAndNestedResourceId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		virtualMachineResourceId,
 		virtualMachineExtensionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"VirtualMachineId": virtualMachineResourceId,
 		"ExtensionId":      virtualMachineExtensionResourceId,
 	}
@@ -811,10 +811,10 @@ func TestResourceIdNamingTopLevelAndNestedResourceId(t *testing.T) {
 }
 
 func TestResourceIdNamingNestedResourceId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		virtualMachineExtensionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"ExtensionId": virtualMachineExtensionResourceId,
 	}
 
@@ -831,10 +831,10 @@ func TestResourceIdNamingNestedResourceId(t *testing.T) {
 }
 
 func TestResourceIdNamingResourceUnderScope(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		scopedMonitorResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"ScopedExtensionId": scopedMonitorResourceId,
 	}
 
@@ -851,11 +851,11 @@ func TestResourceIdNamingResourceUnderScope(t *testing.T) {
 }
 
 func TestResourceIdNamingConflictingTwoLevels(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		virtualNetworkExtensionResourceId,
 		virtualMachineExtensionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"VirtualMachineExtensionId": virtualMachineExtensionResourceId,
 		"ExtensionId":               virtualNetworkExtensionResourceId,
 	}
@@ -873,11 +873,11 @@ func TestResourceIdNamingConflictingTwoLevels(t *testing.T) {
 }
 
 func TestResourceIdNamingConflictingWithUpdatingOperation(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		virtualNetworkExtensionResourceId,
 		virtualMachineExtensionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"VirtualMachineExtensionId": virtualMachineExtensionResourceId,
 		"ExtensionId":               virtualNetworkExtensionResourceId,
 	}
@@ -911,7 +911,7 @@ func TestResourceIdNamingConflictingWithUpdatingOperation(t *testing.T) {
 }
 
 func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
-	workerPoolInstanceResourceId := models.ParsedResourceId{
+	workerPoolInstanceResourceId := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
@@ -971,7 +971,7 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 			},
 		},
 	}
-	multiRolePoolInstanceResourceId := models.ParsedResourceId{
+	multiRolePoolInstanceResourceId := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
@@ -1032,7 +1032,7 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 			},
 		},
 	}
-	slotInstanceProcessModuleResourceId := models.ParsedResourceId{
+	slotInstanceProcessModuleResourceId := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
@@ -1110,7 +1110,7 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 			},
 		},
 	}
-	instanceProcessModuleResourceId := models.ParsedResourceId{
+	instanceProcessModuleResourceId := importerModels.ParsedResourceId{
 		Constants: map[string]resourcemanager.ConstantDetails{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
@@ -1180,13 +1180,13 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 		},
 	}
 
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		workerPoolInstanceResourceId,
 		multiRolePoolInstanceResourceId,
 		slotInstanceProcessModuleResourceId,
 		instanceProcessModuleResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"WorkerPoolInstanceId": workerPoolInstanceResourceId,
 		"InstanceId":           multiRolePoolInstanceResourceId,
 		"ProcessModuleId":      slotInstanceProcessModuleResourceId,
@@ -1206,10 +1206,10 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 }
 
 func TestResourceIdNamingSignalRId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		signalRResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"SignalRId": signalRResourceId,
 	}
 
@@ -1226,10 +1226,10 @@ func TestResourceIdNamingSignalRId(t *testing.T) {
 }
 
 func TestResourceIdNamingTrafficManagerEndpoint(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		trafficManagerProfileResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"EndpointTypeId": trafficManagerProfileResourceId,
 	}
 
@@ -1246,10 +1246,10 @@ func TestResourceIdNamingTrafficManagerEndpoint(t *testing.T) {
 }
 
 func TestResourceIDNamingRedisDefaultId(t *testing.T) {
-	input := []models.ParsedResourceId{
+	input := []importerModels.ParsedResourceId{
 		redisPatchSchedulesResourceId,
 	}
-	expectedNamesToIds := map[string]models.ParsedResourceId{
+	expectedNamesToIds := map[string]importerModels.ParsedResourceId{
 		"DefaultId": redisPatchSchedulesResourceId,
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/helpers.go
@@ -8,17 +8,16 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
-
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func normalizedResourceManagerResourceId(pri models.ParsedResourceId) string {
+func normalizedResourceManagerResourceId(pri importerModels.ParsedResourceId) string {
 	segments := segmentsWithoutUriSuffix(pri)
 	return normalizedResourceId(segments)
 }
 
-func segmentsWithoutUriSuffix(pri models.ParsedResourceId) []resourcemanager.ResourceIdSegment {
+func segmentsWithoutUriSuffix(pri importerModels.ParsedResourceId) []resourcemanager.ResourceIdSegment {
 	segments := pri.Segments
 	lastUserValueSegment := -1
 	for i, segment := range segments {

--- a/tools/importer-rest-api-specs/components/parser/resourceids/models.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/models.go
@@ -6,16 +6,15 @@ package resourceids
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
-
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 type ParsedOperation struct {
 	// ResourceId is the ParsedResourceId object for this Resource Id
-	ResourceId *models.ParsedResourceId
+	ResourceId *importerModels.ParsedResourceId
 
 	// ResourceIdName is the name of the ResourceID
 	ResourceIdName *string
@@ -32,7 +31,7 @@ type ParseResult struct {
 	OperationIdsToParsedResourceIds map[string]ParsedOperation
 
 	// NamesToResourceIDs is a mapping of the ResourceID Names to the Parsed Resource ID objects
-	NamesToResourceIDs map[string]models.ParsedResourceId
+	NamesToResourceIDs map[string]importerModels.ParsedResourceId
 
 	// Constants is a map of Name - ConstantDetails found within the Resource IDs
 	Constants map[string]resourcemanager.ConstantDetails
@@ -77,7 +76,7 @@ func (r *ParseResult) Append(other ParseResult, logger hclog.Logger) error {
 
 		// since we have a new list of Resource IDs we also need to go through and regenerate the names
 		// as we may have conflicts etc
-		combinedResourceIds := make([]models.ParsedResourceId, 0)
+		combinedResourceIds := make([]importerModels.ParsedResourceId, 0)
 		for _, v := range r.NamesToResourceIDs {
 			combinedResourceIds = append(combinedResourceIds, v)
 		}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/constants"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -86,7 +86,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 				}
 			}
 			if isScope {
-				segments = append(segments, models.ScopeResourceIDSegment(normalizedSegment))
+				segments = append(segments, importerModels.ScopeResourceIDSegment(normalizedSegment))
 				continue
 			}
 
@@ -101,7 +101,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 				}
 
 				if previousSegmentWasSubscriptions {
-					segments = append(segments, models.SubscriptionIDResourceIDSegment(normalizedSegment))
+					segments = append(segments, importerModels.SubscriptionIDResourceIDSegment(normalizedSegment))
 					continue
 				}
 			}
@@ -117,7 +117,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 				}
 
 				if previousSegmentWasResourceGroups {
-					segments = append(segments, models.ResourceGroupResourceIDSegment(normalizedSegment))
+					segments = append(segments, importerModels.ResourceGroupResourceIDSegment(normalizedSegment))
 					continue
 				}
 			}
@@ -161,7 +161,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 						}
 
 						result.Constants[constant.Name] = constant.Details
-						segments = append(segments, models.ConstantResourceIDSegment(normalizedSegment, constant.Name))
+						segments = append(segments, importerModels.ConstantResourceIDSegment(normalizedSegment, constant.Name))
 						isConstant = true
 						break
 					}
@@ -173,7 +173,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 
 			// user specified segments are output as variables, so we need to ensure these aren't language keywords
 			normalizedSegment = cleanup.NormalizeReservedKeywords(normalizedSegment)
-			segments = append(segments, models.UserSpecifiedResourceIDSegment(normalizedSegment))
+			segments = append(segments, importerModels.UserSpecifiedResourceIDSegment(normalizedSegment))
 			continue
 		}
 
@@ -185,14 +185,14 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 			// prefix this with `static{name}` so that the segment is unique
 			// these aren't parsed out anyway, but we need unique names
 			normalizedSegment = normalizeSegment(fmt.Sprintf("static%s", strings.Title(resourceProviderValue)))
-			segments = append(segments, models.ResourceProviderResourceIDSegment(normalizedSegment, resourceProviderValue))
+			segments = append(segments, importerModels.ResourceProviderResourceIDSegment(normalizedSegment, resourceProviderValue))
 			continue
 		}
 
 		// prefix this with `static{name}` so that the segment is unique
 		// these aren't parsed out anyway, but we need unique names
 		normalizedName := normalizeSegment(fmt.Sprintf("static%s", strings.Title(normalizedSegment)))
-		segments = append(segments, models.StaticResourceIDSegment(normalizedName, normalizedSegment))
+		segments = append(segments, importerModels.StaticResourceIDSegment(normalizedName, normalizedSegment))
 	}
 
 	// now that we've parsed all of the URI Segments, let's determine if this contains a Resource ID scope
@@ -244,7 +244,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 	if allSegmentsAreStatic {
 		// if it's not an ARM ID there's nothing to output here, but new up a placeholder
 		// to be able to give us a normalized id for the suffix
-		pri := models.ParsedResourceId{
+		pri := importerModels.ParsedResourceId{
 			Constants: result.Constants,
 			Segments:  segments,
 		}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -68,8 +68,8 @@ func TestParseResourceIDFromOperation_ConstantMultiple(t *testing.T) {
 		t.Fatalf("expected 2 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.StaticResourceIDSegment("planets", "planets"),
-		models.ConstantResourceIDSegment("planetName", "NameOfPlanet"),
+		importerModels.StaticResourceIDSegment("planets", "planets"),
+		importerModels.ConstantResourceIDSegment("planetName", "NameOfPlanet"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 
@@ -111,8 +111,8 @@ func TestParseResourceIDFromOperation_InvalidSegmentDefaultGetsTransformed(t *te
 		t.Fatalf("expected 2 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.StaticResourceIDSegment("defaults", "defaults"),
-		models.UserSpecifiedResourceIDSegment("defaultName"),
+		importerModels.StaticResourceIDSegment("defaults", "defaults"),
+		importerModels.UserSpecifiedResourceIDSegment("defaultName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 
@@ -173,8 +173,8 @@ func TestParseResourceIDFromOperation_InvalidSegmentTypeGetsTransformed(t *testi
 		t.Fatalf("expected 2 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.StaticResourceIDSegment("things", "things"),
-		models.UserSpecifiedResourceIDSegment("typeName"),
+		importerModels.StaticResourceIDSegment("things", "things"),
+		importerModels.UserSpecifiedResourceIDSegment("typeName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 
@@ -206,10 +206,10 @@ func TestParseResourceIDFromOperation_ManagementGroupId(t *testing.T) {
 		t.Fatalf("expected 4 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.StaticResourceIDSegment("providers", "providers"),
-		models.ResourceProviderResourceIDSegment("resourceProviders", "Microsoft.Management"),
-		models.StaticResourceIDSegment("managementGroups", "managementGroups"),
-		models.UserSpecifiedResourceIDSegment("groupId"),
+		importerModels.StaticResourceIDSegment("providers", "providers"),
+		importerModels.ResourceProviderResourceIDSegment("resourceProviders", "Microsoft.Management"),
+		importerModels.StaticResourceIDSegment("managementGroups", "managementGroups"),
+		importerModels.UserSpecifiedResourceIDSegment("groupId"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -234,10 +234,10 @@ func TestParseResourceIDFromOperation_ResourceGroupId(t *testing.T) {
 		t.Fatalf("expected 4 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.StaticResourceIDSegment("providers", "providers"),
-		models.SubscriptionIDResourceIDSegment("subscriptionId"),
-		models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-		models.ResourceGroupResourceIDSegment("resourceGroupName"),
+		importerModels.StaticResourceIDSegment("providers", "providers"),
+		importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+		importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+		importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -262,10 +262,10 @@ func TestParseResourceIDFromOperation_ResourceGroupId_IncorrectSegment(t *testin
 		t.Fatalf("expected 4 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.StaticResourceIDSegment("providers", "providers"),
-		models.SubscriptionIDResourceIDSegment("subscriptionId"),
-		models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-		models.ResourceGroupResourceIDSegment("resourceGroupName"),
+		importerModels.StaticResourceIDSegment("providers", "providers"),
+		importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+		importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+		importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -290,7 +290,7 @@ func TestParseResourceIDFromOperation_Scope(t *testing.T) {
 		t.Fatalf("expected 1 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.ScopeResourceIDSegment("resourceId"),
+		importerModels.ScopeResourceIDSegment("resourceId"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -315,8 +315,8 @@ func TestParseResourceIDFromOperation_SubscriptionId(t *testing.T) {
 		t.Fatalf("expected 2 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.StaticResourceIDSegment("providers", "providers"),
-		models.SubscriptionIDResourceIDSegment("subscriptionId"),
+		importerModels.StaticResourceIDSegment("providers", "providers"),
+		importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -359,14 +359,14 @@ func TestParseResourceIDFromOperation_UserAssignedIdentityId(t *testing.T) {
 		t.Fatalf("expected 8 segments but got 0")
 	}
 	expectedSegments := []resourcemanager.ResourceIdSegment{
-		models.StaticResourceIDSegment("subscriptions", "subscriptions"),
-		models.SubscriptionIDResourceIDSegment("subscriptionId"),
-		models.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
-		models.ResourceGroupResourceIDSegment("resourceGroupName"),
-		models.StaticResourceIDSegment("providers", "providers"),
-		models.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-		models.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-		models.UserSpecifiedResourceIDSegment("resourceName"),
+		importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
+		importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
+		importerModels.StaticResourceIDSegment("resourceGroups", "resourceGroups"),
+		importerModels.ResourceGroupResourceIDSegment("resourceGroupName"),
+		importerModels.StaticResourceIDSegment("providers", "providers"),
+		importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+		importerModels.StaticResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+		importerModels.UserSpecifiedResourceIDSegment("resourceName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parser.go
@@ -6,7 +6,7 @@ package resourceids
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 // Parse takes a list of Swagger Resources and returns a ParseResult, containing
@@ -56,7 +56,7 @@ func (p *Parser) Parse() (*ParseResult, error) {
 	}, nil
 }
 
-func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSegments map[string]processedResourceId, namesToResourceIds map[string]models.ParsedResourceId) (*map[string]ParsedOperation, error) {
+func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSegments map[string]processedResourceId, namesToResourceIds map[string]importerModels.ParsedResourceId) (*map[string]ParsedOperation, error) {
 	output := make(map[string]ParsedOperation)
 
 	for operationId, operation := range operationIdsToSegments {
@@ -72,7 +72,7 @@ func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSe
 			continue
 		}
 
-		placeholder := models.ParsedResourceId{
+		placeholder := importerModels.ParsedResourceId{
 			Constants: operation.constants,
 			Segments:  *operation.segments,
 		}
@@ -80,7 +80,7 @@ func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSe
 		found := false
 		for name, resourceId := range namesToResourceIds {
 			// NOTE: we intentionally use an empty `id` here to avoid comparing on the Alias
-			other := models.ParsedResourceId{
+			other := importerModels.ParsedResourceId{
 				Constants: resourceId.Constants,
 				Segments:  resourceId.Segments,
 			}

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T) {
@@ -16,34 +16,34 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Hello": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 
 					"First": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Hello_First",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						// https://github.com/hashicorp/pandora/issues/3807
 						UriSuffix: pointer.To("/someotheruri"),
@@ -53,9 +53,9 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Hello_PutBar",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/bar"),
 					},
@@ -64,9 +64,9 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "hello_PutFoo",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/foo"),
 					},
@@ -75,9 +75,9 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 						ExpectedStatusCodes: []int{200},
 						Method:              "PATCH",
 						OperationId:         "hello_Second",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						// https://github.com/hashicorp/pandora/issues/3807
 						UriSuffix: pointer.To("/someotheruri"),
@@ -95,33 +95,33 @@ func TestParsingOperationsOnResources(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expected := models.AzureApiDefinition{
+	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]models.AzureApiResource{
+		Resources: map[string]importerModels.AzureApiResource{
 			"Hello": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"First": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Hello_First",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						// https://github.com/hashicorp/pandora/issues/3807
 						UriSuffix: pointer.To("/someotheruri"),
@@ -131,9 +131,9 @@ func TestParsingOperationsOnResources(t *testing.T) {
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
 						OperationId:         "Hello_PutBar",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/bar"),
 					},
@@ -142,9 +142,9 @@ func TestParsingOperationsOnResources(t *testing.T) {
 						ExpectedStatusCodes: []int{200},
 						Method:              "PATCH",
 						OperationId:         "hello_Second",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						// https://github.com/hashicorp/pandora/issues/3807
 						UriSuffix: pointer.To("/someotheruri"),
@@ -152,28 +152,28 @@ func TestParsingOperationsOnResources(t *testing.T) {
 				},
 			},
 			"HelloOperations": {
-				Models: map[string]models.ModelDetails{
+				Models: map[string]importerModels.ModelDetails{
 					"Example": {
-						Fields: map[string]models.FieldDetails{
+						Fields: map[string]importerModels.FieldDetails{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: &models.ObjectDefinition{
-									Type: models.ObjectDefinitionString,
+								ObjectDefinition: &importerModels.ObjectDefinition{
+									Type: importerModels.ObjectDefinitionString,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.OperationDetails{
+				Operations: map[string]importerModels.OperationDetails{
 					"HelloRestart": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "POST",
 						OperationId:         "Hello_Restart",
-						RequestObject: &models.ObjectDefinition{
+						RequestObject: &importerModels.ObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ObjectDefinitionReference,
+							Type:          importerModels.ObjectDefinitionReference,
 						},
 						UriSuffix: pointer.To("/foo"),
 					},

--- a/tools/importer-rest-api-specs/components/terraform/populate.go
+++ b/tools/importer-rest-api-specs/components/terraform/populate.go
@@ -11,13 +11,13 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/schema"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/testing"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/transformer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 // NOTE: this file wants further refactoring and is just a minimal viable grouping for now
 
-func PopulateForResources(data *models.AzureApiDefinition, resourceBuildInfo map[string]models.ResourceBuildInfo, providerPrefix string, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+func PopulateForResources(data *importerModels.AzureApiDefinition, resourceBuildInfo map[string]importerModels.ResourceBuildInfo, providerPrefix string, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
 	logger.Trace("generating Terraform Details")
 	var err error
 	data, err = generateTerraformDetails(data, resourceBuildInfo, logger.Named("TerraformDetails"))
@@ -40,7 +40,7 @@ func PopulateForResources(data *models.AzureApiDefinition, resourceBuildInfo map
 	return data, nil
 }
 
-func generateTerraformDetails(data *models.AzureApiDefinition, resourceBuildInfo map[string]models.ResourceBuildInfo, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+func generateTerraformDetails(data *importerModels.AzureApiDefinition, resourceBuildInfo map[string]importerModels.ResourceBuildInfo, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
 	for key, resource := range data.Resources {
 		if resource.Terraform == nil {
 			continue
@@ -62,7 +62,7 @@ func generateTerraformDetails(data *models.AzureApiDefinition, resourceBuildInfo
 			// use the ResourceName to build up the name for this Schema Model
 			resourceDetails.SchemaModelName = fmt.Sprintf("%sResource", resourceDetails.ResourceName)
 
-			var buildInfo *models.ResourceBuildInfo
+			var buildInfo *importerModels.ResourceBuildInfo
 			if resourceBuildInfo != nil {
 				if b, ok := resourceBuildInfo[resourceLabel]; ok {
 					buildInfo = &b
@@ -106,8 +106,8 @@ func generateTerraformDetails(data *models.AzureApiDefinition, resourceBuildInfo
 	return data, nil
 }
 
-func generateTerraformExampleUsage(data *models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
-	apiResources := make(map[string]models.AzureApiResource)
+func generateTerraformExampleUsage(data *importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
+	apiResources := make(map[string]importerModels.AzureApiResource)
 	for k, v := range data.Resources {
 		if v.Terraform != nil {
 			// TODO: support Data Sources
@@ -129,7 +129,7 @@ func generateTerraformExampleUsage(data *models.AzureApiDefinition) (*models.Azu
 	return data, nil
 }
 
-func generateTerraformTests(data *models.AzureApiDefinition, providerPrefix string, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+func generateTerraformTests(data *importerModels.AzureApiDefinition, providerPrefix string, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
 	for _, resource := range data.Resources {
 		if resource.Terraform == nil {
 			continue

--- a/tools/importer-rest-api-specs/components/terraform/schema/build_chaos_experiment_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/build_chaos_experiment_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -339,7 +339,7 @@ func TestBuildForChaosStudioExperimentWithRealData(t *testing.T) {
 		SchemaModelName: "Experiment",
 	}
 
-	var inputResourceBuildInfo *models.ResourceBuildInfo
+	var inputResourceBuildInfo *importerModels.ResourceBuildInfo
 
 	actualModels, actualMappings, err := builder.Build(input, inputResourceBuildInfo, hclog.New(hclog.DefaultOptions))
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/terraform/schema/build_resource_group_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/build_resource_group_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -150,7 +150,7 @@ func TestBuildForResourceGroupHappyPathAllModelsTheSame(t *testing.T) {
 		},
 	}
 
-	var inputResourceBuildInfo *models.ResourceBuildInfo
+	var inputResourceBuildInfo *importerModels.ResourceBuildInfo
 
 	actualModels, actualMappings, err := builder.Build(input, inputResourceBuildInfo, hclog.New(hclog.DefaultOptions))
 	if err != nil {
@@ -353,7 +353,7 @@ func TestBuildForResourceGroupUsingRealData(t *testing.T) {
 		},
 	}
 
-	var inputResourceBuildInfo *models.ResourceBuildInfo
+	var inputResourceBuildInfo *importerModels.ResourceBuildInfo
 
 	actualModels, actualMappings, err := builder.Build(input, inputResourceBuildInfo, hclog.New(hclog.DefaultOptions))
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/terraform/schema/build_search_service_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/build_search_service_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -524,7 +524,7 @@ func TestBuildForSearchServiceUsingRealData(t *testing.T) {
 		},
 	}
 
-	var inputResourceBuildInfo *models.ResourceBuildInfo
+	var inputResourceBuildInfo *importerModels.ResourceBuildInfo
 
 	actualModels, actualMappings, err := builder.Build(input, inputResourceBuildInfo, hclog.New(hclog.DefaultOptions))
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/terraform/schema/build_servicebus_namespace_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/build_servicebus_namespace_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -242,7 +242,7 @@ func TestBuildForServiceBusNamespaceHappyPath(t *testing.T) {
 		},
 	}
 
-	var inputResourceBuildInfo *models.ResourceBuildInfo
+	var inputResourceBuildInfo *importerModels.ResourceBuildInfo
 
 	actualModels, actualMappings, err := builder.Build(input, inputResourceBuildInfo, hclog.New(hclog.DefaultOptions))
 	if err != nil {
@@ -973,7 +973,7 @@ func TestBuildForServiceBusNamespaceUsingRealData(t *testing.T) {
 		},
 	}
 
-	var inputResourceBuildInfo *models.ResourceBuildInfo
+	var inputResourceBuildInfo *importerModels.ResourceBuildInfo
 
 	actualModels, actualMappings, err := builder.Build(input, inputResourceBuildInfo, hclog.New(hclog.DefaultOptions))
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/terraform/schema/builder.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/builder.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/helpers"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/schema/processors"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -39,7 +39,7 @@ func NewBuilder(constants map[string]resourcemanager.ConstantDetails, models map
 }
 
 // Build produces a map of TerraformSchemaModelDefinitions which comprise the Schema for this Resource
-func (b Builder) Build(input resourcemanager.TerraformResourceDetails, resourceBuildInfo *models.ResourceBuildInfo, logger hclog.Logger) (*map[string]resourcemanager.TerraformSchemaModelDefinition, *resourcemanager.MappingDefinition, error) {
+func (b Builder) Build(input resourcemanager.TerraformResourceDetails, resourceBuildInfo *importerModels.ResourceBuildInfo, logger hclog.Logger) (*map[string]resourcemanager.TerraformSchemaModelDefinition, *resourcemanager.MappingDefinition, error) {
 	mappings := resourcemanager.MappingDefinition{
 		Fields:     []resourcemanager.FieldMappingDefinition{},
 		ResourceId: []resourcemanager.ResourceIdMappingDefinition{},
@@ -251,7 +251,7 @@ type modelParseResult struct {
 	nestedModels map[string]resourcemanager.ModelDetails
 }
 
-func (b Builder) schemaFromTopLevelModel(input resourcemanager.TerraformResourceDetails, mappings *resourcemanager.MappingDefinition, resourceBuildInfo *models.ResourceBuildInfo, logger hclog.Logger) (*modelParseResult, error) {
+func (b Builder) schemaFromTopLevelModel(input resourcemanager.TerraformResourceDetails, mappings *resourcemanager.MappingDefinition, resourceBuildInfo *importerModels.ResourceBuildInfo, logger hclog.Logger) (*modelParseResult, error) {
 	createReadUpdateMethods, err := b.findCreateUpdateReadPayloads(input)
 	if err != nil {
 		return nil, fmt.Errorf("finding create/update/read payloads: %+v", err)
@@ -438,7 +438,7 @@ func (b Builder) findCreateUpdateReadPayloads(input resourcemanager.TerraformRes
 	return &out, nil
 }
 
-func (b Builder) buildNestedModelDefinition(schemaModelName, topLevelModelName, sdkModelName string, model resourcemanager.ModelDetails, details resourcemanager.TerraformResourceDetails, mappings resourcemanager.MappingDefinition, resourceBuildInfo *models.ResourceBuildInfo, logger hclog.Logger) (*resourcemanager.TerraformSchemaModelDefinition, *resourcemanager.MappingDefinition, error) {
+func (b Builder) buildNestedModelDefinition(schemaModelName, topLevelModelName, sdkModelName string, model resourcemanager.ModelDetails, details resourcemanager.TerraformResourceDetails, mappings resourcemanager.MappingDefinition, resourceBuildInfo *importerModels.ResourceBuildInfo, logger hclog.Logger) (*resourcemanager.TerraformSchemaModelDefinition, *resourcemanager.MappingDefinition, error) {
 	out := make(map[string]resourcemanager.TerraformSchemaFieldDefinition, 0)
 
 	for sdkFieldName, sdkField := range model.Fields {

--- a/tools/importer-rest-api-specs/components/terraform/schema/fields_nested.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/fields_nested.go
@@ -8,14 +8,13 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/helpers"
-
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/helpers"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func (b Builder) identifyFieldsWithinPropertiesBlock(schemaModelName string, input operationPayloads, resource *resourcemanager.TerraformResourceDetails, mappings *resourcemanager.MappingDefinition, resourceBuildInfo *models.ResourceBuildInfo, named hclog.Logger) (*map[string]resourcemanager.TerraformSchemaFieldDefinition, *resourcemanager.MappingDefinition, error) {
+func (b Builder) identifyFieldsWithinPropertiesBlock(schemaModelName string, input operationPayloads, resource *resourcemanager.TerraformResourceDetails, mappings *resourcemanager.MappingDefinition, resourceBuildInfo *importerModels.ResourceBuildInfo, named hclog.Logger) (*map[string]resourcemanager.TerraformSchemaFieldDefinition, *resourcemanager.MappingDefinition, error) {
 	allFields := make(map[string]struct{}, 0)
 	propertiesPayloads := input.createReadUpdatePayloadsProperties()
 	for _, model := range propertiesPayloads {

--- a/tools/importer-rest-api-specs/components/terraform/schema/fields_resource_id.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/fields_resource_id.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/helpers"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func (b Builder) identifyTopLevelFieldsWithinResourceID(input resourcemanager.ResourceIdDefinition, mappings *resourcemanager.MappingDefinition, displayName string, resourceBuildInfo *models.ResourceBuildInfo, logger hclog.Logger) (*map[string]resourcemanager.TerraformSchemaFieldDefinition, *resourcemanager.MappingDefinition, error) {
+func (b Builder) identifyTopLevelFieldsWithinResourceID(input resourcemanager.ResourceIdDefinition, mappings *resourcemanager.MappingDefinition, displayName string, resourceBuildInfo *importerModels.ResourceBuildInfo, logger hclog.Logger) (*map[string]resourcemanager.TerraformSchemaFieldDefinition, *resourcemanager.MappingDefinition, error) {
 	out := make(map[string]resourcemanager.TerraformSchemaFieldDefinition, 0)
-	overrides := make([]models.Override, 0)
+	overrides := make([]importerModels.Override, 0)
 
 	if resourceBuildInfo != nil && resourceBuildInfo.Overrides != nil {
 		overrides = resourceBuildInfo.Overrides
@@ -157,7 +157,7 @@ func (b Builder) identifyTopLevelFieldsWithinResourceID(input resourcemanager.Re
 	return &out, mappings, nil
 }
 
-func descriptionForResourceIDSegment(input, resourceDisplayName string, overrides []models.Override) string {
+func descriptionForResourceIDSegment(input, resourceDisplayName string, overrides []importerModels.Override) string {
 	if overrides != nil && len(overrides) > 0 {
 		for _, o := range overrides {
 			if o.UpdatedName != nil && strings.EqualFold(input, helpers.ConvertFromSnakeToTitleCase(*o.UpdatedName)) {

--- a/tools/importer-rest-api-specs/components/terraform/schema/fields_resource_id_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/fields_resource_id_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -24,7 +24,7 @@ func TestTopLevelFieldsWithinResourceId_NoSegmentsShouldError(t *testing.T) {
 		ResourceId: []resourcemanager.ResourceIdMappingDefinition{},
 	}
 
-	actualFields, actualMappings, err := Builder{}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Nothing", &models.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
+	actualFields, actualMappings, err := Builder{}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Nothing", &importerModels.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
 	if err == nil {
 		t.Fatalf("expected an error but didn't get one")
 	}
@@ -64,7 +64,7 @@ func TestTopLevelFieldsWithinResourceId_ResourceGroup(t *testing.T) {
 		ResourceId: []resourcemanager.ResourceIdMappingDefinition{},
 	}
 
-	actualFields, actualMappings, err := Builder{}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Resource Group", &models.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
+	actualFields, actualMappings, err := Builder{}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Resource Group", &importerModels.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 	}
@@ -153,7 +153,7 @@ func TestTopLevelFieldsWithinResourceId_VirtualMachine(t *testing.T) {
 		ResourceId: []resourcemanager.ResourceIdMappingDefinition{},
 	}
 
-	actualFields, actualMappings, err := Builder{}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Virtual Machine", &models.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
+	actualFields, actualMappings, err := Builder{}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Virtual Machine", &importerModels.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 	}
@@ -313,7 +313,7 @@ func TestTopLevelFieldsWithinResourceId_VirtualMachineExtension(t *testing.T) {
 				},
 			},
 		},
-	}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Virtual Machine Extension", &models.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
+	}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Virtual Machine Extension", &importerModels.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 	}
@@ -481,7 +481,7 @@ func TestTopLevelFieldsWithinResourceId_KubernetesTrustedAccessRoleBinding(t *te
 				},
 			},
 		},
-	}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Kubernetes Cluster Trusted Access Role Binding", &models.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
+	}.identifyTopLevelFieldsWithinResourceID(input, &inputMappings, "Kubernetes Cluster Trusted Access Role Binding", &importerModels.ResourceBuildInfo{}, hclog.New(hclog.DefaultOptions))
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 	}
@@ -601,8 +601,8 @@ func TestTopLevelFieldsWithinResourceId_ParentIdSchemaOverride(t *testing.T) {
 		Fields:     []resourcemanager.FieldMappingDefinition{},
 		ResourceId: []resourcemanager.ResourceIdMappingDefinition{},
 	}
-	inputResourceBuildInfo := models.ResourceBuildInfo{
-		Overrides: []models.Override{
+	inputResourceBuildInfo := importerModels.ResourceBuildInfo{
+		Overrides: []importerModels.Override{
 			{
 				Name:        "kubernetes_cluster_id",
 				UpdatedName: pointer.To("renamed_cluster_id"),
@@ -766,8 +766,8 @@ func TestTopLevelFieldsWithinResourceId_SchemaOverride(t *testing.T) {
 		Fields:     []resourcemanager.FieldMappingDefinition{},
 		ResourceId: []resourcemanager.ResourceIdMappingDefinition{},
 	}
-	inputResourceBuildInfo := models.ResourceBuildInfo{
-		Overrides: []models.Override{
+	inputResourceBuildInfo := importerModels.ResourceBuildInfo{
+		Overrides: []importerModels.Override{
 			{
 				Name:        "name",
 				UpdatedName: pointer.To("target_type"),
@@ -885,8 +885,8 @@ func TestTopLevelFieldsWithinResourceId_DocumentationOverride(t *testing.T) {
 		Fields:     []resourcemanager.FieldMappingDefinition{},
 		ResourceId: []resourcemanager.ResourceIdMappingDefinition{},
 	}
-	inputResourceBuildInfo := models.ResourceBuildInfo{
-		Overrides: []models.Override{
+	inputResourceBuildInfo := importerModels.ResourceBuildInfo{
+		Overrides: []importerModels.Override{
 			{
 				Name:        "name",
 				UpdatedName: pointer.To("target_type"),

--- a/tools/importer-rest-api-specs/components/terraform/schema/helpers.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/helpers.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/helpers"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/schema/processors"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -57,7 +57,7 @@ func getField(model resourcemanager.ModelDetails, fieldName string) (*resourcema
 	return nil, false
 }
 
-func updateFieldName(fieldName string, model *resourcemanager.ModelDetails, resource *resourcemanager.TerraformResourceDetails, constants map[string]resourcemanager.ConstantDetails, resourceBuildInfo *models.ResourceBuildInfo) (string, error) {
+func updateFieldName(fieldName string, model *resourcemanager.ModelDetails, resource *resourcemanager.TerraformResourceDetails, constants map[string]resourcemanager.ConstantDetails, resourceBuildInfo *importerModels.ResourceBuildInfo) (string, error) {
 	metadata := processors.FieldMetadata{
 		TerraformDetails: *resource,
 		Model:            *model,
@@ -90,7 +90,7 @@ func updateFieldName(fieldName string, model *resourcemanager.ModelDetails, reso
 	return fieldName, nil
 }
 
-func applySchemaOverrides(fieldName string, overrides []models.Override) (*string, error) {
+func applySchemaOverrides(fieldName string, overrides []importerModels.Override) (*string, error) {
 	for _, override := range overrides {
 		if strings.EqualFold(fieldName, strings.ReplaceAll(override.Name, "_", "")) {
 			if override.UpdatedName != nil {

--- a/tools/importer-rest-api-specs/components/terraform/schema/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -53,12 +53,12 @@ func TestExtractDescription(t *testing.T) {
 func TestUpdateField_ApplySchemaOverrides(t *testing.T) {
 	testData := []struct {
 		fieldInput string
-		overrides  []models.Override
+		overrides  []importerModels.Override
 		expected   *string
 	}{
 		{
 			fieldInput: "name",
-			overrides: []models.Override{
+			overrides: []importerModels.Override{
 				{
 					Name:        "name",
 					UpdatedName: pointer.To("target_resource_id"),
@@ -68,7 +68,7 @@ func TestUpdateField_ApplySchemaOverrides(t *testing.T) {
 		},
 		{
 			fieldInput: "ThreeCoffeesADay",
-			overrides: []models.Override{
+			overrides: []importerModels.Override{
 				{
 					Name:        "name",
 					UpdatedName: pointer.To("target_resource_id"),

--- a/tools/importer-rest-api-specs/pipeline/task_parse_data.go
+++ b/tools/importer-rest-api-specs/pipeline/task_parse_data.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/resources"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/transformer"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/config/definitions"
 )
 
-func (pipelineTask) parseDataForApiVersion(input discovery.ServiceInput, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+func (pipelineTask) parseDataForApiVersion(input discovery.ServiceInput, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
 	logger.Trace("Parsing Swagger Files..")
 	data, err := parseSwaggerFiles(input, logger.Named("Swagger"))
 	if err != nil {
@@ -42,7 +42,7 @@ func (pipelineTask) parseDataForApiVersion(input discovery.ServiceInput, logger 
 	return data, nil
 }
 
-func parseSwaggerFiles(input discovery.ServiceInput, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+func parseSwaggerFiles(input discovery.ServiceInput, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
 	parseResult, err := parser.LoadAndParseFiles(input.SwaggerDirectory, input.SwaggerFiles, input.ServiceName, input.ApiVersion, input.ResourceProviderToFilterTo, logger)
 	if err != nil {
 		return nil, fmt.Errorf("parsing files in %q: %+v", input.SwaggerDirectory, err)
@@ -51,12 +51,12 @@ func parseSwaggerFiles(input discovery.ServiceInput, logger hclog.Logger) (*mode
 	return parseResult, nil
 }
 
-func identifyCandidateTerraformResources(input *models.AzureApiDefinition, terraformServiceDefinition definitions.ServiceDefinition, logger hclog.Logger) (*models.AzureApiDefinition, error) {
+func identifyCandidateTerraformResources(input *importerModels.AzureApiDefinition, terraformServiceDefinition definitions.ServiceDefinition, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
 	if input == nil {
 		return input, nil
 	}
 
-	parsedResources := make(map[string]models.AzureApiResource, 0)
+	parsedResources := make(map[string]importerModels.AzureApiResource, 0)
 
 	for k, v := range input.Resources {
 		definitionsForThisResource := findResourceDefinitionsForResource(input.ApiVersion, k, terraformServiceDefinition)


### PR DESCRIPTION
I'm doing this in one swoop rather than adhoc because it makes the migration/consolidation easier