### PR TITLE
`importer-rest-api-specs` - extract discriminator information for orphans from parent

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/constants_test.go
+++ b/tools/importer-rest-api-specs/components/parser/constants_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 	// Enums can either be modelled as strings or not.. this is an Int that's output as an Integer.
-	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_ints.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_ints.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -69,7 +69,7 @@ func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 func TestParseConstantsIntegersTopLevelAsIntsWithDisplayName(t *testing.T) {
 	// This is an Integer Enum where there's a (Display) Name listed for the integer
 	// so we should be using `Name (string): Value (integer`)
-	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_with_names.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_with_names.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -123,7 +123,7 @@ func TestParseConstantsIntegersTopLevelAsIntsWithDisplayName(t *testing.T) {
 
 func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 	// Tests an Integer Constant with modelAsString, which is bad data / should be ignored
-	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -177,7 +177,7 @@ func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 
 func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 	// Enums can either be modelled as strings or not.. this is an Int that's output as an Integer.
-	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_ints_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_ints_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -232,7 +232,7 @@ func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
 	// This is an Integer Enum where there's a (Display) Name listed for the integer
 	// so we should be using `Name (string): Value (integer`)
-	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_with_names_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_with_names_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -285,7 +285,7 @@ func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
 }
 
 func TestParseConstantsMultipleTypeEnums(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "constants_multiple_type_enums.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_multiple_type_enums.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -368,7 +368,7 @@ func TestParseConstantsMultipleTypeEnums(t *testing.T) {
 
 func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 	// Tests an Integer Constant defined Inline with modelAsString, which is bad data / should be ignored
-	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_strings_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_integers_as_strings_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -422,7 +422,7 @@ func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 
 func TestParseConstantsFloatsTopLevelAsFloats(t *testing.T) {
 	// Enums can either be modelled as strings or not.. this is an Float that's output as a Float.
-	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_floats.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_floats.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -476,7 +476,7 @@ func TestParseConstantsFloatsTopLevelAsFloats(t *testing.T) {
 
 func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
 	// Tests an Float Constant with modelAsString, which is bad data / should be ignored
-	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -530,7 +530,7 @@ func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
 
 func TestParseConstantsFloatsInlinedAsFloats(t *testing.T) {
 	// Enums can either be modelled as strings or not.. this is an Float that's output as a Float.
-	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_floats_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_floats_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -584,7 +584,7 @@ func TestParseConstantsFloatsInlinedAsFloats(t *testing.T) {
 
 func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
 	// Tests an Float Constant defined inline with modelAsString, which is bad data / should be ignored
-	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_strings_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_strings_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -637,7 +637,7 @@ func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
 }
 
 func TestParseConstantsStringsTopLevel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "constants_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -694,7 +694,7 @@ func TestParseConstantsStringsTopLevelAsNonStrings(t *testing.T) {
 	// whilst the value is "string", due to (what appears to be) bad data the
 	// "modelAsString" property can be set to false - as such we force it to
 	// a string either way, since that's what it is
-	actual, err := ParseSwaggerFileForTesting(t, "constants_strings_as_non_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_strings_as_non_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -747,7 +747,7 @@ func TestParseConstantsStringsTopLevelAsNonStrings(t *testing.T) {
 }
 
 func TestParseConstantsStringsInlined(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "constants_strings_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_strings_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -800,7 +800,7 @@ func TestParseConstantsStringsInlined(t *testing.T) {
 }
 
 func TestParseConstantsStringsInlinedAsNonStrings(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "constants_strings_inlined_as_non_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_strings_inlined_as_non_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -854,7 +854,7 @@ func TestParseConstantsStringsInlinedAsNonStrings(t *testing.T) {
 
 func TestParseConstantsStringsTopLevelContainingFloats(t *testing.T) {
 	// Enums can either be modelled as strings or not.. this is a Float that's output as a String.
-	actual, err := ParseSwaggerFileForTesting(t, "constants_strings_which_are_floats.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_strings_which_are_floats.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -908,7 +908,7 @@ func TestParseConstantsStringsTopLevelContainingFloats(t *testing.T) {
 
 func TestParseConstantsStringsInlinedContainingFloats(t *testing.T) {
 	// Enums can either be modelled as strings or not.. this is a Float that's output as a Float.
-	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_floats_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "constants_floats_as_floats_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -961,7 +961,7 @@ func TestParseConstantsStringsInlinedContainingFloats(t *testing.T) {
 }
 
 func TestParseConstantsFromParameters(t *testing.T) {
-	result, err := ParseSwaggerFileForTesting(t, "constants_in_operation_parameters.json")
+	result, err := ParseSwaggerFileForTesting(t, "constants_in_operation_parameters.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/pandora/tools/sdk/resourcemanager"
 )
 
-func ParseSwaggerFileForTesting(t *testing.T, file string) (*importerModels.AzureApiDefinition, error) {
+func ParseSwaggerFileForTesting(t *testing.T, file string, serviceName *string) (*importerModels.AzureApiDefinition, error) {
 	// TODO: make this function private
 	parsed, err := load("testdata/", file, hclog.New(hclog.DefaultOptions))
 	if err != nil {
@@ -28,7 +28,11 @@ func ParseSwaggerFileForTesting(t *testing.T, file string) (*importerModels.Azur
 		t.Fatalf("parsing Resource Ids: %+v", err)
 	}
 
-	out, err := parsed.parse("Example", "2020-01-01", resourceProvider, *resourceIds)
+	service := "Example"
+	if serviceName != nil {
+		service = *serviceName
+	}
+	out, err := parsed.parse(service, "2020-01-01", resourceProvider, *resourceIds)
 	if err != nil {
 		t.Fatalf("parsing file %q: %+v", file, err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/models_commonschema_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_commonschema_test.go
@@ -18,7 +18,7 @@ import (
 // TODO: Zones
 
 func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedList(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitylegacysystemanduserassignedlist.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitylegacysystemanduserassignedlist.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -67,7 +67,7 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedList(t *test
 }
 
 func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitylegacysystemanduserassignedmap.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitylegacysystemanduserassignedmap.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -118,7 +118,7 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap(t *testi
 func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap_ExtraFields(t *testing.T) {
 	// this handles the scenario of a System Assigned & User Assigned model having extra fields
 	// in the user assigned identity block (#1066) - for example an extra `appId`
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitylegacysystemanduserassignedmap_extrafields.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitylegacysystemanduserassignedmap_extrafields.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -167,7 +167,7 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap_ExtraFie
 }
 
 func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap_GenericDictionary(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitylegacysystemanduserassignedmap_genericdictionary.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitylegacysystemanduserassignedmap_genericdictionary.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -216,7 +216,7 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap_GenericD
 }
 
 func TestParseModel_CommonSchema_IdentitySystemAssigned(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemassigned.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemassigned.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -265,7 +265,7 @@ func TestParseModel_CommonSchema_IdentitySystemAssigned(t *testing.T) {
 }
 
 func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedList(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemanduserassignedlist.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemanduserassignedlist.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -314,7 +314,7 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedList(t *testing.T)
 }
 
 func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedMap(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemanduserassignedmap.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemanduserassignedmap.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -365,7 +365,7 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedMap(t *testing.T) 
 func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedMap_ExtraFields(t *testing.T) {
 	// this handles the scenario of a System Assigned & User Assigned model having extra fields
 	// in the user assigned identity block (#1066) - for example an extra `appId`
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemanduserassignedmap.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemanduserassignedmap.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -414,7 +414,7 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedMap_ExtraFields(t 
 }
 
 func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedList(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemoruserassignedlist.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemoruserassignedlist.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -463,7 +463,7 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedList(t *testing.T) 
 }
 
 func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemoruserassignedmap.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemoruserassignedmap.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -514,7 +514,7 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap(t *testing.T) {
 func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap_DelegatedResources(t *testing.T) {
 	// this handles the scenario of a System Assigned & User Assigned model having a DelegatedResources block
 	// this block isn't intended to be used by users of the API (and is for internal ARM usage only)
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemoruserassignedmap_delegatedresources.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemoruserassignedmap_delegatedresources.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -565,7 +565,7 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap_DelegatedResour
 func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap_ExtraFields(t *testing.T) {
 	// this handles the scenario of a System Assigned & User Assigned model having extra fields
 	// in the user assigned identity block (#1066) - for example an extra `appId`
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemoruserassignedmap_extrafields.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identitysystemoruserassignedmap_extrafields.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -614,7 +614,7 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap_ExtraFields(t *
 }
 
 func TestParseModel_CommonSchema_IdentityUserAssignedList(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identityuserassignedlist.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identityuserassignedlist.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -663,7 +663,7 @@ func TestParseModel_CommonSchema_IdentityUserAssignedList(t *testing.T) {
 }
 
 func TestParseModel_CommonSchema_IdentityUserAssignedMap(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identityuserassignedmap.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identityuserassignedmap.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -712,7 +712,7 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap(t *testing.T) {
 }
 
 func TestParseModel_CommonSchema_IdentityUserAssignedMap_PrincipalID(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identityuserassignedmap_principalid.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identityuserassignedmap_principalid.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -761,7 +761,7 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap_PrincipalID(t *testing.
 }
 
 func TestParseModel_CommonSchema_IdentityUserAssignedMap_TenantID(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identityuserassignedmap_tenantid.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_identityuserassignedmap_tenantid.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -810,7 +810,7 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap_TenantID(t *testing.T) 
 }
 
 func TestParseModel_CommonSchema_Location(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_location.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_commonschema_location.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/models_dictionaries_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_dictionaries_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParseModelWithADictionaryOfIntegers(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_integers.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_integers.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -64,7 +64,7 @@ func TestParseModelWithADictionaryOfIntegers(t *testing.T) {
 }
 
 func TestParseModelWithADictionaryOfIntegersInlined(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_integers_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_integers_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -116,7 +116,7 @@ func TestParseModelWithADictionaryOfIntegersInlined(t *testing.T) {
 }
 
 func TestParseModelWithADictionaryOfAnObject(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_object.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -201,7 +201,7 @@ func TestParseModelWithADictionaryOfAnObject(t *testing.T) {
 }
 
 func TestParseModelWithADictionaryOfAnObjectInlined(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_object_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_object_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -286,7 +286,7 @@ func TestParseModelWithADictionaryOfAnObjectInlined(t *testing.T) {
 }
 
 func TestParseModelWithADictionaryOfString(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_string.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_string.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -338,7 +338,7 @@ func TestParseModelWithADictionaryOfString(t *testing.T) {
 }
 
 func TestParseModelWithADictionaryOfStringInlined(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_string_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_dictionary_of_string_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/models_discriminators_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_discriminators_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParseDiscriminatorsTopLevel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_simple.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_simple.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -109,7 +109,7 @@ func TestParseDiscriminatorsTopLevel(t *testing.T) {
 }
 
 func TestParseDiscriminatorsWithinArray(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_within_array.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_within_array.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -216,7 +216,7 @@ func TestParseDiscriminatorsWithinArray(t *testing.T) {
 }
 
 func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_within_discriminators.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_within_discriminators.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -401,7 +401,7 @@ func TestParseDiscriminatedParentTypeThatShouldntBe(t *testing.T) {
 	// Some Swagger files define top level types with a Discriminator value which don't inherit
 	// from anything. As such these aren't actually discriminated types but bad data - so we should
 	// look to ensure these are parsed out as a regular non-discriminated type.
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_parent_that_shouldnt_be.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_parent_that_shouldnt_be.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -446,7 +446,7 @@ func TestParseDiscriminatedChildTypeThatShouldntBe(t *testing.T) {
 	// Some Swagger files define top level types with a Discriminator value which don't inherit
 	// from anything. As such these aren't actually discriminated types but bad data - so we should
 	// look to ensure these are parsed out as a regular non-discriminated type.
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_child_that_shouldnt_be.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_child_that_shouldnt_be.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -491,7 +491,7 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 	// Some Swagger files contain Models with a reference to a Discriminated Type (e.g. an implementation
 	// where a Parent should be used instead) - this asserts that we shouldn't switch these out to
 	// referencing the Parent, instead should just use the Implementation itself.
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_child_used_as_parent.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_child_used_as_parent.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -588,7 +588,7 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 }
 
 func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_inherited_from_discriminators.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_inherited_from_discriminators.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -692,7 +692,7 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 }
 
 func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_deep_inheritance.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_deep_inheritance.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -875,7 +875,7 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 	// In this scenario the discriminated type Human inherits from NamedEntity (containing just properties)
 	// which inherits from the discriminated parent type BiologicalEntity
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_multiple_parents.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_multiple_parents.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1026,7 +1026,7 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 	// In this scenario the discriminated type Human inherits from NamedEntity (containing just properties)
 	// which inherits from the discriminated parent type BiologicalEntity
-	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_multiple_parents_within_array.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_discriminators_multiple_parents_within_array.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1178,7 +1178,7 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 }
 
 func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "/nestedtestdata/model_discriminators_orphaned_child.json")
+	actual, err := ParseSwaggerFileForTesting(t, "/nestedtestdata/model_discriminators_orphaned_child.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1255,7 +1255,7 @@ func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
 }
 
 func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "/nestedtestdata/model_discriminators_orphaned_child_with_nested_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "/nestedtestdata/model_discriminators_orphaned_child_with_nested_model.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1353,6 +1353,69 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
+}
+
+func TestParseDiscriminatorsOrphanedChildWithoutDiscriminatorValue(t *testing.T) {
+	actual, err := ParseSwaggerFileForTesting(t, "/nestedtestdata/model_discriminators_orphaned_child_without_discriminator_value.json", pointer.To("datafactory"))
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+
+	expected := importerModels.AzureApiDefinition{
+		ServiceName: "DataFactory",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]importerModels.AzureApiResource{
+			// NOTE: since there's no Operations defined the Models are placed into an APIResource based on the
+			// File Name. Whilst in a normal scenario this would make sense - for testing purposes it leads to
+			// some unexpectedly named data, but this is fine providing the APIResource we're expecting exists.
+			"ModelDiscriminatorsOrphanedChildWithoutDiscriminatorValues": {
+				Models: map[string]models.SDKModel{
+					"Animal": {
+						Fields: map[string]models.SDKField{
+							"AnimalType": {
+								JsonName: "animalType",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.StringSDKObjectDefinitionType,
+								},
+								Required: true,
+							},
+						},
+						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
+					},
+					"Cat": {
+						Fields: map[string]models.SDKField{
+							"AnimalType": {
+								JsonName: "animalType",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.StringSDKObjectDefinitionType,
+								},
+								Required: true,
+							},
+						},
+						ParentTypeName:                        pointer.To("Animal"),
+						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
+						DiscriminatedValue:                    pointer.To("Cat"),
+					},
+					"Dog": {
+						Fields: map[string]models.SDKField{
+							"AnimalType": {
+								JsonName: "animalType",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.StringSDKObjectDefinitionType,
+								},
+								Required: true,
+							},
+						},
+						ParentTypeName:                        pointer.To("Animal"),
+						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
+						DiscriminatedValue:                    pointer.To("Dog"),
+					},
+					// ExampleWrapper is present in the Swagger but unused
 				},
 			},
 		},

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -14,7 +14,7 @@ import (
 // TODO: tests for the different types of Object Definition
 
 func TestParseModelTopLevel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_top_level.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_top_level.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -95,7 +95,7 @@ func TestParseModelTopLevel(t *testing.T) {
 }
 
 func TestParseModelTopLevelWithRawFile(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_top_level_with_rawfile.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_top_level_with_rawfile.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -126,7 +126,7 @@ func TestParseModelTopLevelWithRawFile(t *testing.T) {
 }
 
 func TestParseModelTopLevelWithInlinedModel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_top_level_with_inlined_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_top_level_with_inlined_model.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -226,7 +226,7 @@ func TestParseModelTopLevelWithInlinedModel(t *testing.T) {
 }
 
 func TestParseModelWithDateTimeNoType(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_with_datetime_no_type.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_with_datetime_no_type.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -272,7 +272,7 @@ func TestParseModelWithDateTimeNoType(t *testing.T) {
 }
 
 func TestParseModelWithInlinedObject(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_with_inlined_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_with_inlined_object.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -367,7 +367,7 @@ func TestParseModelWithInlinedObject(t *testing.T) {
 }
 
 func TestParseModelWithNumberPrefixedField(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_with_number_prefixed_field.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_with_number_prefixed_field.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -416,7 +416,7 @@ func TestParseModelWithNumberPrefixedField(t *testing.T) {
 }
 
 func TestParseModelWithReference(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_with_reference.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_with_reference.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -499,7 +499,7 @@ func TestParseModelWithReference(t *testing.T) {
 }
 
 func TestParseModelWithReferenceToArray(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_with_reference_array.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_with_reference_array.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -568,7 +568,7 @@ func TestParseModelWithReferenceToArray(t *testing.T) {
 }
 
 func TestParseModelWithReferenceToConstant(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_with_reference_constant.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_with_reference_constant.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -649,7 +649,7 @@ func TestParseModelWithReferenceToConstant(t *testing.T) {
 }
 
 func TestParseModelWithReferenceToString(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_with_reference_string.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_with_reference_string.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -720,7 +720,7 @@ func TestParseModelWithReferenceToString(t *testing.T) {
 }
 
 func TestParseModelWithCircularReferences(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_with_circular_reference.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_with_circular_reference.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -822,7 +822,7 @@ func TestParseModelWithCircularReferences(t *testing.T) {
 }
 
 func TestParseModelInheritingFromObjectWithNoExtraFields(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_no_new_fields.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_no_new_fields.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -866,7 +866,7 @@ func TestParseModelInheritingFromObjectWithNoExtraFields(t *testing.T) {
 }
 
 func TestParseModelInheritingFromObjectWithNoExtraFieldsInlined(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_no_new_fields_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_no_new_fields_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -927,7 +927,7 @@ func TestParseModelInheritingFromObjectWithNoExtraFieldsInlined(t *testing.T) {
 }
 
 func TestParseModelInheritingFromObjectWithOnlyDescription(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_with_only_description.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_with_only_description.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -976,7 +976,7 @@ func TestParseModelInheritingFromObjectWithPropertiesWithinAllOf(t *testing.T) {
 	// This covers a regression from https://github.com/hashicorp/pandora/pull/3720
 	// which surfaced in https://github.com/hashicorp/pandora/pull/3726 for the model `AgentPool`
 	// within `ContainerService@2019-08-01/AgentPools` which was renamed `SubResource`.
-	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_with_properties_within_allof.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_other_model_with_properties_within_allof.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1021,7 +1021,7 @@ func TestParseModelInheritingFromObjectWithPropertiesWithinAllOf(t *testing.T) {
 }
 
 func TestParseModelContainingAllOfToTypeObject(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_containing_allof_object_type.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_containing_allof_object_type.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1074,7 +1074,7 @@ func TestParseModelContainingAllOfToTypeObject(t *testing.T) {
 }
 
 func TestParseModelContainingAllOfToTypeObjectWithProperties(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_containing_allof_object_type_with_properties.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_containing_allof_object_type_with_properties.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1127,7 +1127,7 @@ func TestParseModelContainingAllOfToTypeObjectWithProperties(t *testing.T) {
 }
 
 func TestParseModelContainingAllOfWithinProperties(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_containing_allof_within_properties.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_containing_allof_within_properties.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1206,7 +1206,7 @@ func TestParseModelContainingAllOfWithinProperties(t *testing.T) {
 }
 
 func TestParseModelContainingMultipleAllOfWithinProperties(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_containing_allof_within_properties_multiple.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_containing_allof_within_properties_multiple.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1297,7 +1297,7 @@ func TestParseModelContainingMultipleAllOfWithinProperties(t *testing.T) {
 }
 
 func TestParseModelContainingLists(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_containing_lists.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_containing_lists.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1383,7 +1383,7 @@ func TestParseModelContainingLists(t *testing.T) {
 }
 
 func TestParseModelInlinedWithNoName(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_inlined_with_no_name.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_inlined_with_no_name.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1440,7 +1440,7 @@ func TestParseModelInlinedWithNoName(t *testing.T) {
 }
 
 func TestParseModelInheritingFromParent(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_parent.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_inheriting_from_parent.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1514,7 +1514,7 @@ func TestParseModelInheritingFromParent(t *testing.T) {
 }
 
 func TestParseModelMultipleTopLevelModelsAndOperations(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "model_multiple_top_level_models_and_operations.json")
+	actual, err := ParseSwaggerFileForTesting(t, "model_multiple_top_level_models_and_operations.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1623,7 +1623,7 @@ func TestParseModelMultipleTopLevelModelsAndOperations(t *testing.T) {
 }
 
 func TestParseModelBug2675DuplicateModel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "models_bug_2675_duplicate_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "models_bug_2675_duplicate_model.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/operations_test.go
+++ b/tools/importer-rest-api-specs/components/parser/operations_test.go
@@ -15,7 +15,7 @@ import (
 // TODO: tests for the different types of Operation Object Definition - including CSV's inner object
 
 func TestParseOperationsEmpty(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_empty.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_empty.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -28,7 +28,7 @@ func TestParseOperationsEmpty(t *testing.T) {
 }
 
 func TestParseOperationSingleWithTag(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -53,7 +53,7 @@ func TestParseOperationSingleWithTag(t *testing.T) {
 }
 
 func TestParseOperationSingleWithTagAndResourceId(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag_resource_id.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag_resource_id.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -92,7 +92,7 @@ func TestParseOperationSingleWithTagAndResourceId(t *testing.T) {
 }
 
 func TestParseOperationSingleWithTagAndResourceIdSuffix(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag_resource_id_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_tag_resource_id_suffix.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -132,7 +132,7 @@ func TestParseOperationSingleWithTagAndResourceIdSuffix(t *testing.T) {
 }
 
 func TestParseOperationSingleWithRequestObject(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_object.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -174,7 +174,7 @@ func TestParseOperationSingleWithRequestObject(t *testing.T) {
 }
 
 func TestParseOperationSingleWithRequestObjectInlined(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_object_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_object_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -216,7 +216,7 @@ func TestParseOperationSingleWithRequestObjectInlined(t *testing.T) {
 }
 
 func TestParseOperationSingleWithResponseObject(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -258,7 +258,7 @@ func TestParseOperationSingleWithResponseObject(t *testing.T) {
 }
 
 func TestParseOperationSingleWithResponseObjectInlined(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object_inlined.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object_inlined.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -300,7 +300,7 @@ func TestParseOperationSingleWithResponseObjectInlined(t *testing.T) {
 }
 
 func TestParseOperationSingleWithResponseObjectInlinedList(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object_inlined_list.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_response_object_inlined_list.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -345,7 +345,7 @@ func TestParseOperationSingleWithResponseObjectInlinedList(t *testing.T) {
 }
 
 func TestParseOperationSingleRequestingWithABool(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_bool.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_bool.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -373,7 +373,7 @@ func TestParseOperationSingleRequestingWithABool(t *testing.T) {
 }
 
 func TestParseOperationSingleRequestingWithAInteger(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_int.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_int.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -401,7 +401,7 @@ func TestParseOperationSingleRequestingWithAInteger(t *testing.T) {
 }
 
 func TestParseOperationSingleRequestingWithADictionaryOfStrings(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_dictionary_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_dictionary_of_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -432,7 +432,7 @@ func TestParseOperationSingleRequestingWithADictionaryOfStrings(t *testing.T) {
 }
 
 func TestParseOperationSingleRequestingWithAListOfStrings(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_list_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_list_of_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -465,7 +465,7 @@ func TestParseOperationSingleRequestingWithAListOfStrings(t *testing.T) {
 // Models are already tested above
 
 func TestParseOperationSingleRequestingWithAString(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_string.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_requesting_with_a_string.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -493,7 +493,7 @@ func TestParseOperationSingleRequestingWithAString(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningABool(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_bool.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_bool.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -521,7 +521,7 @@ func TestParseOperationSingleReturningABool(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAFloat(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_float.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_float.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -549,7 +549,7 @@ func TestParseOperationSingleReturningAFloat(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAFile(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_file.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_file.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -577,7 +577,7 @@ func TestParseOperationSingleReturningAFile(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAnInteger(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_integer.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_integer.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -605,7 +605,7 @@ func TestParseOperationSingleReturningAnInteger(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAString(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_string.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_string.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -634,7 +634,7 @@ func TestParseOperationSingleReturningAString(t *testing.T) {
 
 func TestParseOperationSingleReturningAnErrorStatusCode(t *testing.T) {
 	// In this instance the error status code should be ignored we're only concerned with 2XX status codes
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_error_status_code.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_an_error_status_code.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -662,7 +662,7 @@ func TestParseOperationSingleReturningAnErrorStatusCode(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningATopLevelRawObject(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_top_level_raw_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_top_level_raw_object.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -693,7 +693,7 @@ func TestParseOperationSingleReturningATopLevelRawObject(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningADictionaryOfAModel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_dictionary_of_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_dictionary_of_model.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -738,7 +738,7 @@ func TestParseOperationSingleReturningADictionaryOfAModel(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningADictionaryOfStrings(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_dictionary_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_dictionary_of_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -769,7 +769,7 @@ func TestParseOperationSingleReturningADictionaryOfStrings(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAListOfIntegers(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_ints.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_ints.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -800,7 +800,7 @@ func TestParseOperationSingleReturningAListOfIntegers(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAListOfAModel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_model.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -845,7 +845,7 @@ func TestParseOperationSingleReturningAListOfAModel(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAListOfStrings(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -876,7 +876,7 @@ func TestParseOperationSingleReturningAListOfStrings(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAListOfListOfAModel(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_list_of_model.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_list_of_model.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -924,7 +924,7 @@ func TestParseOperationSingleReturningAListOfListOfAModel(t *testing.T) {
 }
 
 func TestParseOperationSingleReturningAListOfListOfStrings(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_list_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_returning_a_list_of_list_of_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -958,7 +958,7 @@ func TestParseOperationSingleReturningAListOfListOfStrings(t *testing.T) {
 }
 
 func TestParseOperationSingleWithList(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1003,7 +1003,7 @@ func TestParseOperationSingleWithList(t *testing.T) {
 func TestParseOperationSingleWithListWhichIsNotAList(t *testing.T) {
 	// all List operations should have an `x-ms-pageable` attribute, but some don't due to bad data
 	// as such this checks we can duck-type it out
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_which_is_not_a_list.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_which_is_not_a_list.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1050,7 +1050,7 @@ func TestParseOperationSingleWithListWhichIsNotAList(t *testing.T) {
 }
 
 func TestParseOperationSingleWithListReturningAListOfStrings(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_of_strings.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_of_strings.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1081,7 +1081,7 @@ func TestParseOperationSingleWithListReturningAListOfStrings(t *testing.T) {
 func TestParseOperationSingleWithListWithoutPageable(t *testing.T) {
 	// all List operations should have an `x-ms-pageable` attribute, but some don't due to bad data
 	// as such this checks we can duck-type it out
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_without_pageable.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_list_without_pageable.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1124,7 +1124,7 @@ func TestParseOperationSingleWithListWithoutPageable(t *testing.T) {
 }
 
 func TestParseOperationSingleWithLongRunningOperation(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_long_running.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_long_running.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1167,7 +1167,7 @@ func TestParseOperationSingleWithLongRunningOperation(t *testing.T) {
 }
 
 func TestParseOperationSingleWithRequestAndResponseObject(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_and_response_object.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_request_and_response_object.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1213,7 +1213,7 @@ func TestParseOperationSingleWithRequestAndResponseObject(t *testing.T) {
 }
 
 func TestParseOperationSingleWithMultipleTags(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_tags.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_tags.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1250,7 +1250,7 @@ func TestParseOperationSingleWithMultipleTags(t *testing.T) {
 }
 
 func TestParseOperationSingleWithInferredTag(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_no_tag.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_no_tag.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1277,7 +1277,7 @@ func TestParseOperationSingleWithInferredTag(t *testing.T) {
 }
 
 func TestParseOperationSingleWithHeaderOptions(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_header_options.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_header_options.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1359,7 +1359,7 @@ func TestParseOperationSingleWithHeaderOptions(t *testing.T) {
 }
 
 func TestParseOperationSingleWithQueryStringOptions(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_querystring_options.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_with_querystring_options.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1441,7 +1441,7 @@ func TestParseOperationSingleWithQueryStringOptions(t *testing.T) {
 }
 
 func TestParseOperationMultipleBasedOnTheSameResourceId(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_multiple_same_resource_id.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_multiple_same_resource_id.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1487,7 +1487,7 @@ func TestParseOperationMultipleBasedOnTheSameResourceId(t *testing.T) {
 }
 
 func TestParseOperationsContainingContentTypes(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operation_content_types.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operation_content_types.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1549,7 +1549,7 @@ func TestParseOperationsContainingContentTypes(t *testing.T) {
 }
 
 func TestParseOperationContainingMultipleReturnObjects(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_return_objects.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_multiple_return_objects.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -1591,7 +1591,7 @@ func TestParseOperationContainingMultipleReturnObjects(t *testing.T) {
 }
 
 func TestParseOperationsWithStutteringNames(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_with_stuttering_names.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_with_stuttering_names.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -78,7 +78,7 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 		inferredTag := cleanup.PluraliseName(swaggerFileName[len(swaggerFileName)-1])
 		normalizedTag := cleanup.NormalizeResourceName(inferredTag)
 
-		result, err := d.findOrphanedDiscriminatedModels()
+		result, err := d.findOrphanedDiscriminatedModels(serviceName)
 		if err != nil {
 			return nil, fmt.Errorf("finding orphaned discriminated models in %q: %+v", d.Name, err)
 		}

--- a/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParseResourceIdBasic(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_basic.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_basic.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -51,7 +51,7 @@ func TestParseResourceIdBasic(t *testing.T) {
 }
 
 func TestParseResourceIdContainingAConstant(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_constant.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_constant.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -98,7 +98,7 @@ func TestParseResourceIdContainingAConstant(t *testing.T) {
 }
 
 func TestParseResourceIdContainingAScope(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_scope.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_scope.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -143,7 +143,7 @@ func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
 		t.Run(file, func(t *testing.T) {
 			fileName := file
 
-			actual, err := ParseSwaggerFileForTesting(t, fileName)
+			actual, err := ParseSwaggerFileForTesting(t, fileName, nil)
 			if err != nil {
 				t.Fatalf("parsing: %+v", err)
 			}
@@ -179,7 +179,7 @@ func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
 
 func TestParseResourceIdContainingAHiddenScopeWithExtraSegment(t *testing.T) {
 	// The extra segment should be ignored and detected as a regular scope
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_extra_segment.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_extra_segment.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -212,7 +212,7 @@ func TestParseResourceIdContainingAHiddenScopeWithExtraSegment(t *testing.T) {
 }
 
 func TestParseResourceIdContainingAHiddenScopeWithSuffix(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_with_suffix.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -255,7 +255,7 @@ func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
 		t.Run(file, func(t *testing.T) {
 			fileName := file
 
-			actual, err := ParseSwaggerFileForTesting(t, fileName)
+			actual, err := ParseSwaggerFileForTesting(t, fileName, nil)
 			if err != nil {
 				t.Fatalf("parsing: %+v", err)
 			}
@@ -290,7 +290,7 @@ func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
 }
 
 func TestParseResourceIdContainingAHiddenScopeNestedWithExtraSegment(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_extra_segment.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_extra_segment.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -323,7 +323,7 @@ func TestParseResourceIdContainingAHiddenScopeNestedWithExtraSegment(t *testing.
 }
 
 func TestParseResourceIdContainingAHiddenScopeNestedWithSuffix(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_containing_hidden_scope_nested_with_suffix.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -357,7 +357,7 @@ func TestParseResourceIdContainingAHiddenScopeNestedWithSuffix(t *testing.T) {
 }
 
 func TestParseResourceIdWithJustUriSuffix(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_just_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_just_suffix.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -382,7 +382,7 @@ func TestParseResourceIdWithJustUriSuffix(t *testing.T) {
 }
 
 func TestParseResourceIdWithResourceIdAndUriSuffix(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_suffix.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_suffix.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -422,7 +422,7 @@ func TestParseResourceIdWithResourceIdAndUriSuffix(t *testing.T) {
 }
 
 func TestParseResourceIdWithResourceIdAndUriSuffixForMultipleUris(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_suffix_multiple_uris.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_with_suffix_multiple_uris.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -475,7 +475,7 @@ func TestParseResourceIdWithResourceIdAndUriSuffixForMultipleUris(t *testing.T) 
 }
 
 func TestParseResourceIdContainingResourceProviderShouldGetTitleCased(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_lowercased_resource_provider.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_lowercased_resource_provider.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -514,7 +514,7 @@ func TestParseResourceIdContainingResourceProviderShouldGetTitleCased(t *testing
 }
 
 func TestParseResourceIdContainingTheSameResourceIdWithDifferentSegments(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_same_id_different_segment_casing.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_same_id_different_segment_casing.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -560,7 +560,7 @@ func TestParseResourceIdContainingTheSameResourceIdWithDifferentSegments(t *test
 }
 
 func TestParseResourceIdContainingTheSegmentsNamedTheSame(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_multiple_segments_same_name.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_multiple_segments_same_name.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -613,7 +613,7 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 	for i := 0; i < 100; i++ {
 		t.Logf("iteration %d", i)
 
-		actual, err := ParseSwaggerFileForTesting(t, "resource_ids_same_uri_different_constant_values_per_operation.json")
+		actual, err := ParseSwaggerFileForTesting(t, "resource_ids_same_uri_different_constant_values_per_operation.json", nil)
 		if err != nil {
 			t.Fatalf("parsing: %+v", err)
 		}
@@ -674,7 +674,7 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 }
 
 func TestParseResourceIdsCommon(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_common.json")
+	actual, err := ParseSwaggerFileForTesting(t, "resource_ids_common.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_single_tag_different_casing.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_single_tag_different_casing.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}
@@ -87,7 +87,7 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 }
 
 func TestParsingOperationsOnResources(t *testing.T) {
-	actual, err := ParseSwaggerFileForTesting(t, "operations_on_resources.json")
+	actual, err := ParseSwaggerFileForTesting(t, "operations_on_resources.json", nil)
 	if err != nil {
 		t.Fatalf("parsing: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/testdata/nestedtestdata/model_discriminators_orphaned_child_without_discriminator_value.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/nestedtestdata/model_discriminators_orphaned_child_without_discriminator_value.json
@@ -1,0 +1,57 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "DataFactory",
+    "description": "DataFactory",
+    "version": "2020-01-01"
+  },
+  "paths": {},
+  "definitions": {
+    "ExampleWrapper": {
+      "description": "The Resource definition.",
+      "properties": {
+        "nested": {
+          "$ref": "#/definitions/Animal"
+        }
+      },
+      "required": [
+        "nested"
+      ],
+      "title": "ExampleWrapper",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "Animal": {
+      "discriminator": "animalType",
+      "properties": {
+        "animalType": {
+          "type": "string",
+          "description": "The type of Animal this is, used as a Discriminator value."
+        }
+      },
+      "required": [
+        "animalType"
+      ],
+      "title": "Animal",
+      "type": "object"
+    },
+    "Cat": {
+      "description": "A cat is a kind of animal",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Animal"
+        }
+      ],
+      "type": "object"
+    },
+    "Dog": {
+      "description": "A dog is a kind of animal",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Animal"
+        }
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
This PR re-enables a previous fix to extract the discriminator information for orphans from the parent and also correctly sets a value for the discriminator value by using the model name if it hasn't been specified by `x-ms-discriminator-value`.

This is behaviour is currently scoped to `DataFactory` since it's one of few? services that have discriminators defined this way.

To support testing for this the `ParseSwaggerFileForTesting` helper needed to be extended to accept a service name to be able to test the scoped behaviour.