### PR TITLE
`tools/importer-rest-api-specs`: temporarily disabling the `ReadOnly` and `Sensitive` field values

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_devcenter_26189.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_devcenter_26189.go
@@ -34,6 +34,8 @@ func (workaroundDevCenter26189) Name() string {
 }
 
 func (workaroundDevCenter26189) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
+	// TODO: investigate removing this now the upstream PR has been merged
+
 	// First we need to patch the DevCenters issue (marking DevCenterUri as required)
 	devCentersResource, ok := apiDefinition.Resources["DevCenters"]
 	if !ok {
@@ -48,7 +50,9 @@ func (workaroundDevCenter26189) Process(apiDefinition importerModels.AzureApiDef
 	if !ok {
 		return nil, fmt.Errorf("expected a Field named `DevCenterUri` but didn't get one")
 	}
-	devCenterField.ReadOnly = true
+
+	// TODO: re-enable readonly/sensitive
+	//devCenterField.ReadOnly = true
 
 	devCenterModel.Fields["DevCenterUri"] = devCenterField
 	devCentersResource.Models["DevCenterProperties"] = devCenterModel
@@ -75,7 +79,9 @@ func (workaroundDevCenter26189) Process(apiDefinition importerModels.AzureApiDef
 	if !ok {
 		return nil, fmt.Errorf("expected a Field named `DevCenterUri` but didn't get one")
 	}
-	projectDevCenterUriField.ReadOnly = true
+	// TODO: re-enable readonly/sensitive
+	//projectDevCenterUriField.ReadOnly = true
+	projectDevCenterUriField.Required = false
 	projectModel.Fields["DevCenterUri"] = projectDevCenterUriField
 
 	projectsResource.Models["ProjectProperties"] = projectModel

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_recoveryservicessiterecovery_26680.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_recoveryservicessiterecovery_26680.go
@@ -73,9 +73,10 @@ func (w workaroundRecoveryServicesSiteRecovery26680) Process(apiDefinition impor
 		return nil, fmt.Errorf("expected a Model named `CertificateRequest` but didn't get one")
 	}
 	model.Fields["CertificateCreateOptions"] = importerModels.FieldDetails{
-		Required:    false,
-		ReadOnly:    false,
-		Sensitive:   false,
+		Required: false,
+		// TODO: re-enable readonly/sensitive
+		//ReadOnly:    false,
+		//Sensitive:   false,
 		JsonName:    "certificateCreateOptions",
 		Description: "",
 		ObjectDefinition: models.SDKObjectDefinition{

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_redis_22407.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_redis_22407.go
@@ -27,9 +27,10 @@ func (w workaroundRedis22407) Process(apiDefinition importerModels.AzureApiDefin
 
 			if _, ok := model.Fields["NotifyKeyspaceEvents"]; !ok {
 				model.Fields["NotifyKeyspaceEvents"] = importerModels.FieldDetails{
-					Required:    false,
-					ReadOnly:    false,
-					Sensitive:   false,
+					Required: false,
+					// TODO: re-enable readonly/sensitive
+					//ReadOnly:    false,
+					//Sensitive:   false,
 					JsonName:    "notify-keyspace-events",
 					Description: "The KeySpace Events which should be monitored.",
 					ObjectDefinition: models.SDKObjectDefinition{

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -71,15 +71,17 @@ func validateParsedFieldsMatch(t *testing.T, expected importerModels.FieldDetail
 	if expected.JsonName != actual.JsonName {
 		t.Fatalf("expected `JsonName` to be %q but got %q for Field %q", expected.JsonName, actual.JsonName, fieldName)
 	}
-	if expected.ReadOnly != actual.ReadOnly {
-		t.Fatalf("expected `ReadOnly` to be %t but got %t for Field %q", expected.ReadOnly, actual.ReadOnly, fieldName)
-	}
+	// TODO: re-enable readonly/sensitive
+	//if expected.ReadOnly != actual.ReadOnly {
+	//	t.Fatalf("expected `ReadOnly` to be %t but got %t for Field %q", expected.ReadOnly, actual.ReadOnly, fieldName)
+	//}
 	if expected.Required != actual.Required {
 		t.Fatalf("expected `Required` to be %t but got %t for Field %q", expected.Required, actual.Required, fieldName)
 	}
-	if expected.Sensitive != actual.Sensitive {
-		t.Fatalf("expected `Sensitive` to be %t but got %t for Field %q", expected.Sensitive, actual.Sensitive, fieldName)
-	}
+	// TODO: re-enable readonly/sensitive
+	//if expected.Sensitive != actual.Sensitive {
+	//	t.Fatalf("expected `Sensitive` to be %t but got %t for Field %q", expected.Sensitive, actual.Sensitive, fieldName)
+	//}
 
 	validateParsedObjectDefinitionsMatch(t, expected.ObjectDefinition, actual.ObjectDefinition, fieldName)
 }

--- a/tools/importer-rest-api-specs/components/parser/internal/structs.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/structs.go
@@ -100,9 +100,10 @@ func compareFields(first map[string]importerModels.FieldDetails, second map[stri
 		if firstVal.Required != secondVal.Required {
 			return fmt.Errorf("first.Required was %t but second.Required was %t", firstVal.Required, secondVal.Required)
 		}
-		if firstVal.Sensitive != secondVal.Sensitive {
-			return fmt.Errorf("first.Sensitive was %t but second.Sensitive was %t", firstVal.Sensitive, secondVal.Sensitive)
-		}
+		// TODO: re-enable readonly/sensitive
+		//if firstVal.Sensitive != secondVal.Sensitive {
+		//	return fmt.Errorf("first.Sensitive was %t but second.Sensitive was %t", firstVal.Sensitive, secondVal.Sensitive)
+		//}
 		if err := objectDefinitionsMatch(firstVal.ObjectDefinition, secondVal.ObjectDefinition); err != nil {
 			return fmt.Errorf("object definitions differ: %+v.\n\nFirst %q\n\nSecond %q", err, firstVal.ObjectDefinition, secondVal.ObjectDefinition)
 		}

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -141,9 +141,10 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 	result.Append(known)
 
 	field := importerModels.FieldDetails{
-		Required:    isRequired,
-		ReadOnly:    value.ReadOnly, // TODO: generator should handle this in some manner?
-		Sensitive:   false,          // todo: this probably needs to be a predefined list, unless there's something we can parse
+		Required: isRequired,
+		// TODO: re-enable readonly/sensitive
+		//ReadOnly:    value.ReadOnly,
+		//Sensitive:   false,          // todo: this probably needs to be a predefined list, unless there's something we can parse
 		JsonName:    propertyName,
 		Description: value.Description,
 	}

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -334,7 +334,8 @@ func TestParseModelWithInlinedObject(t *testing.T) {
 								ObjectDefinition: models.SDKObjectDefinition{
 									Type: models.StringSDKObjectDefinitionType,
 								},
-								ReadOnly: true,
+								// TODO: re-enable readonly/sensitive
+								//ReadOnly: true,
 								Required: false,
 							},
 							"PrincipalId": {
@@ -342,7 +343,8 @@ func TestParseModelWithInlinedObject(t *testing.T) {
 								ObjectDefinition: models.SDKObjectDefinition{
 									Type: models.StringSDKObjectDefinitionType,
 								},
-								ReadOnly: true,
+								// TODO: re-enable readonly/sensitive
+								//ReadOnly: true,
 								Required: false,
 							},
 						},
@@ -1641,7 +1643,8 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 								ObjectDefinition: models.SDKObjectDefinition{
 									Type: models.StringSDKObjectDefinitionType,
 								},
-								ReadOnly: true,
+								// TODO: re-enable readonly/sensitive
+								//ReadOnly: true,
 								Required: false,
 							},
 							"RoleName": {
@@ -1649,7 +1652,8 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 								ObjectDefinition: models.SDKObjectDefinition{
 									Type: models.StringSDKObjectDefinitionType,
 								},
-								ReadOnly: true,
+								// TODO: re-enable readonly/sensitive
+								//ReadOnly: true,
 								Required: false,
 							},
 						},
@@ -1695,7 +1699,8 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 								ObjectDefinition: models.SDKObjectDefinition{
 									Type: models.StringSDKObjectDefinitionType,
 								},
-								ReadOnly: true,
+								// TODO: re-enable readonly/sensitive
+								//ReadOnly: true,
 								Required: false,
 							},
 							"UserRoleAssignments": {

--- a/tools/importer-rest-api-specs/components/transformer/models_to_api.go
+++ b/tools/importer-rest-api-specs/components/transformer/models_to_api.go
@@ -67,10 +67,11 @@ func apiFieldsFromModelFields(input map[string]importerModels.FieldDetails, mode
 			Description: v.Description,
 		}
 
-		if v.ReadOnly {
-			details.Required = false
-			details.Optional = false
-		}
+		// TODO: re-enable readonly/sensitive
+		//if v.ReadOnly {
+		//	details.Required = false
+		//	details.Optional = false
+		//}
 
 		if details.ObjectDefinition.Type == models.DateTimeSDKObjectDefinitionType {
 			dateFormat := resourcemanager.RFC3339

--- a/tools/importer-rest-api-specs/models/models.go
+++ b/tools/importer-rest-api-specs/models/models.go
@@ -62,8 +62,6 @@ type ModelDetails struct {
 
 type FieldDetails struct {
 	Required    bool
-	ReadOnly    bool
-	Sensitive   bool
 	JsonName    string
 	Description string
 


### PR DESCRIPTION
These aren't current used but are threaded through in a few places (and should be being used) - so for now I've opted to comment these out with the TODO used as a reference for the issue (which'll be coming when the refactoring is completed)

This enables us to switch out usages of `importerModels.FieldDetails` for `SDKField` far more easily - and then re-enable this once support has been added.