### PR TITLE
`tools/importer-rest-api-specs`: temporary disabling the Common ID for Kubernetes Fleet

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -85,7 +85,7 @@ var commonIdTypes = []commonIdMatcher{
 
 	// Kubernetes
 	commonIdKubernetesCluster{},
-	commonIdKubernetesFleet{},
+	//commonIdKubernetesFleet{},
 
 	// SQL
 	commonIdSqlDatabase{},

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -72,6 +72,7 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdDedicatedHostGroup{},
 	commonIdDiskEncryptionSet{},
 	commonIdManagedDisk{},
+	commonIdSharedImageGallery{},
 
 	// HDInsight
 	commonIdHDInsightCluster{},
@@ -83,6 +84,7 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdKeyVaultPrivateEndpointConnection{},
 
 	// Kubernetes
+	commonIdKubernetesCluster{},
 	commonIdKubernetesFleet{},
 
 	// SQL
@@ -103,12 +105,6 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdAppService{},
 	commonIdAppServiceEnvironment{},
 	commonIdAppServicePlan{},
-
-	// Parent IDs
-	commonIdKubernetesCluster{},
-
-	// Shared Image Gallery
-	commonIdSharedImageGallery{},
 }
 
 func switchOutCommonResourceIDsAsNeeded(input []models.ResourceID) []models.ResourceID {


### PR DESCRIPTION
Whilst this should be enabled, it's hindering fixing the pipeline for the moment - so this PR temporarily disables this until everything is clean. Once thats done, we can update `hashicorp/terraform-provider-azurerm` to account for it.