### PR TITLE
`data-api` - standardise logging in Data API

### DIFF
--- a/tools/data-api/internal/endpoints/home_page.go
+++ b/tools/data-api/internal/endpoints/home_page.go
@@ -6,12 +6,12 @@ package endpoints
 import (
 	"fmt"
 	"html/template"
-	"log"
 	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/hashicorp/pandora/tools/data-api/internal/logging"
 )
 
 const homePageTemplate = `
@@ -48,7 +48,7 @@ func HomePage(router chi.Router) func(w http.ResponseWriter, r *http.Request) {
 
 		templ, err := template.New("home-page").Parse(homePageTemplate)
 		if err != nil {
-			log.Printf("[ERROR] Serving Home Page: %+v", err)
+			logging.Errorf("Serving Home Page: %+v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 		templ.Execute(w, links)

--- a/tools/data-api/internal/endpoints/routing.go
+++ b/tools/data-api/internal/endpoints/routing.go
@@ -4,11 +4,10 @@
 package endpoints
 
 import (
-	"log"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/hashicorp/pandora/tools/data-api/internal/endpoints/infrastructure"
 	"github.com/hashicorp/pandora/tools/data-api/internal/endpoints/v1"
+	"github.com/hashicorp/pandora/tools/data-api/internal/logging"
 	"github.com/hashicorp/pandora/tools/data-api/internal/repositories"
 )
 
@@ -23,8 +22,7 @@ func Router(directory string, serviceNames *[]string) func(chi.Router) {
 			}
 			serviceRepo, err := repositories.NewServicesRepository(directory, opts.ServiceType, serviceNames)
 			if err != nil {
-				// TODO logging
-				log.Fatalf("Error: %+v", err)
+				logging.Fatalf("Error: %+v", err)
 			}
 			v1.Router(r, opts, serviceRepo)
 		})
@@ -36,8 +34,7 @@ func Router(directory string, serviceNames *[]string) func(chi.Router) {
 			}
 			serviceRepo, err := repositories.NewServicesRepository(directory, opts.ServiceType, serviceNames)
 			if err != nil {
-				// TODO logging
-				log.Fatalf("Error: %+v", err)
+				logging.Fatalf("Error: %+v", err)
 			}
 			v1.Router(r, opts, serviceRepo)
 		})

--- a/tools/data-api/internal/endpoints/v1/errors.go
+++ b/tools/data-api/internal/endpoints/v1/errors.go
@@ -4,12 +4,13 @@
 package v1
 
 import (
-	"log"
 	"net/http"
+
+	"github.com/hashicorp/pandora/tools/data-api/internal/logging"
 )
 
 func internalServerError(w http.ResponseWriter, err error) {
 	// TODO: update errors
-	log.Printf("[ERROR] %+v", err)
+	logging.Errorf("%+v", err)
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 }

--- a/tools/data-api/internal/endpoints/v1/routing.go
+++ b/tools/data-api/internal/endpoints/v1/routing.go
@@ -6,10 +6,10 @@ package v1
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/hashicorp/pandora/tools/data-api/internal/logging"
 	"github.com/hashicorp/pandora/tools/data-api/internal/repositories"
 )
 
@@ -83,7 +83,7 @@ func (api Api) serviceRouteContext(next http.Handler) http.Handler {
 
 		serviceName := chi.URLParam(r, "serviceName")
 		if serviceName == "" {
-			log.Printf("[DEBUG] Missing Service Name")
+			logging.Debugf("Missing Service Name")
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
 
@@ -103,7 +103,7 @@ func serviceApiVersionRouteContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		serviceApiVersion := chi.URLParam(r, "serviceApiVersion")
 		if serviceApiVersion == "" {
-			log.Printf("[DEBUG] Missing Service API Version")
+			logging.Debugf("Missing Service API Version")
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
 
@@ -129,7 +129,7 @@ func apiResourceNameRouteContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resourceName := chi.URLParam(r, "resourceName")
 		if resourceName == "" {
-			log.Printf("[DEBUG] Missing Resource Name")
+			logging.Debugf("Missing Resource Name")
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
 

--- a/tools/data-api/internal/logging/log.go
+++ b/tools/data-api/internal/logging/log.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+var Log hclog.Logger
+
+func init() {
+	Log = hclog.NewNullLogger()
+}
+
+func Debugf(msg string, args ...interface{}) {
+	Log.Debug(fmt.Sprintf(msg, args...))
+}
+
+func Errorf(msg string, args ...interface{}) {
+	Log.Error(fmt.Sprintf(msg, args...))
+}
+
+func Fatalf(msg string, args ...interface{}) {
+	Log.Error(fmt.Sprintf(msg, args...))
+	os.Exit(1)
+}
+
+func Tracef(msg string, args ...interface{}) {
+	Log.Trace(fmt.Sprintf(msg, args...))
+}
+
+func Infof(msg string, args ...interface{}) {
+	Log.Info(fmt.Sprintf(msg, args...))
+}
+
+func Warnf(msg string, args ...interface{}) {
+	Log.Warn(fmt.Sprintf(msg, args...))
+}

--- a/tools/data-api/internal/repositories/discovery.go
+++ b/tools/data-api/internal/repositories/discovery.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/hashicorp/pandora/tools/data-api/internal/logging"
 	"github.com/hashicorp/pandora/tools/sdk/dataapimodels"
 )
 
@@ -65,6 +66,7 @@ func (s *ServicesRepositoryImpl) discoverSubsetOfServices() error {
 	services := make(map[string]string, 0)
 	for _, d := range *dirs {
 		for _, service := range *s.serviceNames {
+			logging.Debugf("Finding service %q", service)
 			serviceDir := path.Join(d, service)
 			if _, err := os.Stat(serviceDir); os.IsNotExist(err) {
 				// we continue here since the service we're looking for could exist in another source directory e.g. under handwritten definitions
@@ -74,6 +76,7 @@ func (s *ServicesRepositoryImpl) discoverSubsetOfServices() error {
 				return fmt.Errorf("duplicate definitions for service %q", service)
 			}
 			services[service] = serviceDir
+			logging.Debugf("Found service %q", service)
 		}
 	}
 
@@ -98,6 +101,7 @@ func (s *ServicesRepositoryImpl) discoverAllServices() error {
 		return fmt.Errorf("discovering service type directories for service type %q: %+v", s.serviceType, err)
 	}
 
+	logging.Debugf("Finding all services")
 	allServices := make(map[string]string, 0)
 	for _, d := range *dirs {
 		files, err := os.ReadDir(d)
@@ -111,6 +115,7 @@ func (s *ServicesRepositoryImpl) discoverAllServices() error {
 					return fmt.Errorf("duplicate definitions for service %q", f.Name())
 				}
 				allServices[f.Name()] = path.Join(d, f.Name())
+				logging.Debugf("Found service %q", f.Name())
 			}
 		}
 	}

--- a/tools/data-api/internal/repositories/helpers.go
+++ b/tools/data-api/internal/repositories/helpers.go
@@ -6,10 +6,11 @@ package repositories
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/pandora/tools/data-api/internal/logging"
 )
 
 func listSubDirectories(path string) (*[]string, error) {
@@ -88,7 +89,7 @@ func getTerraformDefinitionInfo(fileName string) (string, string, error) {
 	// Resource-Schema Files can have multiple files with the model type appended to it (ie. KubernetesFleetManager-Resource-Schema-FleetHubProfile
 	// that final piece of the final name is not used and can be safely ignored
 	if strings.Contains(strings.ToLower(definitionType), "resource-schema") && len(strings.Split(definitionType, "-")) >= 3 {
-		log.Printf("FileName: %s", fileName)
+		logging.Tracef("FileName: %s", fileName)
 		definitionType = "Resource-Schema"
 	}
 

--- a/tools/data-api/main.go
+++ b/tools/data-api/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/hashicorp/pandora/tools/data-api/internal/logging"
 	"log"
 	"os"
 
@@ -14,10 +15,13 @@ import (
 )
 
 func main() {
-	logger := hclog.New(hclog.DefaultOptions)
-	logger.SetLevel(hclog.Trace)
+	loggingOpts := hclog.DefaultOptions
+	if v := os.Getenv("LOG_LEVEL"); v != "" {
+		loggingOpts.Level = hclog.LevelFromString(v)
+	}
+	logging.Log = hclog.New(loggingOpts)
 
-	logger.Info("Data API launched")
+	logging.Log.Info("Data API launched")
 
 	c := cli.NewCLI("data-api", "1.0.0")
 	c.Args = os.Args[1:]


### PR DESCRIPTION
- Instantiates a global instance of the logging like in `generator-go-sdk`
- Adds some additional debug log messaging around the discovery and processing of services in the data API