### PR TITLE
`tools/importer-rest-api-specs`: flagging fields that are expected to be Computed in the Terraform Schema to be ReadOnly for now

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
@@ -12,7 +12,15 @@ type workaroundTempReadOnlyFields struct {
 }
 
 func (w workaroundTempReadOnlyFields) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
-	return apiDefinition.ServiceName == "ManagedIdentity" && apiDefinition.ApiVersion == "2023-01-31"
+	if apiDefinition.ServiceName == "DevCenter" && apiDefinition.ApiVersion == "2023-04-01" {
+		return true
+	}
+
+	if apiDefinition.ServiceName == "ManagedIdentity" && apiDefinition.ApiVersion == "2023-01-31" {
+		return true
+	}
+
+	return false
 }
 
 func (w workaroundTempReadOnlyFields) Name() string {
@@ -20,42 +28,68 @@ func (w workaroundTempReadOnlyFields) Name() string {
 }
 
 func (w workaroundTempReadOnlyFields) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
-	resource, ok := apiDefinition.Resources["ManagedIdentities"]
-	if !ok {
-		return nil, fmt.Errorf("expected an APIResource `ManagedIdentities` but didn't get one")
+	if apiDefinition.ServiceName == "DevCenter" && apiDefinition.ApiVersion == "2023-04-01" {
+		resource, ok := apiDefinition.Resources["Projects"]
+		if !ok {
+			return nil, fmt.Errorf("expected an APIResource `Projects` but didn't get one")
+		}
+		model, ok := resource.Models["ProjectProperties"]
+		if !ok {
+			return nil, fmt.Errorf("expected a Model `ProjectProperties` but didn't get one")
+		}
+		devCenterUri, ok := model.Fields["DevCenterUri"]
+		if !ok {
+			return nil, fmt.Errorf("expected a Field `DevCenterUri` but didn't get one")
+		}
+		devCenterUri.Optional = false
+		devCenterUri.ReadOnly = true
+		devCenterUri.Required = false
+		model.Fields["DevCenterUri"] = devCenterUri
+
+		resource.Models["ProjectProperties"] = model
+		apiDefinition.Resources["Projects"] = resource
+		return &apiDefinition, nil
 	}
 
-	model, ok := resource.Models["UserAssignedIdentityProperties"]
-	if !ok {
-		return nil, fmt.Errorf("expected a Model `UserAssignedIdentityProperties` but didn't get one")
+	if apiDefinition.ServiceName == "ManagedIdentity" && apiDefinition.ApiVersion == "2023-01-31" {
+		resource, ok := apiDefinition.Resources["ManagedIdentities"]
+		if !ok {
+			return nil, fmt.Errorf("expected an APIResource `ManagedIdentities` but didn't get one")
+		}
+
+		model, ok := resource.Models["UserAssignedIdentityProperties"]
+		if !ok {
+			return nil, fmt.Errorf("expected a Model `UserAssignedIdentityProperties` but didn't get one")
+		}
+
+		clientId, ok := model.Fields["ClientId"]
+		if !ok {
+			return nil, fmt.Errorf("expected a Field `ClientId` but didn't get one")
+		}
+		clientId.Optional = true
+		clientId.ReadOnly = true
+		model.Fields["ClientId"] = clientId
+
+		principalId, ok := model.Fields["PrincipalId"]
+		if !ok {
+			return nil, fmt.Errorf("expected a Field `PrincipalId` but didn't get one")
+		}
+		principalId.Optional = true
+		principalId.ReadOnly = true
+		model.Fields["PrincipalId"] = principalId
+
+		tenantId, ok := model.Fields["TenantId"]
+		if !ok {
+			return nil, fmt.Errorf("expected a Field `TenantId` but didn't get one")
+		}
+		tenantId.Optional = true
+		tenantId.ReadOnly = true
+		model.Fields["TenantId"] = tenantId
+
+		resource.Models["UserAssignedIdentityProperties"] = model
+		apiDefinition.Resources["ManagedIdentities"] = resource
+		return &apiDefinition, nil
 	}
 
-	clientId, ok := model.Fields["ClientId"]
-	if !ok {
-		return nil, fmt.Errorf("expected a Field `ClientId` but didn't get one")
-	}
-	clientId.Optional = true
-	clientId.ReadOnly = true
-	model.Fields["ClientId"] = clientId
-
-	principalId, ok := model.Fields["PrincipalId"]
-	if !ok {
-		return nil, fmt.Errorf("expected a Field `PrincipalId` but didn't get one")
-	}
-	principalId.Optional = true
-	principalId.ReadOnly = true
-	model.Fields["PrincipalId"] = principalId
-
-	tenantId, ok := model.Fields["TenantId"]
-	if !ok {
-		return nil, fmt.Errorf("expected a Field `TenantId` but didn't get one")
-	}
-	tenantId.Optional = true
-	tenantId.ReadOnly = true
-	model.Fields["TenantId"] = tenantId
-
-	resource.Models["UserAssignedIdentityProperties"] = model
-
-	apiDefinition.Resources["ManagedIdentities"] = resource
-	return &apiDefinition, nil
+	return nil, fmt.Errorf("unexpected Service %q / API Version %q", apiDefinition.ServiceName, apiDefinition.ApiVersion)
 }

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
@@ -29,67 +29,61 @@ func (w workaroundTempReadOnlyFields) Name() string {
 
 func (w workaroundTempReadOnlyFields) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
 	if apiDefinition.ServiceName == "DevCenter" && apiDefinition.ApiVersion == "2023-04-01" {
-		resource, ok := apiDefinition.Resources["Projects"]
-		if !ok {
-			return nil, fmt.Errorf("expected an APIResource `Projects` but didn't get one")
+		definition, err := w.markFieldAsComputed(apiDefinition, "Projects", "ProjectProperties", "DevCenterUri")
+		if err != nil {
+			return nil, err
 		}
-		model, ok := resource.Models["ProjectProperties"]
-		if !ok {
-			return nil, fmt.Errorf("expected a Model `ProjectProperties` but didn't get one")
-		}
-		devCenterUri, ok := model.Fields["DevCenterUri"]
-		if !ok {
-			return nil, fmt.Errorf("expected a Field `DevCenterUri` but didn't get one")
-		}
-		devCenterUri.Optional = false
-		devCenterUri.ReadOnly = true
-		devCenterUri.Required = false
-		model.Fields["DevCenterUri"] = devCenterUri
 
-		resource.Models["ProjectProperties"] = model
-		apiDefinition.Resources["Projects"] = resource
-		return &apiDefinition, nil
+		definition, err = w.markFieldAsComputed(*definition, "DevCenters", "DevCenterProperties", "DevCenterUri")
+		if err != nil {
+			return nil, err
+		}
+
+		return definition, nil
 	}
 
 	if apiDefinition.ServiceName == "ManagedIdentity" && apiDefinition.ApiVersion == "2023-01-31" {
-		resource, ok := apiDefinition.Resources["ManagedIdentities"]
-		if !ok {
-			return nil, fmt.Errorf("expected an APIResource `ManagedIdentities` but didn't get one")
+		definition, err := w.markFieldAsComputed(apiDefinition, "ManagedIdentities", "UserAssignedIdentityProperties", "ClientId")
+		if err != nil {
+			return nil, err
 		}
 
-		model, ok := resource.Models["UserAssignedIdentityProperties"]
-		if !ok {
-			return nil, fmt.Errorf("expected a Model `UserAssignedIdentityProperties` but didn't get one")
+		definition, err = w.markFieldAsComputed(*definition, "ManagedIdentities", "UserAssignedIdentityProperties", "PrincipalId")
+		if err != nil {
+			return nil, err
 		}
 
-		clientId, ok := model.Fields["ClientId"]
-		if !ok {
-			return nil, fmt.Errorf("expected a Field `ClientId` but didn't get one")
+		definition, err = w.markFieldAsComputed(*definition, "ManagedIdentities", "UserAssignedIdentityProperties", "TenantId")
+		if err != nil {
+			return nil, err
 		}
-		clientId.Optional = true
-		clientId.ReadOnly = true
-		model.Fields["ClientId"] = clientId
 
-		principalId, ok := model.Fields["PrincipalId"]
-		if !ok {
-			return nil, fmt.Errorf("expected a Field `PrincipalId` but didn't get one")
-		}
-		principalId.Optional = true
-		principalId.ReadOnly = true
-		model.Fields["PrincipalId"] = principalId
-
-		tenantId, ok := model.Fields["TenantId"]
-		if !ok {
-			return nil, fmt.Errorf("expected a Field `TenantId` but didn't get one")
-		}
-		tenantId.Optional = true
-		tenantId.ReadOnly = true
-		model.Fields["TenantId"] = tenantId
-
-		resource.Models["UserAssignedIdentityProperties"] = model
-		apiDefinition.Resources["ManagedIdentities"] = resource
-		return &apiDefinition, nil
+		return definition, nil
 	}
 
 	return nil, fmt.Errorf("unexpected Service %q / API Version %q", apiDefinition.ServiceName, apiDefinition.ApiVersion)
+}
+
+func (w workaroundTempReadOnlyFields) markFieldAsComputed(input models.AzureApiDefinition, apiResourceName, modelName, fieldName string) (*models.AzureApiDefinition, error) {
+	resource, ok := input.Resources[apiResourceName]
+	if !ok {
+		return nil, fmt.Errorf("expected an APIResource %q but didn't get one", apiResourceName)
+	}
+	model, ok := resource.Models[modelName]
+	if !ok {
+		return nil, fmt.Errorf("expected a Model %q but didn't get one", modelName)
+	}
+	field, ok := model.Fields[fieldName]
+	if !ok {
+		return nil, fmt.Errorf("expected a Field %q but didn't get one", fieldName)
+	}
+	field.Optional = false
+	field.ReadOnly = true
+	field.Required = false
+	field.Sensitive = false
+	model.Fields[fieldName] = field
+
+	resource.Models[modelName] = model
+	input.Resources[apiResourceName] = resource
+	return &input, nil
 }

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
@@ -16,6 +16,10 @@ func (w workaroundTempReadOnlyFields) IsApplicable(apiDefinition *models.AzureAp
 		return true
 	}
 
+	if apiDefinition.ServiceName == "LoadTestService" && apiDefinition.ApiVersion == "2022-12-01" {
+		return true
+	}
+
 	if apiDefinition.ServiceName == "ManagedIdentity" && apiDefinition.ApiVersion == "2023-01-31" {
 		return true
 	}
@@ -35,6 +39,15 @@ func (w workaroundTempReadOnlyFields) Process(apiDefinition models.AzureApiDefin
 		}
 
 		definition, err = w.markFieldAsComputed(*definition, "DevCenters", "DevCenterProperties", "DevCenterUri")
+		if err != nil {
+			return nil, err
+		}
+
+		return definition, nil
+	}
+
+	if apiDefinition.ServiceName == "LoadTestService" && apiDefinition.ApiVersion == "2022-12-01" {
+		definition, err := w.markFieldAsComputed(apiDefinition, "LoadTests", "LoadTestProperties", "DataPlaneURI")
 		if err != nil {
 			return nil, err
 		}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
@@ -12,6 +12,10 @@ type workaroundTempReadOnlyFields struct {
 }
 
 func (w workaroundTempReadOnlyFields) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+	if apiDefinition.ServiceName == "ContainerService" && apiDefinition.ApiVersion == "2022-09-02-preview" {
+		return true
+	}
+
 	if apiDefinition.ServiceName == "DevCenter" && apiDefinition.ApiVersion == "2023-04-01" {
 		return true
 	}
@@ -32,6 +36,20 @@ func (w workaroundTempReadOnlyFields) Name() string {
 }
 
 func (w workaroundTempReadOnlyFields) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+	if apiDefinition.ServiceName == "ContainerService" && apiDefinition.ApiVersion == "2022-09-02-preview" {
+		definition, err := w.markFieldAsComputed(apiDefinition, "Fleets", "FleetHubProfile", "Fqdn")
+		if err != nil {
+			return nil, err
+		}
+
+		definition, err = w.markFieldAsComputed(*definition, "Fleets", "FleetHubProfile", "KubernetesVersion")
+		if err != nil {
+			return nil, err
+		}
+
+		return definition, nil
+	}
+
 	if apiDefinition.ServiceName == "DevCenter" && apiDefinition.ApiVersion == "2023-04-01" {
 		definition, err := w.markFieldAsComputed(apiDefinition, "Projects", "ProjectProperties", "DevCenterUri")
 		if err != nil {


### PR DESCRIPTION
This PR works around an issue described in https://github.com/hashicorp/pandora/issues/3895 where due to an issue when parsing the Swaggers the `ReadOnly` information is inconsistent - meaning that currently when generating Terraform Resources, an issue exists where fields that should be marked as Computed aren't being picked up as such - the results can be seen in https://github.com/hashicorp/terraform-provider-azurerm/pull/25052.

This issue stems from the fact that we now explicitly differentiate values which are `ReadOnly` from those which aren't, since we're now canonically using the `SDKModel` type throughout - meaning that when generating the Terraform Schema for the specified resource we're using the SDKField's `ReadOnly` property to indicate that the associated Terraform Schema Field should be marked as `Computed`.

Since the root cause of this issue is an issue when parsing the Swagger definitions - this PR intentionally applies a Data Workaround rather than attempting to patch this within the Terraform side of things - which isn't ideal, but _feels_ like the right place to apply this since we'll need to look into #3895 once the refactoring is completed.

Ultimately this PR means that the changes from https://github.com/hashicorp/terraform-provider-azurerm/pull/25052 become a noop - which'll fix the Terraform Generator.

---

Changes as a result of this diff:

```diff
diff --git a/api-definitions/resource-manager/ContainerService/2022-09-02-preview/Fleets/Model-FleetHubProfile.json b/api-definitions/resource-manager/ContainerService/2022-09-02-preview/Fleets/Model-FleetHubProfile.json
index 34977bf444..50fd861647 100644
--- a/api-definitions/resource-manager/ContainerService/2022-09-02-preview/Fleets/Model-FleetHubProfile.json
+++ b/api-definitions/resource-manager/ContainerService/2022-09-02-preview/Fleets/Model-FleetHubProfile.json
@@ -22,8 +22,8 @@
         "type": "String",
         "referenceName": null
       },
-      "optional": true,
-      "readOnly": false,
+      "optional": false,
+      "readOnly": true,
       "required": false,
       "sensitive": false
     },
@@ -35,8 +35,8 @@
         "type": "String",
         "referenceName": null
       },
-      "optional": true,
-      "readOnly": false,
+      "optional": false,
+      "readOnly": true,
       "required": false,
       "sensitive": false
     }
diff --git a/api-definitions/resource-manager/ContainerService/Terraform/KubernetesFleetManager-Resource-Schema-FleetHubProfile.json b/api-definitions/resource-manager/ContainerService/Terraform/KubernetesFleetManager-Resource-Schema-FleetHubProfile.json
index b51ff56bc1..69bc393e7c 100644
--- a/api-definitions/resource-manager/ContainerService/Terraform/KubernetesFleetManager-Resource-Schema-FleetHubProfile.json
+++ b/api-definitions/resource-manager/ContainerService/Terraform/KubernetesFleetManager-Resource-Schema-FleetHubProfile.json
@@ -10,8 +10,8 @@
       "required": true
     },
     {
+      "computed": true,
       "hclName": "fqdn",
-      "optional": true,
       "name": "Fqdn",
       "objectDefinition": {
         "referenceName": null,
@@ -19,8 +19,8 @@
       }
     },
     {
+      "computed": true,
       "hclName": "kubernetes_version",
-      "optional": true,
       "name": "KubernetesVersion",
       "objectDefinition": {
         "referenceName": null,
diff --git a/api-definitions/resource-manager/ContainerService/Terraform/Tests/KubernetesFleetManager-Resource-Complete-Test.hcl b/api-definitions/resource-manager/ContainerService/Terraform/Tests/KubernetesFleetManager-Resource-Complete-Test.hcl
index 88f2913f0a..01b0ade42d 100644
--- a/api-definitions/resource-manager/ContainerService/Terraform/Tests/KubernetesFleetManager-Resource-Complete-Test.hcl
+++ b/api-definitions/resource-manager/ContainerService/Terraform/Tests/KubernetesFleetManager-Resource-Complete-Test.hcl
@@ -13,9 +13,7 @@ resource "azurerm_kubernetes_fleet_manager" "test" {
     some_key    = "some-value"
   }
   hub_profile {
-    dns_prefix         = "val-${var.random_string}"
-    fqdn               = "val-${var.random_string}"
-    kubernetes_version = "val-${var.random_string}"
+    dns_prefix = "val-${var.random_string}"
   }
 }

diff --git a/api-definitions/resource-manager/DevCenter/2023-04-01/DevCenters/Model-DevCenterProperties.json b/api-definitions/resource-manager/DevCenter/2023-04-01/DevCenters/Model-DevCenterProperties.json
index a5a1c806a7..012d3b2ec8 100644
--- a/api-definitions/resource-manager/DevCenter/2023-04-01/DevCenters/Model-DevCenterProperties.json
+++ b/api-definitions/resource-manager/DevCenter/2023-04-01/DevCenters/Model-DevCenterProperties.json
@@ -9,8 +9,8 @@
         "type": "String",
         "referenceName": null
       },
-      "optional": true,
-      "readOnly": false,
+      "optional": false,
+      "readOnly": true,
       "required": false,
       "sensitive": false
     },
diff --git a/api-definitions/resource-manager/DevCenter/2023-04-01/Projects/Model-ProjectProperties.json b/api-definitions/resource-manager/DevCenter/2023-04-01/Projects/Model-ProjectProperties.json
index 9201af9f76..972a9788e9 100644
--- a/api-definitions/resource-manager/DevCenter/2023-04-01/Projects/Model-ProjectProperties.json
+++ b/api-definitions/resource-manager/DevCenter/2023-04-01/Projects/Model-ProjectProperties.json
@@ -35,8 +35,8 @@
         "type": "String",
         "referenceName": null
       },
-      "optional": true,
-      "readOnly": false,
+      "optional": false,
+      "readOnly": true,
       "required": false,
       "sensitive": false
     },
diff --git a/api-definitions/resource-manager/DevCenter/Terraform/DevCenter-Resource-Schema.json b/api-definitions/resource-manager/DevCenter/Terraform/DevCenter-Resource-Schema.json
index 00e04463b3..e2ae5a9de6 100644
--- a/api-definitions/resource-manager/DevCenter/Terraform/DevCenter-Resource-Schema.json
+++ b/api-definitions/resource-manager/DevCenter/Terraform/DevCenter-Resource-Schema.json
@@ -1,11 +1,11 @@
 {
   "fields": [
     {
+      "computed": true,
       "documentation": {
         "markdown": "The URI of the Dev Center."
       },
       "hclName": "dev_center_uri",
-      "optional": true,
       "name": "DevCenterUri",
       "objectDefinition": {
         "referenceName": null,
diff --git a/api-definitions/resource-manager/DevCenter/Terraform/DevCenterProject-Resource-Schema.json b/api-definitions/resource-manager/DevCenter/Terraform/DevCenterProject-Resource-Schema.json
index c2ee5f35db..ca7d82e341 100644
--- a/api-definitions/resource-manager/DevCenter/Terraform/DevCenterProject-Resource-Schema.json
+++ b/api-definitions/resource-manager/DevCenter/Terraform/DevCenterProject-Resource-Schema.json
@@ -27,12 +27,11 @@
       "required": true
     },
     {
+      "computed": true,
       "documentation": {
         "markdown": "The URI of the Dev Center resource this project is associated with."
       },
-      "forceNew": true,
       "hclName": "dev_center_uri",
-      "optional": true,
       "name": "DevCenterUri",
       "objectDefinition": {
         "referenceName": null,
diff --git a/api-definitions/resource-manager/DevCenter/Terraform/Tests/DevCenter-Resource-Complete-Test.hcl b/api-definitions/resource-manager/DevCenter/Terraform/Tests/DevCenter-Resource-Complete-Test.hcl
index 8eb361e65d..b1205abf2f 100644
--- a/api-definitions/resource-manager/DevCenter/Terraform/Tests/DevCenter-Resource-Complete-Test.hcl
+++ b/api-definitions/resource-manager/DevCenter/Terraform/Tests/DevCenter-Resource-Complete-Test.hcl
@@ -8,7 +8,6 @@ resource "azurerm_dev_center" "test" {
   location            = azurerm_resource_group.test.location
   name                = "acctestdc-${var.random_string}"
   resource_group_name = azurerm_resource_group.test.name
-  dev_center_uri      = "val-${var.random_string}"
   tags = {
     environment = "terraform-acctests"
     some_key    = "some-value"
diff --git a/api-definitions/resource-manager/DevCenter/Terraform/Tests/DevCenterProject-Resource-Complete-Test.hcl b/api-definitions/resource-manager/DevCenter/Terraform/Tests/DevCenterProject-Resource-Complete-Test.hcl
index 3b6fef9a68..c2372e9580 100644
--- a/api-definitions/resource-manager/DevCenter/Terraform/Tests/DevCenterProject-Resource-Complete-Test.hcl
+++ b/api-definitions/resource-manager/DevCenter/Terraform/Tests/DevCenterProject-Resource-Complete-Test.hcl
@@ -10,7 +10,6 @@ resource "azurerm_dev_center_project" "test" {
   name                       = "acctestdcp-${var.random_string}"
   resource_group_name        = azurerm_resource_group.test.name
   description                = "Description for the Dev Center Project"
-  dev_center_uri             = "val-${var.random_string}"
   maximum_dev_boxes_per_user = 21
   tags = {
     environment = "terraform-acctests"
diff --git a/api-definitions/resource-manager/LoadTestService/2022-12-01/LoadTests/Model-LoadTestProperties.json b/api-definitions/resource-manager/LoadTestService/2022-12-01/LoadTests/Model-LoadTestProperties.json
index b7a9ddb81d..c40414b7d9 100644
--- a/api-definitions/resource-manager/LoadTestService/2022-12-01/LoadTests/Model-LoadTestProperties.json
+++ b/api-definitions/resource-manager/LoadTestService/2022-12-01/LoadTests/Model-LoadTestProperties.json
@@ -9,8 +9,8 @@
         "type": "String",
         "referenceName": null
       },
-      "optional": true,
-      "readOnly": false,
+      "optional": false,
+      "readOnly": true,
       "required": false,
       "sensitive": false
     },
diff --git a/api-definitions/resource-manager/LoadTestService/Terraform/LoadTest-Resource-Schema.json b/api-definitions/resource-manager/LoadTestService/Terraform/LoadTest-Resource-Schema.json
index e3d3ad27c8..60db33a2b0 100644
--- a/api-definitions/resource-manager/LoadTestService/Terraform/LoadTest-Resource-Schema.json
+++ b/api-definitions/resource-manager/LoadTestService/Terraform/LoadTest-Resource-Schema.json
@@ -1,12 +1,11 @@
 {
   "fields": [
     {
+      "computed": true,
       "documentation": {
         "markdown": "Resource data plane URI."
       },
-      "forceNew": true,
       "hclName": "data_plane_uri",
-      "optional": true,
       "name": "DataPlaneURI",
       "objectDefinition": {
         "referenceName": null,
diff --git a/api-definitions/resource-manager/LoadTestService/Terraform/Tests/LoadTest-Resource-Complete-Test.hcl b/api-definitions/resource-manager/LoadTestService/Terraform/Tests/LoadTest-Resource-Complete-Test.hcl
index 77e665f99f..5fa6e22782 100644
--- a/api-definitions/resource-manager/LoadTestService/Terraform/Tests/LoadTest-Resource-Complete-Test.hcl
+++ b/api-definitions/resource-manager/LoadTestService/Terraform/Tests/LoadTest-Resource-Complete-Test.hcl
@@ -8,7 +8,6 @@ resource "azurerm_load_test" "test" {
   location            = azurerm_resource_group.test.location
   name                = "acctestlt-${var.random_string}"
   resource_group_name = azurerm_resource_group.test.name
-  data_plane_uri      = "val-${var.random_string}"
   description         = "Description for the Load Test"
   tags = {
     environment = "terraform-acctests"
diff --git a/api-definitions/resource-manager/ManagedIdentity/2023-01-31/ManagedIdentities/Model-UserAssignedIdentityProperties.json b/api-definitions/resource-manager/ManagedIdentity/2023-01-31/ManagedIdentities/Model-UserAssignedIdentityProperties.json
index 1e0332ff21..4808de720e 100644
--- a/api-definitions/resource-manager/ManagedIdentity/2023-01-31/ManagedIdentities/Model-UserAssignedIdentityProperties.json
+++ b/api-definitions/resource-manager/ManagedIdentity/2023-01-31/ManagedIdentities/Model-UserAssignedIdentityProperties.json
@@ -9,7 +9,7 @@
         "type": "String",
         "referenceName": null
       },
-      "optional": true,
+      "optional": false,
       "readOnly": true,
       "required": false,
       "sensitive": false
@@ -22,7 +22,7 @@
         "type": "String",
         "referenceName": null
       },
-      "optional": true,
+      "optional": false,
       "readOnly": true,
       "required": false,
       "sensitive": false
@@ -35,7 +35,7 @@
         "type": "String",
         "referenceName": null
       },
-      "optional": true,
+      "optional": false,
       "readOnly": true,
       "required": false,
       "sensitive": false
```