### PR TITLE
`tools/importer-rest-api-specs`: disabling ReadOnly for now

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
@@ -1,0 +1,61 @@
+package dataworkarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundTempReadOnlyFields{}
+
+type workaroundTempReadOnlyFields struct {
+}
+
+func (w workaroundTempReadOnlyFields) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	return apiDefinition.ServiceName == "ManagedIdentity" && apiDefinition.ApiVersion == "2023-01-31"
+}
+
+func (w workaroundTempReadOnlyFields) Name() string {
+	return "Temp - Mark readonly fields as readonly"
+}
+
+func (w workaroundTempReadOnlyFields) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	resource, ok := apiDefinition.Resources["ManagedIdentities"]
+	if !ok {
+		return nil, fmt.Errorf("expected an APIResource `ManagedIdentities` but didn't get one")
+	}
+
+	model, ok := resource.Models["UserAssignedIdentityProperties"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Model `UserAssignedIdentityProperties` but didn't get one")
+	}
+
+	clientId, ok := model.Fields["ClientId"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Field `ClientId` but didn't get one")
+	}
+	clientId.Optional = true
+	clientId.ReadOnly = true
+	model.Fields["ClientId"] = clientId
+
+	principalId, ok := model.Fields["PrincipalId"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Field `PrincipalId` but didn't get one")
+	}
+	principalId.Optional = true
+	principalId.ReadOnly = true
+	model.Fields["PrincipalId"] = principalId
+
+	tenantId, ok := model.Fields["TenantId"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Field `TenantId` but didn't get one")
+	}
+	tenantId.Optional = true
+	tenantId.ReadOnly = true
+	model.Fields["TenantId"] = tenantId
+
+	resource.Models["UserAssignedIdentityProperties"] = model
+
+	apiDefinition.Resources["ManagedIdentities"] = resource
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -31,6 +31,7 @@ var workarounds = []workaround{
 
 	// These workarounds relate to Terraform specific overrides we want to apply (for example for Resource Generation)
 	workaroundDevCenterIdToRequired{},
+	workaroundTempReadOnlyFields{},
 
 	// These workarounds relate to data inconsistencies
 	workaroundInconsistentlyDefinedSegments{},

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -71,9 +71,10 @@ func validateParsedSDKFieldsMatch(t *testing.T, expected, actual models.SDKField
 	if expected.JsonName != actual.JsonName {
 		t.Fatalf("expected `JsonName` to be %q but got %q for Field %q", expected.JsonName, actual.JsonName, fieldName)
 	}
-	if expected.ReadOnly != actual.ReadOnly {
-		t.Fatalf("expected `ReadOnly` to be %t but got %t for Field %q", expected.ReadOnly, actual.ReadOnly, fieldName)
-	}
+	// TODO: @tombuildsstuff: reenable readonly support
+	//if expected.ReadOnly != actual.ReadOnly {
+	//	t.Fatalf("expected `ReadOnly` to be %t but got %t for Field %q", expected.ReadOnly, actual.ReadOnly, fieldName)
+	//}
 	if expected.Required != actual.Required {
 		t.Fatalf("expected `Required` to be %t but got %t for Field %q", expected.Required, actual.Required, fieldName)
 	}

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -141,9 +141,9 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 
 	field := models.SDKField{
 		Required:    isRequired,
-		Optional:    !isRequired && !value.ReadOnly,
-		ReadOnly:    value.ReadOnly,
-		Sensitive:   false, // todo: this probably needs to be a predefined list, unless there's something we can parse
+		Optional:    !isRequired, //TODO: re-enable readonly && !value.ReadOnly,
+		ReadOnly:    false,       // TODO: re-enable readonly value.ReadOnly,
+		Sensitive:   false,       // todo: this probably needs to be a predefined list, unless there's something we can parse
 		JsonName:    propertyName,
 		Description: value.Description,
 	}


### PR DESCRIPTION
This PR disables `ReadOnly` for now due to issues with the Swagger Parser not correctly identifying these when a model comes from a separate file - but hardcodes this for the User Assigned Identity resource to keep the Terraform Generator happy.

We'll come back and address this/open an issue for this in a bit.