### PR TITLE
`tools/importer-rest-api-specs`: fixing an issue where the Resource Name would be output rather than the API Resource

### DIFF
--- a/tools/importer-rest-api-specs/components/dataapigeneratorjson/transforms/terraform_resource_definition.go
+++ b/tools/importer-rest-api-specs/components/dataapigeneratorjson/transforms/terraform_resource_definition.go
@@ -27,7 +27,7 @@ func MapTerraformResourceDefinitionToRepository(resourceLabel string, input mode
 		GenerateSchema:               input.GenerateSchema,
 		Label:                        resourceLabel,
 		ReadMethod:                   mapTerraformMethodDefinitionToRepository(input.ReadMethod),
-		Resource:                     input.ResourceName,
+		Resource:                     input.APIResource,
 		ResourceIdName:               input.ResourceIDName,
 		// todo remove Schema when https://github.com/hashicorp/pandora/issues/3346 is addressed
 		SchemaModelName: fmt.Sprintf("%sSchema", input.SchemaModelName),


### PR DESCRIPTION
There's also an eventual consistency issue where the Resource IDs are flapping based on the name of the UserSpecifiedSegment differing - I've reviewed https://github.com/hashicorp/pandora/pull/3860 but I don't see anything obvious in that - however given there's several PRs in flight, I think it's worth merging those and then investigating this one.
