### PR TITLE
Unignore deploymentoperations

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/swagger_tags.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags.go
@@ -9,7 +9,6 @@ import (
 )
 
 var tagsToIgnore = map[string]struct{}{
-	"deploymentoperations":  {},
 	"azurefirewallfqdntags": {},
 	"usage":                 {},
 }


### PR DESCRIPTION
In https://github.com/hashicorp/pandora/pull/3180 we added deployment operations to the tags to ignore list, however the Packer Azure plugin relies on ListDeploymentOperations for builds, so we need that API back to upgrade the plugin to the newest version of the SDK