### PR TITLE
`tools/importer-rest-api-specs`: updating `ConstantDetails` to use the Data API SDK Type

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_assigned.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_assigned.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 var _ customFieldMatcher = systemAssignedIdentityMatcher{}
@@ -68,8 +68,8 @@ func (systemAssignedIdentityMatcher) IsMatch(_ importerModels.FieldDetails, defi
 	return hasMatchingType && hasPrincipalId && hasTenantId
 }
 
-func validateIdentityConstantValues(input resourcemanager.ConstantDetails, expected map[string]string) bool {
-	if input.Type != resourcemanager.StringConstant {
+func validateIdentityConstantValues(input models.SDKConstant, expected map[string]string) bool {
+	if input.Type != models.StringSDKConstantType {
 		return false
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_system_data.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_system_data.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 var _ customFieldMatcher = systemDataMatcher{}
@@ -123,8 +123,8 @@ func (systemDataMatcher) IsMatch(_ importerModels.FieldDetails, definition impor
 	return hasCreatedByType && hasCreatedBy && hasLastModifiedbyType && hasLastModifiedAt && hasLastModifiedBy && hasCreatedAt
 }
 
-func validateSystemDataConstantValues(input resourcemanager.ConstantDetails, expected map[string]string) bool {
-	if input.Type != resourcemanager.StringConstant {
+func validateSystemDataConstantValues(input models.SDKConstant, expected map[string]string) bool {
+	if input.Type != models.StringSDKConstantType {
 		return false
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/constants/interface.go
+++ b/tools/importer-rest-api-specs/components/parser/constants/interface.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/featureflags"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 type constantExtension struct {
@@ -29,7 +29,7 @@ type constantExtension struct {
 
 type ParsedConstant struct {
 	Name    string
-	Details resourcemanager.ConstantDetails
+	Details models.SDKConstant
 }
 
 func MapConstant(typeVal spec.StringOrArray, fieldName string, values []interface{}, extensions spec.Extensions, logger hclog.Logger) (*ParsedConstant, error) {
@@ -52,16 +52,16 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, values []interfac
 		constantName = constExtension.name
 	}
 
-	constantType := resourcemanager.StringConstant
+	constantType := models.StringSDKConstantType
 	if typeVal.Contains("integer") {
-		constantType = resourcemanager.IntegerConstant
+		constantType = models.IntegerSDKConstantType
 	} else if typeVal.Contains("number") {
-		constantType = resourcemanager.FloatConstant
+		constantType = models.FloatSDKConstantType
 	}
 
 	keysAndValues := make(map[string]string)
 	for i, raw := range values {
-		if constantType == resourcemanager.StringConstant {
+		if constantType == models.StringSDKConstantType {
 			value, ok := raw.(string)
 			if !ok {
 				return nil, fmt.Errorf("expected a string but got %+v for the %d value for %q", raw, i, constExtension.name)
@@ -85,7 +85,7 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, values []interfac
 			continue
 		}
 
-		if constantType == resourcemanager.IntegerConstant {
+		if constantType == models.IntegerSDKConstantType {
 			// This gets parsed out as a float64 even though it's an Integer :upside_down_smile:
 			value, ok := raw.(float64)
 			if !ok {
@@ -119,7 +119,7 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, values []interfac
 			continue
 		}
 
-		if constantType == resourcemanager.FloatConstant {
+		if constantType == models.FloatSDKConstantType {
 			value, ok := raw.(float64)
 			if !ok {
 				return nil, fmt.Errorf("expected an float but got %+v for the %d value for %q", raw, i, constExtension.name)
@@ -137,12 +137,12 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, values []interfac
 
 	// allows us to parse out the actual types above then force a string here if needed
 	if constExtension == nil {
-		constantType = resourcemanager.StringConstant
+		constantType = models.StringSDKConstantType
 	}
 
 	return &ParsedConstant{
 		Name: constantName,
-		Details: resourcemanager.ConstantDetails{
+		Details: models.SDKConstant{
 			Values: keysAndValues,
 			Type:   constantType,
 		},

--- a/tools/importer-rest-api-specs/components/parser/constants_test.go
+++ b/tools/importer-rest-api-specs/components/parser/constants_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
@@ -23,9 +23,9 @@ func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.IntegerConstant,
+						Type: models.IntegerSDKConstantType,
 						Values: map[string]string{
 							"One":              "1",
 							"Two":              "2",
@@ -80,9 +80,9 @@ func TestParseConstantsIntegersTopLevelAsIntsWithDisplayName(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.IntegerConstant,
+						Type: models.IntegerSDKConstantType,
 						Values: map[string]string{
 							"First":  "1",
 							"Second": "2",
@@ -135,9 +135,9 @@ func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.IntegerConstant,
+						Type: models.IntegerSDKConstantType,
 						Values: map[string]string{
 							"One":   "1",
 							"Two":   "2",
@@ -190,9 +190,9 @@ func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.IntegerConstant,
+						Type: models.IntegerSDKConstantType,
 						Values: map[string]string{
 							"One":   "1",
 							"Two":   "2",
@@ -246,9 +246,9 @@ func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.IntegerConstant,
+						Type: models.IntegerSDKConstantType,
 						Values: map[string]string{
 							"First":  "1",
 							"Second": "2",
@@ -301,9 +301,9 @@ func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.IntegerConstant,
+						Type: models.IntegerSDKConstantType,
 						Values: map[string]string{
 							"One":   "1",
 							"Two":   "2",
@@ -356,9 +356,9 @@ func TestParseConstantsFloatsTopLevelAsFloats(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.FloatConstant,
+						Type: models.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -411,9 +411,9 @@ func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.FloatConstant,
+						Type: models.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -466,9 +466,9 @@ func TestParseConstantsFloatsInlinedAsFloats(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.FloatConstant,
+						Type: models.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -521,9 +521,9 @@ func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.FloatConstant,
+						Type: models.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -575,9 +575,9 @@ func TestParseConstantsStringsTopLevel(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"AnimalType": {
-						Type: resourcemanager.StringConstant,
+						Type: models.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -633,9 +633,9 @@ func TestParseConstantsStringsTopLevelAsNonStrings(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"AnimalType": {
-						Type: resourcemanager.StringConstant,
+						Type: models.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -687,9 +687,9 @@ func TestParseConstantsStringsInlined(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"AnimalType": {
-						Type: resourcemanager.StringConstant,
+						Type: models.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -741,9 +741,9 @@ func TestParseConstantsStringsInlinedAsNonStrings(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"AnimalType": {
-						Type: resourcemanager.StringConstant,
+						Type: models.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -796,9 +796,9 @@ func TestParseConstantsStringsTopLevelContainingFloats(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.StringConstant,
+						Type: models.StringSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -851,9 +851,9 @@ func TestParseConstantsStringsInlinedContainingFloats(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"TableNumber": {
-						Type: resourcemanager.FloatConstant,
+						Type: models.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -929,7 +929,7 @@ func TestParseConstantsFromParameters(t *testing.T) {
 	if !ok {
 		t.Fatalf("resource.Constants['TableNumber'] was not found")
 	}
-	if favouriteTable.Type != resourcemanager.StringConstant {
+	if favouriteTable.Type != models.StringSDKConstantType {
 		t.Fatalf("expected resource.Constants['TableNumber'].Type to be 'String' but got %q", favouriteTable.Type)
 	}
 	if len(favouriteTable.Values) != 3 {

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 var _ workaround = workaroundBotService27351{}
@@ -75,7 +75,7 @@ func (workaroundBotService27351) Process(input importerModels.AzureApiDefinition
 	if !ok {
 		return nil, fmt.Errorf("expected a Constant named `EmailChannelAuthMethod` but didn't get one")
 	}
-	constant.Type = resourcemanager.IntegerConstant
+	constant.Type = models.IntegerSDKConstantType
 	resource.Constants["EmailChannelAuthMethod"] = constant
 
 	output.Resources["Channel"] = resource

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 var _ workaround = workaroundHDInsight26838{}
@@ -65,8 +65,8 @@ func (workaroundHDInsight26838) Process(apiDefinition importerModels.AzureApiDef
 	if v, ok := resource.Constants["ClusterKind"]; ok {
 		return nil, fmt.Errorf("an existing Constant exists with the name `ClusterKind`: %+v", v)
 	}
-	resource.Constants["ClusterKind"] = resourcemanager.ConstantDetails{
-		Type: resourcemanager.StringConstant,
+	resource.Constants["ClusterKind"] = models.SDKConstant{
+		Type: models.StringSDKConstantType,
 		Values: map[string]string{
 			"Hadoop":          "HADOOP",
 			"HBase":           "HBASE",

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -60,12 +60,9 @@ func validateParsedApiResourceMatches(t *testing.T, expected importerModels.Azur
 	validateObjectsMatch(t, expected.Terraform, actual.Terraform, "Terraform", validateParsedTerraformDetailsMatch)
 }
 
-func validateParsedConstantsMatch(t *testing.T, expected resourcemanager.ConstantDetails, actual resourcemanager.ConstantDetails, constantName string) {
+func validateParsedConstantsMatch(t *testing.T, expected, actual models.SDKConstant, constantName string) {
 	if expected.Type != actual.Type {
 		t.Fatalf("expected Type to be %q but got %q for Constant %q", string(expected.Type), string(actual.Type), constantName)
-	}
-	if expected.CaseInsensitive != actual.CaseInsensitive {
-		t.Fatalf("expected CaseInsensitive to be %t but got %t for Constant %q", expected.CaseInsensitive, actual.CaseInsensitive, constantName)
 	}
 	validateMapsMatch(t, expected.Values, actual.Values, "Values", validateStringsMatch)
 }

--- a/tools/importer-rest-api-specs/components/parser/internal/structs.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/structs.go
@@ -9,18 +9,18 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 type ParseResult struct {
-	Constants map[string]resourcemanager.ConstantDetails
+	Constants map[string]models.SDKConstant
 	Models    map[string]importerModels.ModelDetails
 }
 
 func (r *ParseResult) Append(other ParseResult) error {
 	if r.Constants == nil {
-		r.Constants = make(map[string]resourcemanager.ConstantDetails)
+		r.Constants = make(map[string]models.SDKConstant)
 	}
 	if err := r.AppendConstants(other.Constants); err != nil {
 		return fmt.Errorf("appending constants: %+v", err)
@@ -36,7 +36,7 @@ func (r *ParseResult) Append(other ParseResult) error {
 	return nil
 }
 
-func (r *ParseResult) AppendConstants(other map[string]resourcemanager.ConstantDetails) error {
+func (r *ParseResult) AppendConstants(other map[string]models.SDKConstant) error {
 	for k, v := range other {
 		existing, hasExisting := r.Constants[k]
 		if !hasExisting {

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -8,17 +8,17 @@ import (
 	"strings"
 
 	"github.com/go-openapi/spec"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/commonschema"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/constants"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func (d *SwaggerDefinition) parseModel(name string, input spec.Schema) (*internal.ParseResult, error) {
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 
@@ -60,7 +60,7 @@ func (d *SwaggerDefinition) parseModel(name string, input spec.Schema) (*interna
 func (d *SwaggerDefinition) findConstantsWithinModel(fieldName string, input spec.Schema, known internal.ParseResult) (*internal.ParseResult, error) {
 	// NOTE: both Models and Fields are passed in here
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 	result.Append(known)
@@ -136,7 +136,7 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 	d.logger.Trace(fmt.Sprintf("Parsing details for field %q in %q..", propertyName, modelName))
 
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 	result.Append(known)
@@ -243,7 +243,7 @@ func determineCustomFieldType(field importerModels.FieldDetails, definition impo
 func (d *SwaggerDefinition) fieldsForModel(modelName string, input spec.Schema, known internal.ParseResult) (*map[string]importerModels.FieldDetails, *internal.ParseResult, error) {
 	fields := make(map[string]importerModels.FieldDetails, 0)
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 	result.Append(known)
@@ -458,7 +458,7 @@ func (d *SwaggerDefinition) findAncestorType(input spec.Schema) (*string, *strin
 
 func (d *SwaggerDefinition) findOrphanedDiscriminatedModels() (*internal.ParseResult, error) {
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 
@@ -497,7 +497,7 @@ func (d SwaggerDefinition) parseObjectDefinition(
 	// find the object and any models and constants etc we can find
 	// however _don't_ look for discriminator implementations - since that should be done when we're completely done
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 	result.Append(known)
@@ -537,7 +537,7 @@ func (d SwaggerDefinition) parseObjectDefinition(
 		}
 
 		knownIncludingPlaceholder := internal.ParseResult{
-			Constants: map[string]resourcemanager.ConstantDetails{},
+			Constants: map[string]models.SDKConstant{},
 			Models:    map[string]importerModels.ModelDetails{},
 		}
 

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -582,9 +583,9 @@ func TestParseModelWithReferenceToConstant(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"AnimalType": {
-						Type: resourcemanager.StringConstant,
+						Type: models.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat": "Cat",
 							"Dog": "Dog",

--- a/tools/importer-rest-api-specs/components/parser/normalizer.go
+++ b/tools/importer-rest-api-specs/components/parser/normalizer.go
@@ -15,7 +15,7 @@ import (
 // that all the Names and References are consistent (TitleCase) as a final effort
 // to ensure the Swagger Data is normalized.
 func normalizeAzureApiResource(input importerModels.AzureApiResource) importerModels.AzureApiResource {
-	normalizedConstants := make(map[string]resourcemanager.ConstantDetails)
+	normalizedConstants := make(map[string]models.SDKConstant)
 	for k, v := range input.Constants {
 		name := cleanup.NormalizeName(k)
 		normalizedConstants[name] = v
@@ -82,7 +82,7 @@ func normalizeAzureApiResource(input importerModels.AzureApiResource) importerMo
 	for k, v := range input.ResourceIds {
 		segments := make([]resourcemanager.ResourceIdSegment, 0)
 
-		normalizedConstants := make(map[string]resourcemanager.ConstantDetails)
+		normalizedConstants := make(map[string]models.SDKConstant)
 		for k, constant := range v.Constants {
 			name := cleanup.NormalizeName(k)
 			normalizedConstants[name] = constant

--- a/tools/importer-rest-api-specs/components/parser/operations.go
+++ b/tools/importer-rest-api-specs/components/parser/operations.go
@@ -5,19 +5,18 @@ package parser
 
 import (
 	"fmt"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/go-openapi/spec"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/constants"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 type operationsParser struct {
@@ -30,7 +29,7 @@ func (d *SwaggerDefinition) parseOperationsWithinTag(tag *string, operationIdsTo
 	logger := d.logger.Named("Operations Parser")
 	operations := make(map[string]importerModels.OperationDetails, 0)
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 	result.Append(found)
@@ -76,7 +75,7 @@ func (d *SwaggerDefinition) parseOperationsWithinTag(tag *string, operationIdsTo
 
 func (p operationsParser) parseOperation(operation parsedOperation, resourceProvider *string, logger hclog.Logger) (*importerModels.OperationDetails, *internal.ParseResult, error) {
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 
@@ -340,7 +339,7 @@ func (p operationsParser) operationIsLongRunning(input parsedOperation) bool {
 func (p operationsParser) optionsForOperation(input parsedOperation, logger hclog.Logger) (*map[string]models.SDKOperationOption, *internal.ParseResult, error) {
 	output := make(map[string]models.SDKOperationOption)
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 	}
 
 	for _, param := range input.operation.Parameters {
@@ -467,7 +466,7 @@ func (p operationsParser) operationIsASuccess(statusCode int, resp spec.Response
 func (p operationsParser) responseObjectForOperation(input parsedOperation, known internal.ParseResult) (*operationResponseObjectResult, *internal.ParseResult, error) {
 	output := operationResponseObjectResult{}
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 	result.Append(known)

--- a/tools/importer-rest-api-specs/components/parser/parse_data.go
+++ b/tools/importer-rest-api-specs/components/parser/parse_data.go
@@ -6,8 +6,8 @@ package parser
 import (
 	"fmt"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func combineResourcesWith(first importerModels.AzureApiDefinition, other map[string]importerModels.AzureApiResource) (*map[string]importerModels.AzureApiResource, error) {
@@ -53,8 +53,8 @@ func combineResourcesWith(first importerModels.AzureApiDefinition, other map[str
 	return &resources, nil
 }
 
-func combineConstants(first map[string]resourcemanager.ConstantDetails, second map[string]resourcemanager.ConstantDetails) (*map[string]resourcemanager.ConstantDetails, error) {
-	constants := make(map[string]resourcemanager.ConstantDetails, 0)
+func combineConstants(first, second map[string]models.SDKConstant) (*map[string]models.SDKConstant, error) {
+	constants := make(map[string]models.SDKConstant)
 	for k, v := range first {
 		constants[k] = v
 	}

--- a/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -62,9 +63,9 @@ func TestParseResourceIdContainingAConstant(t *testing.T) {
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
 			"Example": {
-				Constants: map[string]resourcemanager.ConstantDetails{
+				Constants: map[string]models.SDKConstant{
 					"Planet": {
-						Type: resourcemanager.StringConstant,
+						Type: models.StringSDKConstantType,
 						Values: map[string]string{
 							"Earth":   "Earth",
 							"Jupiter": "Jupiter",
@@ -75,9 +76,9 @@ func TestParseResourceIdContainingAConstant(t *testing.T) {
 				},
 				ResourceIds: map[string]importerModels.ParsedResourceId{
 					"PlanetId": {
-						Constants: map[string]resourcemanager.ConstantDetails{
+						Constants: map[string]models.SDKConstant{
 							"Planet": {
-								Type: resourcemanager.StringConstant,
+								Type: models.StringSDKConstantType,
 								Values: map[string]string{
 									"Earth":   "Earth",
 									"Jupiter": "Jupiter",
@@ -649,9 +650,9 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 			ApiVersion:  "2020-01-01",
 			Resources: map[string]importerModels.AzureApiResource{
 				"Hello": {
-					Constants: map[string]resourcemanager.ConstantDetails{
+					Constants: map[string]models.SDKConstant{
 						"PlanetNames": {
-							Type: resourcemanager.StringConstant,
+							Type: models.StringSDKConstantType,
 							Values: map[string]string{
 								"Earth": "Earth",
 								"Mars":  "Mars",
@@ -666,9 +667,9 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 							},
 						},
 						"PlanetId": {
-							Constants: map[string]resourcemanager.ConstantDetails{
+							Constants: map[string]models.SDKConstant{
 								"PlanetNames": {
-									Type: resourcemanager.StringConstant,
+									Type: models.StringSDKConstantType,
 									Values: map[string]string{
 										"Earth": "Earth",
 										"Mars":  "Mars",

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdAppService) id() importerModels.ParsedResourceId {
 	name := "AppService"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_environment.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_environment.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdAppServiceEnvironment) id() importerModels.ParsedResourceId {
 	name := "AppServiceEnvironment"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_plan.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_plan.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdAppServicePlan) id() importerModels.ParsedResourceId {
 	name := "AppServicePlan"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_automation_compilation_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_automation_compilation_job.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdAutomationCompilationJob) id() importerModels.ParsedResourceId {
 	name := "AutomationCompilationJob"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_availability_set.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_availability_set.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdAvailabilitySet) id() importerModels.ParsedResourceId {
 	name := "AvailabilitySet"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (commonIdBotService) id() importerModels.ParsedResourceId {
 	name := "BotService"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service_channel.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service_channel.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,10 +17,9 @@ func (commonIdBotServiceChannel) id() importerModels.ParsedResourceId {
 	name := "BotServiceChannel"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants: map[string]resourcemanager.ConstantDetails{
+		Constants: map[string]models.SDKConstant{
 			"BotServiceChannelType": {
-				CaseInsensitive: false,
-				Type:            resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"AcsChatChannel":          "AcsChatChannel",
 					"AlexaChannel":            "AlexaChannel",

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_capability.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_capability.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (commonIdChaosStudioCapability) id() importerModels.ParsedResourceId {
 	name := "ChaosStudioCapability"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.ScopeResourceIDSegment("scope"),
 			importerModels.StaticResourceIDSegment("staticProviders", "providers"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_target.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_target.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (commonIdChaosStudioTarget) id() importerModels.ParsedResourceId {
 	name := "ChaosStudioTarget"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.ScopeResourceIDSegment("scope"),
 			importerModels.StaticResourceIDSegment("staticProviders", "providers"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_ip_configuration.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdCloudServicesIPConfiguration) id() importerModels.ParsedResource
 	name := "CloudServicesIPConfiguration"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_public_ip_address.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdCloudServicesPublicIPAddress) id() importerModels.ParsedResource
 	name := "CloudServicesPublicIPAddress"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdDedicatedHost) id() importerModels.ParsedResourceId {
 	name := "DedicatedHost"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host_group.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdDedicatedHostGroup) id() importerModels.ParsedResourceId {
 	name := "DedicatedHostGroup"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_disk_encryption_set.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_disk_encryption_set.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdDiskEncryptionSet) id() importerModels.ParsedResourceId {
 	name := "DiskEncryptionSet"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_expressroute_circuit_peering.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_expressroute_circuit_peering.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdExpressRouteCircuitPeering) id() importerModels.ParsedResourceId
 	name := "ExpressRouteCircuitPeering"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hdinsight_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hdinsight_cluster.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdHDInsightCluster) id() importerModels.ParsedResourceId {
 	name := "HDInsightCluster"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_job.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdHyperVSiteJob) id() importerModels.ParsedResourceId {
 	name := "HyperVSiteJob"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_machine.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_machine.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdHyperVSiteMachine) id() importerModels.ParsedResourceId {
 	name := "HyperVSiteMachine"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_runasaccount.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_runasaccount.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdHyperVSiteRunAsAccount) id() importerModels.ParsedResourceId {
 	name := "HyperVSiteRunAsAccount"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdKeyVault) id() importerModels.ParsedResourceId {
 	name := "KeyVault"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdKeyVaultKey) id() importerModels.ParsedResourceId {
 	name := "KeyVaultKey"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key_version.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key_version.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdKeyVaultKeyVersion) id() importerModels.ParsedResourceId {
 	name := "KeyVaultKeyVersion"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_private_endpoint_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_private_endpoint_connection.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdKeyVaultPrivateEndpointConnection) id() importerModels.ParsedRes
 	name := "KeyVaultPrivateEndpointConnection"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdKubernetesCluster) id() importerModels.ParsedResourceId {
 	name := "KubernetesCluster"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_fleet.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_fleet.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdKubernetesFleet) id() importerModels.ParsedResourceId {
 	name := "KubernetesFleet"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_cluster.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdKustoCluster) id() importerModels.ParsedResourceId {
 	name := "KustoCluster"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_database.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdKustoDatabase) id() importerModels.ParsedResourceId {
 	name := "KustoDatabase"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_managed_disk.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_managed_disk.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdManagedDisk) id() importerModels.ParsedResourceId {
 	name := "ManagedDisk"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (commonIdManagementGroupMatcher) id() importerModels.ParsedResourceId {
 	name := "ManagementGroup"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("providers", "providers"),
 			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group_test.go
@@ -6,13 +6,14 @@ package resourceids
 import (
 	"testing"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_ManagementGroup(t *testing.T) {
 	valid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("providers", "providers"),
 			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
@@ -21,7 +22,7 @@ func TestCommonResourceID_ManagementGroup(t *testing.T) {
 		},
 	}
 	invalid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("providers", "providers"),
 			importerModels.ResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdNetworkInterface) id() importerModels.ParsedResourceId {
 	name := "NetworkInterface"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface_ip_configuration.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdNetworkInterfaceIPConfiguration) id() importerModels.ParsedResou
 	name := "NetworkInterfaceIPConfiguration"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_provisioning_service_id.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_provisioning_service_id.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdProvisioningService) id() importerModels.ParsedResourceId {
 	name := "ProvisioningService"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_ip_address.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdPublicIPAddress) id() importerModels.ParsedResourceId {
 	name := "PublicIPAddress"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_p2s_vpn_gateway.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_p2s_vpn_gateway.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdP2sVPNGateway) id() importerModels.ParsedResourceId {
 	name := "P2sVPNGateway"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (commonIdResourceGroupMatcher) id() importerModels.ParsedResourceId {
 	name := "ResourceGroup"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
@@ -6,13 +6,14 @@ package resourceids
 import (
 	"testing"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_ResourceGroup(t *testing.T) {
 	valid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
@@ -21,7 +22,7 @@ func TestCommonResourceID_ResourceGroup(t *testing.T) {
 		},
 	}
 	invalid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
@@ -62,7 +63,7 @@ func TestCommonResourceID_ResourceGroup(t *testing.T) {
 func TestCommonResourceID_ResourceGroupIncorrectSegment(t *testing.T) {
 	input := []importerModels.ParsedResourceId{
 		{
-			Constants: map[string]resourcemanager.ConstantDetails{},
+			Constants: map[string]models.SDKConstant{},
 			Segments: []resourcemanager.ResourceIdSegment{
 				importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 				importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
@@ -71,7 +72,7 @@ func TestCommonResourceID_ResourceGroupIncorrectSegment(t *testing.T) {
 			},
 		},
 		{
-			Constants: map[string]resourcemanager.ConstantDetails{},
+			Constants: map[string]models.SDKConstant{},
 			Segments: []resourcemanager.ResourceIdSegment{
 				importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 				importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (commonIdScopeMatcher) id() importerModels.ParsedResourceId {
 	name := "Scope"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.ScopeResourceIDSegment("scope"),
 		},

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope_test.go
@@ -6,19 +6,20 @@ package resourceids
 import (
 	"testing"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_Scope(t *testing.T) {
 	valid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.ScopeResourceIDSegment("resourcePath"),
 		},
 	}
 	invalid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.ScopeResourceIDSegment("scope"),
 			importerModels.StaticResourceIDSegment("someResource", "someResource"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_shared_image_gallery.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_shared_image_gallery.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdSharedImageGallery) id() importerModels.ParsedResourceId {
 	name := "SharedImageGallery"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_spring_cloud_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_spring_cloud_service.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdSpringCloudService) id() importerModels.ParsedResourceId {
 	name := "SpringCloudService"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("staticSubscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_database.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdSqlDatabase) id() importerModels.ParsedResourceId {
 	name := "SqlDatabase"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_elastic_pool.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_elastic_pool.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdSqlElasticPool) id() importerModels.ParsedResourceId {
 	name := "SqlElasticPool"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdSqlManagedInstance) id() importerModels.ParsedResourceId {
 	name := "SqlManagedInstance"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance_database.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdSqlManagedInstanceDatabase) id() importerModels.ParsedResourceId
 	name := "SqlManagedInstanceDatabase"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_server.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_server.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdSqlServer) id() importerModels.ParsedResourceId {
 	name := "SqlServer"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_account.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_account.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdStorageAccount) id() importerModels.ParsedResourceId {
 	name := "StorageAccount"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_container.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_container.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdStorageContainer) id() importerModels.ParsedResourceId {
 	name := "StorageContainer"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subnet.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subnet.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdSubnet) id() importerModels.ParsedResourceId {
 	name := "Subnet"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (commonIdSubscriptionMatcher) id() importerModels.ParsedResourceId {
 	name := "Subscription"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription_test.go
@@ -6,20 +6,21 @@ package resourceids
 import (
 	"testing"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_Subscription(t *testing.T) {
 	valid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
 		},
 	}
 	invalid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (commonIdUserAssignedIdentity) id() importerModels.ParsedResourceId {
 	name := "UserAssignedIdentity"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity_test.go
@@ -6,13 +6,14 @@ package resourceids
 import (
 	"testing"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestCommonResourceID_UserAssignedIdentity(t *testing.T) {
 	valid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),
@@ -25,7 +26,7 @@ func TestCommonResourceID_UserAssignedIdentity(t *testing.T) {
 		},
 	}
 	invalid := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_hub_bgp_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_hub_bgp_connection.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVirtualHubBGPConnection) id() importerModels.ParsedResourceId {
 	name := "VirtualHubBGPConnection"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_ip_configuration.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVirtualMachineScaleSetIPConfiguration) id() importerModels.Parse
 	name := "VirtualMachineScaleSetIPConfiguration"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_network_interface.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_network_interface.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVirtualMachineScaleSetNetworkInterface) id() importerModels.Pars
 	name := "VirtualMachineScaleSetNetworkInterface"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_public_ip_address.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVirtualMachineScaleSetPublicIPAddress) id() importerModels.Parse
 	name := "VirtualMachineScaleSetPublicIPAddress"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_network.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_network.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVirtualNetwork) id() importerModels.ParsedResourceId {
 	name := "VirtualNetwork"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_router_peering.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_router_peering.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVirtualRouterPeering) id() importerModels.ParsedResourceId {
 	name := "VirtualRouterPeering"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_wan_p2s_vpn_gateway.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_wan_p2s_vpn_gateway.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVirtualWANP2SVPNGateway) id() importerModels.ParsedResourceId {
 	name := "VirtualWANP2SVPNGateway"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtualhub_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtualhub_ip_configuration.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVirtualHubIPConfiguration) id() importerModels.ParsedResourceId 
 	name := "VirtualHubIPConfiguration"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_job.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -17,7 +18,7 @@ func (c commonIdVMwareSiteJob) id() importerModels.ParsedResourceId {
 	name := "VMwareSiteJob"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_machine.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_machine.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -17,7 +18,7 @@ func (c commonIdVMwareSiteMachine) id() importerModels.ParsedResourceId {
 	name := "VMwareSiteMachine"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_runasaccount.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_runasaccount.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -17,7 +18,7 @@ func (c commonIdVMwareSiteRunAsAccount) id() importerModels.ParsedResourceId {
 	name := "VMwareSiteRunAsAccount"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vpn_gateway_vpn_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vpn_gateway_vpn_connection.go
@@ -4,6 +4,7 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -16,7 +17,7 @@ func (c commonIdVPNConnection) id() importerModels.ParsedResourceId {
 	name := "VPNConnection"
 	return importerModels.ParsedResourceId{
 		CommonAlias: &name,
-		Constants:   map[string]resourcemanager.ConstantDetails{},
+		Constants:   map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			importerModels.StaticResourceIDSegment("subscriptions", "subscriptions"),
 			importerModels.SubscriptionIDResourceIDSegment("subscriptionId"),

--- a/tools/importer-rest-api-specs/components/parser/resourceids/distinct_constants.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/distinct_constants.go
@@ -4,14 +4,14 @@
 package resourceids
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func (p *Parser) findDistinctConstants(input map[string]importerModels.ParsedResourceId) (*map[string]resourcemanager.ConstantDetails, error) {
+func (p *Parser) findDistinctConstants(input map[string]importerModels.ParsedResourceId) (*map[string]models.SDKConstant, error) {
 	intermediate := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 	}
 
 	for _, item := range input {

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 var subscriptionResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type:       resourcemanager.StaticSegment,
@@ -27,7 +28,7 @@ var subscriptionResourceId = importerModels.ParsedResourceId{
 	},
 }
 var resourceGroupResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type:       resourcemanager.StaticSegment,
@@ -50,7 +51,7 @@ var resourceGroupResourceId = importerModels.ParsedResourceId{
 	},
 }
 var managementGroupResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type:       resourcemanager.StaticSegment,
@@ -74,7 +75,7 @@ var managementGroupResourceId = importerModels.ParsedResourceId{
 	},
 }
 var virtualMachineResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type:       resourcemanager.StaticSegment,
@@ -116,7 +117,7 @@ var virtualMachineResourceId = importerModels.ParsedResourceId{
 	},
 }
 var virtualMachineExtensionResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type:       resourcemanager.StaticSegment,
@@ -167,7 +168,7 @@ var virtualMachineExtensionResourceId = importerModels.ParsedResourceId{
 	},
 }
 var virtualNetworkExtensionResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type:       resourcemanager.StaticSegment,
@@ -209,7 +210,7 @@ var virtualNetworkExtensionResourceId = importerModels.ParsedResourceId{
 	},
 }
 var scopedMonitorResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type: resourcemanager.ScopeSegment,
@@ -237,7 +238,7 @@ var scopedMonitorResourceId = importerModels.ParsedResourceId{
 	},
 }
 var signalRResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type:       resourcemanager.StaticSegment,
@@ -279,7 +280,7 @@ var signalRResourceId = importerModels.ParsedResourceId{
 	},
 }
 var eventHubSkuResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{},
+	Constants: map[string]models.SDKConstant{},
 	Segments: []resourcemanager.ResourceIdSegment{
 		{
 			Type:       resourcemanager.StaticSegment,
@@ -313,9 +314,9 @@ var eventHubSkuResourceId = importerModels.ParsedResourceId{
 	},
 }
 var trafficManagerProfileResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{
+	Constants: map[string]models.SDKConstant{
 		"EndpointType": {
-			Type: resourcemanager.StringConstant,
+			Type: models.StringSDKConstantType,
 			Values: map[string]string{
 				"AzureEndpoints":    "azureEndpoints",
 				"ExternalEndpoints": "externalEndpoints",
@@ -375,9 +376,9 @@ var trafficManagerProfileResourceId = importerModels.ParsedResourceId{
 	},
 }
 var redisPatchSchedulesResourceId = importerModels.ParsedResourceId{
-	Constants: map[string]resourcemanager.ConstantDetails{
+	Constants: map[string]models.SDKConstant{
 		"Default": {
-			Type: resourcemanager.StringConstant,
+			Type: models.StringSDKConstantType,
 			Values: map[string]string{
 				"First": "first",
 			},
@@ -596,7 +597,7 @@ func TestResourceIDNamingEventHubSkuId(t *testing.T) {
 
 func TestResourceIDNamingTopLevelScope(t *testing.T) {
 	scopeResourceId := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
 				Type: resourcemanager.ScopeSegment,
@@ -626,9 +627,9 @@ func TestResourceIDNamingTopLevelScope(t *testing.T) {
 
 func TestResourceIDNamingContainingAConstant(t *testing.T) {
 	dnsResourceId := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{
+		Constants: map[string]models.SDKConstant{
 			"DnsRecordType": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"A":    "A",
 					"AAAA": "AAAA",
@@ -697,9 +698,9 @@ func TestResourceIDNamingContainingAConstant(t *testing.T) {
 
 func TestResourceIDNamingContainingAConstantAndSuffix(t *testing.T) {
 	dnsResourceId := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{
+		Constants: map[string]models.SDKConstant{
 			"DnsRecordType": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"A":    "A",
 					"AAAA": "AAAA",
@@ -912,7 +913,7 @@ func TestResourceIdNamingConflictingWithUpdatingOperation(t *testing.T) {
 
 func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 	workerPoolInstanceResourceId := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
 				Type:       resourcemanager.StaticSegment,
@@ -972,7 +973,7 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 		},
 	}
 	multiRolePoolInstanceResourceId := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
 				Type:       resourcemanager.StaticSegment,
@@ -1033,7 +1034,7 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 		},
 	}
 	slotInstanceProcessModuleResourceId := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
 				Type:       resourcemanager.StaticSegment,
@@ -1111,7 +1112,7 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 		},
 	}
 	instanceProcessModuleResourceId := importerModels.ParsedResourceId{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Segments: []resourcemanager.ResourceIdSegment{
 			{
 				Type:       resourcemanager.StaticSegment,

--- a/tools/importer-rest-api-specs/components/parser/resourceids/models.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/models.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 type ParsedOperation struct {
@@ -34,12 +34,12 @@ type ParseResult struct {
 	NamesToResourceIDs map[string]importerModels.ParsedResourceId
 
 	// Constants is a map of Name - ConstantDetails found within the Resource IDs
-	Constants map[string]resourcemanager.ConstantDetails
+	Constants map[string]models.SDKConstant
 }
 
 func (r *ParseResult) Append(other ParseResult, logger hclog.Logger) error {
 	intermediate := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 	}
 	intermediate.AppendConstants(r.Constants)
 	intermediate.AppendConstants(other.Constants)

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/go-openapi/spec"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/constants"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
@@ -31,7 +32,7 @@ var knownSegmentsUsedForScope = []string{
 type processedResourceId struct {
 	segments  *[]resourcemanager.ResourceIdSegment
 	uriSuffix *string
-	constants map[string]resourcemanager.ConstantDetails
+	constants map[string]models.SDKConstant
 }
 
 func (p *Parser) parseSegmentsForEachOperation() (*map[string]processedResourceId, error) {
@@ -63,7 +64,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 
 	segments := make([]resourcemanager.ResourceIdSegment, 0)
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 	}
 
 	uriSegments := strings.Split(strings.TrimPrefix(uri, "/"), "/")

--- a/tools/importer-rest-api-specs/components/parser/swagger_resources.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_resources.go
@@ -13,12 +13,11 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func (d *SwaggerDefinition) parseResourcesWithinSwaggerTag(tag *string, resourceProvider *string, resourceIds resourceids.ParseResult) (*importerModels.AzureApiResource, error) {
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 
@@ -134,7 +133,7 @@ func pullOutModelForListOperations(input map[string]importerModels.OperationDeta
 
 func switchOutCustomTypesAsNeeded(input internal.ParseResult) internal.ParseResult {
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 	result.Append(input)
@@ -164,7 +163,7 @@ func switchOutCustomTypesAsNeeded(input internal.ParseResult) internal.ParseResu
 
 func (d *SwaggerDefinition) findNestedItemsYetToBeParsed(operations map[string]importerModels.OperationDetails, known internal.ParseResult) (*internal.ParseResult, error) {
 	result := internal.ParseResult{
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 		Models:    map[string]importerModels.ModelDetails{},
 	}
 	result.Append(known)

--- a/tools/importer-rest-api-specs/components/terraform/schema/build_chaos_experiment_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/build_chaos_experiment_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -15,15 +16,15 @@ func TestBuildForChaosStudioExperimentWithRealData(t *testing.T) {
 	t.Skipf("TODO: update schema gen & re-enable this test")
 	r := resourceUnderTest{Name: "chaos_studio_experiment"}
 	builder := Builder{
-		constants: map[string]resourcemanager.ConstantDetails{
+		constants: map[string]models.SDKConstant{
 			"TargetReferenceType": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"ChaosTarget": "ChaosTarget",
 				},
 			},
 			"SelectorType": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"List":    "List",
 					"Percent": "Percent",

--- a/tools/importer-rest-api-specs/components/terraform/schema/build_resource_group_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/build_resource_group_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
 func TestBuildForResourceGroupHappyPathAllModelsTheSame(t *testing.T) {
 	builder := Builder{
-		constants: map[string]resourcemanager.ConstantDetails{},
+		constants: map[string]models.SDKConstant{},
 		models: map[string]resourcemanager.ModelDetails{
 			"ResourceGroup": {
 				Fields: map[string]resourcemanager.FieldDetails{
@@ -164,7 +165,7 @@ func TestBuildForResourceGroupUsingRealData(t *testing.T) {
 	t.Skipf("TODO: update schema gen & re-enable this test")
 
 	builder := Builder{
-		constants: map[string]resourcemanager.ConstantDetails{},
+		constants: map[string]models.SDKConstant{},
 		models: map[string]resourcemanager.ModelDetails{
 			"ResourceGroup": {
 				Fields: map[string]resourcemanager.FieldDetails{

--- a/tools/importer-rest-api-specs/components/terraform/schema/build_search_service_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/build_search_service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -17,23 +18,23 @@ func TestBuildForSearchServiceUsingRealData(t *testing.T) {
 		Name: "search_service",
 	}
 	builder := Builder{
-		constants: map[string]resourcemanager.ConstantDetails{
+		constants: map[string]models.SDKConstant{
 			"AdminKeyKind": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Primary":   "primary",
 					"Secondary": "secondary",
 				},
 			},
 			"HostingMode": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Default":     "default",
 					"HighDensity": "highDensity",
 				},
 			},
 			"PrivateLinkServiceConnectionStatus": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Approved":     "Approved",
 					"Disconnected": "Disconnected",
@@ -42,7 +43,7 @@ func TestBuildForSearchServiceUsingRealData(t *testing.T) {
 				},
 			},
 			"ProvisioningState": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Failed":       "failed",
 					"Provisioning": "provisioning",
@@ -50,14 +51,14 @@ func TestBuildForSearchServiceUsingRealData(t *testing.T) {
 				},
 			},
 			"PublicNetworkAccess": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Disabled": "disabled",
 					"Enabled":  "enabled",
 				},
 			},
 			"SearchServiceStatus": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Degraded":     "degraded",
 					"Deleting":     "deleting",
@@ -68,7 +69,7 @@ func TestBuildForSearchServiceUsingRealData(t *testing.T) {
 				},
 			},
 			"SharedPrivateLinkResourceStatus": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Pending":      "Pending",
 					"Approved":     "Approved",
@@ -77,7 +78,7 @@ func TestBuildForSearchServiceUsingRealData(t *testing.T) {
 				},
 			},
 			"SkuName": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Free":                 "free",
 					"Basic":                "basic",

--- a/tools/importer-rest-api-specs/components/terraform/schema/build_servicebus_namespace_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/build_servicebus_namespace_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
@@ -15,9 +16,9 @@ func TestBuildForServiceBusNamespaceHappyPath(t *testing.T) {
 	t.Skipf("TODO: update schema gen & re-enable this test")
 	r := resourceUnderTest{Name: "service_bus_namespace"}
 	builder := Builder{
-		constants: map[string]resourcemanager.ConstantDetails{
+		constants: map[string]models.SDKConstant{
 			"SkuName": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Basic":    "Basic",
 					"Premium":  "Premium",
@@ -295,9 +296,9 @@ func TestBuildForServiceBusNamespaceUsingRealData(t *testing.T) {
 	t.Skipf("TODO: update schema gen & re-enable this test")
 	r := resourceUnderTest{Name: "service_bus_namespace"}
 	builder := Builder{
-		constants: map[string]resourcemanager.ConstantDetails{
+		constants: map[string]models.SDKConstant{
 			"EndPointProvisioningState": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Canceled":  "Canceled",
 					"Creating":  "Creating",
@@ -308,13 +309,13 @@ func TestBuildForServiceBusNamespaceUsingRealData(t *testing.T) {
 				},
 			},
 			"KeySource": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"MicrosoftPointKeyVault": "Microsoft.KeyVault",
 				},
 			},
 			"MinimumTlsVersion": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"1.0": "1.0",
 					"1.1": "1.1",
@@ -322,7 +323,7 @@ func TestBuildForServiceBusNamespaceUsingRealData(t *testing.T) {
 				},
 			},
 			"PrivateLinkConnectionStatus": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Approved":     "Approved",
 					"Disconnected": "Disconnected",
@@ -331,7 +332,7 @@ func TestBuildForServiceBusNamespaceUsingRealData(t *testing.T) {
 				},
 			},
 			"PublicNetworkAccess": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Enabled":            "Enabled",
 					"Disabled":           "Disabled",
@@ -339,7 +340,7 @@ func TestBuildForServiceBusNamespaceUsingRealData(t *testing.T) {
 				},
 			},
 			"SkuName": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Basic":    "Basic",
 					"Premium":  "Premium",
@@ -347,7 +348,7 @@ func TestBuildForServiceBusNamespaceUsingRealData(t *testing.T) {
 				},
 			},
 			"SkuTier": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"Basic":    "Basic",
 					"Premium":  "Premium",

--- a/tools/importer-rest-api-specs/components/terraform/schema/builder.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/builder.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/helpers"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/schema/processors"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
@@ -23,13 +24,13 @@ Things to do here:
 */
 
 type Builder struct {
-	constants   map[string]resourcemanager.ConstantDetails
+	constants   map[string]models.SDKConstant
 	models      map[string]resourcemanager.ModelDetails
 	operations  map[string]resourcemanager.ApiOperation
 	resourceIds map[string]resourcemanager.ResourceIdDefinition
 }
 
-func NewBuilder(constants map[string]resourcemanager.ConstantDetails, models map[string]resourcemanager.ModelDetails, operations map[string]resourcemanager.ApiOperation, resourceIds map[string]resourcemanager.ResourceIdDefinition) Builder {
+func NewBuilder(constants map[string]models.SDKConstant, models map[string]resourcemanager.ModelDetails, operations map[string]resourcemanager.ApiOperation, resourceIds map[string]resourcemanager.ResourceIdDefinition) Builder {
 	return Builder{
 		constants:   constants,
 		models:      models,

--- a/tools/importer-rest-api-specs/components/terraform/schema/helpers.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/helpers.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/helpers"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/terraform/schema/processors"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func fieldShouldBeIgnored(key string, definition resourcemanager.FieldDetails, constants map[string]resourcemanager.ConstantDetails) bool {
+func fieldShouldBeIgnored(key string, definition resourcemanager.FieldDetails, constants map[string]models.SDKConstant) bool {
 	for _, v := range fieldsWhichShouldBeIgnoredExactMatch {
 		if strings.EqualFold(key, v) {
 			return true
@@ -57,7 +58,7 @@ func getField(model resourcemanager.ModelDetails, fieldName string) (*resourcema
 	return nil, false
 }
 
-func updateFieldName(fieldName string, model *resourcemanager.ModelDetails, resource *resourcemanager.TerraformResourceDetails, constants map[string]resourcemanager.ConstantDetails, resourceBuildInfo *importerModels.ResourceBuildInfo) (string, error) {
+func updateFieldName(fieldName string, model *resourcemanager.ModelDetails, resource *resourcemanager.TerraformResourceDetails, constants map[string]models.SDKConstant, resourceBuildInfo *importerModels.ResourceBuildInfo) (string, error) {
 	metadata := processors.FieldMetadata{
 		TerraformDetails: *resource,
 		Model:            *model,

--- a/tools/importer-rest-api-specs/components/terraform/schema/object_definition.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/object_definition.go
@@ -6,6 +6,7 @@ package schema
 import (
 	"fmt"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -42,7 +43,7 @@ func (b Builder) convertToFieldObjectDefinition(modelPrefix string, input resour
 	out := resourcemanager.TerraformSchemaFieldObjectDefinition{}
 
 	var isConstant bool
-	var constant resourcemanager.ConstantDetails
+	var constant models.SDKConstant
 	if input.ReferenceName != nil {
 		reference := *input.ReferenceName
 		if constant, isConstant = b.constants[reference]; !isConstant {
@@ -50,11 +51,11 @@ func (b Builder) convertToFieldObjectDefinition(modelPrefix string, input resour
 			reference = fmt.Sprintf("%s%s", modelPrefix, reference)
 		} else {
 			switch constant.Type {
-			case resourcemanager.StringConstant:
+			case models.StringSDKConstantType:
 				out.Type = resourcemanager.TerraformSchemaFieldTypeString
-			case resourcemanager.IntegerConstant:
+			case models.IntegerSDKObjectDefinitionType:
 				out.Type = resourcemanager.TerraformSchemaFieldTypeInteger
-			case resourcemanager.FloatConstant:
+			case models.FloatSDKConstantType:
 				out.Type = resourcemanager.TerraformSchemaFieldTypeFloat
 			default:
 				return nil, fmt.Errorf("constant has unknown or unsupported type: %+v", constant.Type)

--- a/tools/importer-rest-api-specs/components/terraform/schema/processors/field_name_rename_mislabelled_resource_id_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/processors/field_name_rename_mislabelled_resource_id_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -28,9 +29,9 @@ func TestFieldNameRenameMislabelledResourceID_NotApplicable_DifferentConstantVal
 				},
 			},
 		},
-		Constants: map[string]resourcemanager.ConstantDetails{
+		Constants: map[string]models.SDKConstant{
 			"Type": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"SystemAssigned": "SystemAssigned",
 				},
@@ -68,7 +69,7 @@ func TestFieldNameRenameMislabelledResourceID_NotApplicable_SingleField(t *testi
 				},
 			},
 		},
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 	}
 	actual, err := fieldNameRenameMislabelledResourceID{}.ProcessField("ResourceId", metadata)
 	if err != nil {
@@ -101,7 +102,7 @@ func TestFieldNameRenameMislabelledResourceID_NotApplicable_MultipleFields(t *te
 				},
 			},
 		},
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 	}
 	actual, err := fieldNameRenameMislabelledResourceID{}.ProcessField("ResourceId", metadata)
 	if err != nil {
@@ -130,9 +131,9 @@ func TestFieldNameRenameMislabelledResourceID_Applicable_UsingConstant(t *testin
 				},
 			},
 		},
-		Constants: map[string]resourcemanager.ConstantDetails{
+		Constants: map[string]models.SDKConstant{
 			"Type": {
-				Type: resourcemanager.StringConstant,
+				Type: models.StringSDKConstantType,
 				Values: map[string]string{
 					"UserAssigned": "UserAssigned",
 				},
@@ -168,7 +169,7 @@ func TestFieldNameRenameMislabelledResourceID_WithAMatchingTypeFieldThatIsAStrin
 				},
 			},
 		},
-		Constants: map[string]resourcemanager.ConstantDetails{},
+		Constants: map[string]models.SDKConstant{},
 	}
 	actual, err := fieldNameRenameMislabelledResourceID{}.ProcessField("ResourceId", metadata)
 	if err != nil {

--- a/tools/importer-rest-api-specs/components/terraform/schema/processors/fields.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/processors/fields.go
@@ -4,6 +4,7 @@
 package processors
 
 import (
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
@@ -14,7 +15,7 @@ type FieldNameProcessor interface {
 type FieldMetadata struct {
 	TerraformDetails resourcemanager.TerraformResourceDetails
 	Model            resourcemanager.ModelDetails
-	Constants        map[string]resourcemanager.ConstantDetails
+	Constants        map[string]models.SDKConstant
 }
 
 var NamingRules = []FieldNameProcessor{

--- a/tools/importer-rest-api-specs/components/transformer/internal_to_dataapisdk.go
+++ b/tools/importer-rest-api-specs/components/transformer/internal_to_dataapisdk.go
@@ -65,10 +65,6 @@ func mapInternalAPIVersionTypeToDataAPISDKType(input importerModels.AzureApiDefi
 	resources := make(map[string]models.APIResource)
 
 	for apiResource, apiResourceDetails := range input.Resources {
-		constants, err := mapInternalConstantsToDataAPISDKType(apiResourceDetails.Constants)
-		if err != nil {
-			return nil, fmt.Errorf("mapping Constants for API Resource %q: %+v", apiResource, err)
-		}
 		mappedModels, err := mapInternalModelsToDataAPISDKType(apiResourceDetails.Models)
 		if err != nil {
 			return nil, fmt.Errorf("mapping Models for API Resource %q: %+v", apiResource, err)
@@ -83,7 +79,7 @@ func mapInternalAPIVersionTypeToDataAPISDKType(input importerModels.AzureApiDefi
 		}
 
 		resources[apiResource] = models.APIResource{
-			Constants:   *constants,
+			Constants:   apiResourceDetails.Constants,
 			Models:      *mappedModels,
 			Operations:  *operations,
 			ResourceIDs: *resourceIds,
@@ -96,29 +92,6 @@ func mapInternalAPIVersionTypeToDataAPISDKType(input importerModels.AzureApiDefi
 		Resources: resources,
 		Source:    models.AzureRestAPISpecsSourceDataOrigin,
 	}, nil
-}
-
-func mapInternalConstantsToDataAPISDKType(input map[string]resourcemanager.ConstantDetails) (*map[string]models.SDKConstant, error) {
-	output := make(map[string]models.SDKConstant)
-
-	for key, value := range input {
-		mappings := map[resourcemanager.ConstantType]models.SDKConstantType{
-			resourcemanager.FloatConstant:   models.FloatSDKConstantType,
-			resourcemanager.IntegerConstant: models.IntegerSDKConstantType,
-			resourcemanager.StringConstant:  models.StringSDKConstantType,
-		}
-		mappedType, ok := mappings[value.Type]
-		if !ok {
-			return nil, fmt.Errorf("internal-error: missing mapping for Constant Type %q", string(value.Type))
-		}
-
-		output[key] = models.SDKConstant{
-			Type:   mappedType,
-			Values: value.Values,
-		}
-	}
-
-	return &output, nil
 }
 
 func mapInternalModelsToDataAPISDKType(input map[string]importerModels.ModelDetails) (*map[string]models.SDKModel, error) {

--- a/tools/importer-rest-api-specs/components/transformer/models_to_api.go
+++ b/tools/importer-rest-api-specs/components/transformer/models_to_api.go
@@ -5,6 +5,7 @@ package transformer
 
 import (
 	"fmt"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
@@ -39,7 +40,7 @@ func ApiResourceFromModelResource(schema importerModels.AzureApiResource) (*serv
 	}, nil
 }
 
-func apiModelsFromModelModels(inputModels map[string]importerModels.ModelDetails, inputConstants map[string]resourcemanager.ConstantDetails) (*map[string]resourcemanager.ModelDetails, error) {
+func apiModelsFromModelModels(inputModels map[string]importerModels.ModelDetails, inputConstants map[string]models.SDKConstant) (*map[string]resourcemanager.ModelDetails, error) {
 	out := make(map[string]resourcemanager.ModelDetails)
 
 	for k, v := range inputModels {
@@ -59,7 +60,7 @@ func apiModelsFromModelModels(inputModels map[string]importerModels.ModelDetails
 	return &out, nil
 }
 
-func apiFieldsFromModelFields(input map[string]importerModels.FieldDetails, model importerModels.ModelDetails, inputConstants map[string]resourcemanager.ConstantDetails) (*map[string]resourcemanager.FieldDetails, error) {
+func apiFieldsFromModelFields(input map[string]importerModels.FieldDetails, model importerModels.ModelDetails, inputConstants map[string]models.SDKConstant) (*map[string]resourcemanager.FieldDetails, error) {
 	out := make(map[string]resourcemanager.FieldDetails)
 
 	for k, v := range input {
@@ -105,7 +106,7 @@ func apiFieldsFromModelFields(input map[string]importerModels.FieldDetails, mode
 	return &out, nil
 }
 
-func validationForConstant(input resourcemanager.ConstantDetails) *resourcemanager.FieldValidationDetails {
+func validationForConstant(input models.SDKConstant) *resourcemanager.FieldValidationDetails {
 	vals := make([]interface{}, 0)
 	for _, v := range input.Values {
 		vals = append(vals, v)

--- a/tools/importer-rest-api-specs/models/models.go
+++ b/tools/importer-rest-api-specs/models/models.go
@@ -37,7 +37,7 @@ func (d AzureApiDefinition) IsPreviewVersion() bool {
 }
 
 type AzureApiResource struct {
-	Constants   map[string]resourcemanager.ConstantDetails
+	Constants   map[string]models.SDKConstant
 	Models      map[string]ModelDetails
 	Operations  map[string]OperationDetails
 	ResourceIds map[string]ParsedResourceId

--- a/tools/importer-rest-api-specs/models/resource_ids.go
+++ b/tools/importer-rest-api-specs/models/resource_ids.go
@@ -5,6 +5,7 @@ package models
 
 import (
 	"fmt"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
@@ -16,7 +17,7 @@ type ParsedResourceId struct {
 	CommonAlias *string
 
 	// Constants are a map[Name]ConstantDetails for the Constants used in this Resource ID
-	Constants map[string]resourcemanager.ConstantDetails
+	Constants map[string]models.SDKConstant
 
 	// Segments are an ordered list of segments which comprise this Resource ID
 	Segments []resourcemanager.ResourceIdSegment

--- a/tools/importer-rest-api-specs/models/resource_ids.go
+++ b/tools/importer-rest-api-specs/models/resource_ids.go
@@ -5,9 +5,9 @@ package models
 
 import (
 	"fmt"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"strings"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 

--- a/tools/sdk/resourcemanager/api_schema.go
+++ b/tools/sdk/resourcemanager/api_schema.go
@@ -6,6 +6,8 @@ package resourcemanager
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 type ApiSchemaClient struct {
@@ -32,7 +34,7 @@ func (c ApiSchemaClient) Get(input ResourceSummary) (*ApiSchemaDetails, error) {
 type ApiSchemaDetails struct {
 	// Constants is a map of key (Constant Name) to value (ConstantDetails) describing
 	// each Constant supported by this API Version.
-	Constants map[string]ConstantDetails `json:"constants"`
+	Constants map[string]models.SDKConstant `json:"constants"`
 
 	// Models is a map of key (Model Name) to value (ModelDetails) describing
 	// each Model supported by this API version, used in either Requests or Responses
@@ -41,21 +43,6 @@ type ApiSchemaDetails struct {
 	// ResourceIds is a map of key (Resource Name) to value (Resource ID Definitions)
 	// used by this API
 	ResourceIds map[string]ResourceIdDefinition `json:"resourceIds"`
-}
-
-type ConstantDetails struct {
-	// CaseInsensitive specifies that this Constant can be returned insensitively
-	// and should be rewritten on the Client side to be consistent
-	CaseInsensitive bool `json:"caseInsensitive"`
-
-	// Type specifies the backing type for this constant, whilst the name will
-	// always be a String, the backing values can be a Float/Integer/String
-	// albeit returned as a string to maintain formatting.
-	Type ConstantType `json:"type"`
-
-	// Values specifies a key (Display Name) to value (Constant Value) for the
-	// possible values for this Constant
-	Values map[string]string `json:"values"`
 }
 
 type ModelDetails struct {
@@ -119,14 +106,6 @@ type FieldDetails struct {
 	// Description is a description of the field
 	Description string `json:"description"`
 }
-
-type ConstantType string
-
-const (
-	FloatConstant   ConstantType = "float"
-	IntegerConstant ConstantType = "int"
-	StringConstant  ConstantType = "string"
-)
 
 type DateFormat string
 


### PR DESCRIPTION
This PR updates `importer-rest-api-specs` to use the `SDKConstant` type from the Data API SDK in place of the existing `ConstantDetails` struct from the legacy SDK.