### PR TITLE
`tools/generator-go-sdk` - add init() in id generator

### DIFF
--- a/tools/generator-go-sdk/internal/generator/templater_id_parser.go
+++ b/tools/generator-go-sdk/internal/generator/templater_id_parser.go
@@ -41,12 +41,14 @@ import (
     "strings"
 
     "github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+    "github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/recaser"
 )
 
 %[2]s
 %[3]s
 %[4]s
-`, data.packageName, *copyrightLines, *structBody, *methods)
+%[5]s
+`, data.packageName, *copyrightLines, r.registerId(), *structBody, *methods)
 	return &out, nil
 }
 
@@ -81,6 +83,16 @@ type %[1]s struct {
 }
 `, r.name, strings.Join(lines, "\n"), wordifiedName)
 	return &out, nil
+}
+
+func (r resourceIdTemplater) registerId() string {
+	wordifiedName := wordifyString(r.name)
+	return fmt.Sprintf(`
+	// Adds %[1]s to a register of known ids
+	func init() {
+		recaser.RegisterResourceId(&%[2]s{})
+	}
+`, wordifiedName, r.name)
 }
 
 func (r resourceIdTemplater) methods() (*string, error) {

--- a/tools/generator-go-sdk/internal/generator/templater_id_parser.go
+++ b/tools/generator-go-sdk/internal/generator/templater_id_parser.go
@@ -88,7 +88,6 @@ type %[1]s struct {
 func (r resourceIdTemplater) registerId() string {
 	wordifiedName := wordifyString(r.name)
 	return fmt.Sprintf(`
-	// Adds %[1]s to a register of known ids
 	func init() {
 		recaser.RegisterResourceId(&%[2]s{})
 	}

--- a/tools/generator-go-sdk/internal/generator/templater_id_parser_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_id_parser_test.go
@@ -39,9 +39,15 @@ import (
     "strings"
 
     "github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/recaser"
 )
 
 // acctests licence placeholder
+
+// Adds Basic Test to a register of known ids
+func init() {
+    recaser.RegisterResourceId(&BasicTestId{})
+}
 
 var _ resourceids.ResourceId = &BasicTestId{}
 
@@ -183,9 +189,15 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+    "github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids/recaser"
 )
 
 // acctests licence placeholder
+
+// Adds Constant Only to a register of known ids
+func init() {
+    recaser.RegisterResourceId(&ConstantOnlyId{})
+}
 
 var _ resourceids.ResourceId = &ConstantOnlyId{}
 

--- a/tools/generator-go-sdk/internal/generator/templater_id_parser_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_id_parser_test.go
@@ -44,7 +44,6 @@ import (
 
 // acctests licence placeholder
 
-// Adds Basic Test to a register of known ids
 func init() {
     recaser.RegisterResourceId(&BasicTestId{})
 }
@@ -194,7 +193,6 @@ import (
 
 // acctests licence placeholder
 
-// Adds Constant Only to a register of known ids
 func init() {
     recaser.RegisterResourceId(&ConstantOnlyId{})
 }


### PR DESCRIPTION
This add an `init()` func to resource ids which registers them to a list of known ids that can be used for recasing.

dependent on [#221](https://github.com/hashicorp/go-azure-helpers/pull/221)