### PR TITLE
update the test dependency to remove the use of deprecated fields

### DIFF
--- a/tools/importer-rest-api-specs/components/terraform/testing/dependencies_template.go
+++ b/tools/importer-rest-api-specs/components/terraform/testing/dependencies_template.go
@@ -172,9 +172,6 @@ resource "%[1]s_kubernetes_fleet_manager" "test" {
   name                = "acctestkfm${var.random_string}"
   location            = %[1]s_resource_group.test.location
   resource_group_name = %[1]s_resource_group.test.name
-  hub_profile {
-    dns_prefix = "val-${var.random_string}"
-  }
 }
 `, tb.providerPrefix))
 	}

--- a/tools/importer-rest-api-specs/components/terraform/testing/dependencies_template_test.go
+++ b/tools/importer-rest-api-specs/components/terraform/testing/dependencies_template_test.go
@@ -353,9 +353,6 @@ resource "example_kubernetes_fleet_manager" "test" {
   name                = "acctestkfm${var.random_string}"
   location            = example_resource_group.test.location
   resource_group_name = example_resource_group.test.name
-  hub_profile {
-    dns_prefix = "val-${var.random_string}"
-  }
 }
 `
 	actual := builder.generateTemplateConfigForDependencies(dependencies)


### PR DESCRIPTION
To resolve the comments: https://github.com/hashicorp/terraform-provider-azurerm/pull/25010#issuecomment-1977480891