### PR TITLE
`importer-rest-api-specs` - construct a unique constant name for `type`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/constants/interface.go
+++ b/tools/importer-rest-api-specs/components/parser/constants/interface.go
@@ -37,13 +37,7 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, modelName *string
 		return nil, fmt.Errorf("Enum in %q has no values", fieldName)
 	}
 
-	//if modelName != nil && strings.EqualFold(*modelName, "IntegrationRuntimeReference") {
-	//	log.Printf("DEBUG")
-	//}
 	constantName := fieldName
-
-	//api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Constant-ManagementGroupChildTypetype.json
-	//api-definitions/resource-manager/Security/2020-01-01/ApplicationWhitelistings/Constant-RecommendationTypetype.json
 
 	// the name needs to come from the `x-ms-enum` extension
 	constExtension, err := parseConstantExtensionFromExtension(extensions)

--- a/tools/importer-rest-api-specs/components/parser/constants_test.go
+++ b/tools/importer-rest-api-specs/components/parser/constants_test.go
@@ -284,6 +284,96 @@ func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
 	validateParsedSwaggerResultMatches(t, expected, actual)
 }
 
+func TestParseConstantsMultipleTypeEnums(t *testing.T) {
+	actual, err := ParseSwaggerFileForTesting(t, "constants_multiple_type_enums.json")
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+
+	expected := importerModels.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]importerModels.AzureApiResource{
+			"Animal": {
+				Constants: map[string]models.SDKConstant{
+					"AnimalType": {
+						Type: models.StringSDKConstantType,
+						Values: map[string]string{
+							"Cat":   "cat",
+							"Dog":   "dog",
+							"Panda": "panda",
+						},
+					},
+				},
+				Models: map[string]models.SDKModel{
+					"Animal": {
+						Fields: map[string]models.SDKField{
+							"Type": {
+								JsonName: "type",
+								ObjectDefinition: models.SDKObjectDefinition{
+									ReferenceName: pointer.To("AnimalType"),
+									Type:          models.ReferenceSDKObjectDefinitionType,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.SDKOperation{
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						ResponseObject: &models.SDKObjectDefinition{
+							ReferenceName: pointer.To("Animal"),
+							Type:          models.ReferenceSDKObjectDefinitionType,
+						},
+						URISuffix: pointer.To("/animal"),
+					},
+				},
+			},
+			"Planet": {
+				Constants: map[string]models.SDKConstant{
+					"PlanetType": {
+						Type: models.StringSDKConstantType,
+						Values: map[string]string{
+							"Mercury": "mercury",
+							"Saturn":  "saturn",
+						},
+					},
+				},
+				Models: map[string]models.SDKModel{
+					"Planet": {
+						Fields: map[string]models.SDKField{
+							"Type": {
+								JsonName: "type",
+								ObjectDefinition: models.SDKObjectDefinition{
+									ReferenceName: pointer.To("PlanetType"),
+									Type:          models.ReferenceSDKObjectDefinitionType,
+								},
+								Required: false,
+							},
+						},
+					},
+				},
+				Operations: map[string]models.SDKOperation{
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						ResponseObject: &models.SDKObjectDefinition{
+							ReferenceName: pointer.To("Planet"),
+							Type:          models.ReferenceSDKObjectDefinitionType,
+						},
+						URISuffix: pointer.To("/planet"),
+					},
+				},
+			},
+		},
+	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
+}
+
 func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 	// Tests an Integer Constant defined Inline with modelAsString, which is bad data / should be ignored
 	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_strings_inlined.json")

--- a/tools/importer-rest-api-specs/components/parser/constants_test.go
+++ b/tools/importer-rest-api-specs/components/parser/constants_test.go
@@ -294,7 +294,7 @@ func TestParseConstantsMultipleTypeEnums(t *testing.T) {
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
 		Resources: map[string]importerModels.AzureApiResource{
-			"Animal": {
+			"Example": {
 				Constants: map[string]models.SDKConstant{
 					"AnimalType": {
 						Type: models.StringSDKConstantType,
@@ -302,6 +302,13 @@ func TestParseConstantsMultipleTypeEnums(t *testing.T) {
 							"Cat":   "cat",
 							"Dog":   "dog",
 							"Panda": "panda",
+						},
+					},
+					"PlanetType": {
+						Type: models.StringSDKConstantType,
+						Values: map[string]string{
+							"Mercury": "mercury",
+							"Saturn":  "saturn",
 						},
 					},
 				},
@@ -318,31 +325,6 @@ func TestParseConstantsMultipleTypeEnums(t *testing.T) {
 							},
 						},
 					},
-				},
-				Operations: map[string]models.SDKOperation{
-					"Test": {
-						ContentType:         "application/json",
-						ExpectedStatusCodes: []int{200},
-						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							ReferenceName: pointer.To("Animal"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
-						},
-						URISuffix: pointer.To("/animal"),
-					},
-				},
-			},
-			"Planet": {
-				Constants: map[string]models.SDKConstant{
-					"PlanetType": {
-						Type: models.StringSDKConstantType,
-						Values: map[string]string{
-							"Mercury": "mercury",
-							"Saturn":  "saturn",
-						},
-					},
-				},
-				Models: map[string]models.SDKModel{
 					"Planet": {
 						Fields: map[string]models.SDKField{
 							"Type": {
@@ -357,7 +339,17 @@ func TestParseConstantsMultipleTypeEnums(t *testing.T) {
 					},
 				},
 				Operations: map[string]models.SDKOperation{
-					"Test": {
+					"Animal": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "GET",
+						ResponseObject: &models.SDKObjectDefinition{
+							ReferenceName: pointer.To("Animal"),
+							Type:          models.ReferenceSDKObjectDefinitionType,
+						},
+						URISuffix: pointer.To("/animal"),
+					},
+					"Planet": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",

--- a/tools/importer-rest-api-specs/components/parser/operations.go
+++ b/tools/importer-rest-api-specs/components/parser/operations.go
@@ -382,7 +382,7 @@ func (p operationsParser) optionsForOperation(input parsedOperation, logger hclo
 				types := []string{
 					param.Type,
 				}
-				constant, err := constants.MapConstant(types, param.Name, param.Enum, param.Extensions, logger.Named("Constant Parser"))
+				constant, err := constants.MapConstant(types, param.Name, nil, param.Enum, param.Extensions, logger.Named("Constant Parser"))
 				if err != nil {
 					return nil, nil, fmt.Errorf("mapping %q: %+v", param.Name, err)
 				}

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -69,35 +69,32 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 		resourcesOut[resourceName] = updated
 	}
 
-	// TODO this can be removed when https://github.com/hashicorp/pandora/issues/3725 is resolved
-	if !strings.EqualFold(serviceName, "datafactory") {
-		// discriminator implementations that are defined in separate files with no link to a swagger tag
-		// are not parsed. So far there are two known instances of this (Data Factory, Chaos Studio) where the
-		// files are defined in a nested directory e.g. d.Name = /Types/Capabilities
-		swaggerFileName := strings.Split(d.Name, "/")
-		if len(resources) == 0 && len(swaggerFileName) > 2 {
-			// if we're here then there is no tag in this file, so we'll use the file name
-			inferredTag := cleanup.PluraliseName(swaggerFileName[len(swaggerFileName)-1])
-			normalizedTag := cleanup.NormalizeResourceName(inferredTag)
+	// discriminator implementations that are defined in separate files with no link to a swagger tag
+	// are not parsed. So far there are two known instances of this (Data Factory, Chaos Studio) where the
+	// files are defined in a nested directory e.g. d.Name = /Types/Capabilities
+	swaggerFileName := strings.Split(d.Name, "/")
+	if len(resources) == 0 && len(swaggerFileName) > 2 {
+		// if we're here then there is no tag in this file, so we'll use the file name
+		inferredTag := cleanup.PluraliseName(swaggerFileName[len(swaggerFileName)-1])
+		normalizedTag := cleanup.NormalizeResourceName(inferredTag)
 
-			result, err := d.findOrphanedDiscriminatedModels()
-			if err != nil {
-				return nil, fmt.Errorf("finding orphaned discriminated models in %q: %+v", d.Name, err)
+		result, err := d.findOrphanedDiscriminatedModels()
+		if err != nil {
+			return nil, fmt.Errorf("finding orphaned discriminated models in %q: %+v", d.Name, err)
+		}
+
+		// this is to avoid the creation of empty packages/directories in the api definitions
+		if len(result.Models) > 0 || len(result.Constants) > 0 {
+			resource := importerModels.AzureApiResource{
+				Constants: result.Constants,
+				Models:    result.Models,
 			}
+			resource = normalizeAzureApiResource(resource)
 
-			// this is to avoid the creation of empty packages/directories in the api definitions
-			if len(result.Models) > 0 || len(result.Constants) > 0 {
-				resource := importerModels.AzureApiResource{
-					Constants: result.Constants,
-					Models:    result.Models,
-				}
-				resource = normalizeAzureApiResource(resource)
-
-				if mergeResources, ok := resources[normalizedTag]; ok {
-					resources[normalizedTag] = importerModels.MergeResourcesForTag(mergeResources, resource)
-				} else {
-					resourcesOut[normalizedTag] = resource
-				}
+			if mergeResources, ok := resources[normalizedTag]; ok {
+				resources[normalizedTag] = importerModels.MergeResourcesForTag(mergeResources, resource)
+			} else {
+				resourcesOut[normalizedTag] = resource
 			}
 		}
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments.go
@@ -131,7 +131,7 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 
 					if param.Enum != nil {
 						// then find the constant itself
-						constant, err := constants.MapConstant([]string{param.Type}, param.Name, param.Enum, param.Extensions, p.logger.Named("Constant Parser"))
+						constant, err := constants.MapConstant([]string{param.Type}, param.Name, nil, param.Enum, param.Extensions, p.logger.Named("Constant Parser"))
 						if err != nil {
 							return nil, fmt.Errorf("parsing constant from %q: %+v", uriSegment, err)
 						}

--- a/tools/importer-rest-api-specs/components/parser/swagger_resources.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_resources.go
@@ -198,7 +198,7 @@ func (d *SwaggerDefinition) findNestedItemsYetToBeParsed(operations map[string]m
 				return nil, fmt.Errorf("finding top level object named %q: %+v", referenceName, err)
 			}
 
-			parsedAsAConstant, constErr := constants.MapConstant(topLevelObject.Type, referenceName, topLevelObject.Enum, topLevelObject.Extensions, d.logger.Named("Constant Parser"))
+			parsedAsAConstant, constErr := constants.MapConstant(topLevelObject.Type, referenceName, nil, topLevelObject.Enum, topLevelObject.Extensions, d.logger.Named("Constant Parser"))
 			parsedAsAModel, modelErr := d.parseModel(referenceName, *topLevelObject)
 			if (constErr != nil && modelErr != nil) || (parsedAsAConstant == nil && parsedAsAModel == nil) {
 				return nil, fmt.Errorf("reference %q didn't parse as a Model or a Constant.\n\nConstant Error: %+v\n\nModel Error: %+v", referenceName, constErr, modelErr)

--- a/tools/importer-rest-api-specs/components/parser/testdata/constants_multiple_type_enums.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/constants_multiple_type_enums.json
@@ -21,9 +21,9 @@
     "/animal": {
       "get": {
         "tags": [
-          "Animal"
+          "Example"
         ],
-        "operationId": "Animal_Test",
+        "operationId": "Example_Animal",
         "description": "Tests parsing of a model containing a Constant",
         "parameters": [],
         "responses": {
@@ -39,9 +39,9 @@
     "/planet": {
       "get": {
         "tags": [
-          "Planet"
+          "Example"
         ],
-        "operationId": "Planet_Test",
+        "operationId": "Example_Planet",
         "description": "Tests parsing of a model containing a Constant",
         "parameters": [],
         "responses": {

--- a/tools/importer-rest-api-specs/components/parser/testdata/constants_multiple_type_enums.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/constants_multiple_type_enums.json
@@ -1,0 +1,88 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/animal": {
+      "get": {
+        "tags": [
+          "Animal"
+        ],
+        "operationId": "Animal_Test",
+        "description": "Tests parsing of a model containing a Constant",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Animal"
+            }
+          }
+        }
+      }
+    },
+    "/planet": {
+      "get": {
+        "tags": [
+          "Planet"
+        ],
+        "operationId": "Planet_Test",
+        "description": "Tests parsing of a model containing a Constant",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Planet"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Animal": {
+      "description": "The Resource definition.",
+      "properties": {
+        "type": {
+          "description": "The type of Animal this is, which is an Enum.",
+          "enum": [
+            "cat",
+            "dog",
+            "panda"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "Planet": {
+      "description": "The Resource definition.",
+      "properties": {
+        "type": {
+          "description": "The type of Animal this is, which is an Enum.",
+          "enum": [
+            "mercury",
+            "saturn"
+          ],
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
This PR updates the `MapConstant` function to take an additional optional argument called `modelName` which will be used to construct a unique constant name for constants named `type` that do not have a unique name defined by `x-ms-enum` in the swagger.

The approach is intentionally scoped to constants called `type` to prevent renames of constants that already have descriptive field names.

Closes #3725