### PR TITLE
Add compute 2024-03-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -92,7 +92,7 @@ service "communication" {
 }
 service "compute" {
   name      = "Compute"
-  available = ["2021-07-01", "2021-11-01", "2022-03-01", "2022-03-02", "2022-03-03", "2023-03-01", "2023-04-02"]
+  available = ["2021-07-01", "2021-11-01", "2022-03-01", "2022-03-02", "2022-03-03", "2023-03-01", "2023-04-02", "2024-03-01"]
 }
 service "confidentialledger" {
   name      = "ConfidentialLedger"


### PR DESCRIPTION
👋 Hello friends, the Azure Packer plugin needs the 2024-03-01 compute library for a newer version of `galleryimageversions` to solve https://github.com/hashicorp/packer-plugin-azure/issues/395