### PR TITLE
`tools/importer-rest-api-specs`: ensuring the Example Value is updated when the Segments are updated

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
@@ -5,6 +5,7 @@ package dataworkarounds
 
 import (
 	"fmt"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
@@ -51,6 +52,7 @@ func (workaroundInconsistentlyDefinedSegments) Process(apiDefinition importerMod
 				segments = append(segments, val)
 			}
 			id.Segments = segments
+			id.ExampleValue = helpers.DisplayValueForResourceID(id)
 			ids[key] = id
 		}
 		resource.ResourceIds = ids

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
@@ -5,9 +5,9 @@ package dataworkarounds
 
 import (
 	"fmt"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
 	"strings"
 
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"

--- a/tools/importer-rest-api-specs/components/parser/resourceids/distinct_resource_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/distinct_resource_ids.go
@@ -42,6 +42,7 @@ func (p *Parser) distinctResourceIds(input map[string]processedResourceId) ([]mo
 		for _, existing := range out {
 			if ResourceIdsMatch(item, existing) {
 				matchFound = true
+				break
 			}
 		}
 		if !matchFound {


### PR DESCRIPTION
This fixes a regression where the Example Value would flip based on the order the Resource IDs were updated in