### PR TITLE
`importer-rest-api-specs` - data workaround for `AlertsManagement` and move call to `removeUnusedItems`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_alertsmanagement.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_alertsmanagement.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dataworkarounds
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundAlertsManagement{}
+
+// workaroundAlertsManagement works around the missing discriminator implementations for
+// ActionRuleProperties. This workaround can be removed when v4.0 of the AzureRM Provider
+// has been released.
+type workaroundAlertsManagement struct {
+}
+
+func (workaroundAlertsManagement) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
+	serviceMatches := apiDefinition.ServiceName == "AlertsManagement"
+	apiVersionMatches := apiDefinition.ApiVersion == "2019-05-05-preview"
+	return serviceMatches && apiVersionMatches
+}
+
+func (workaroundAlertsManagement) Name() string {
+	return "AlertsManagement"
+}
+
+func (workaroundAlertsManagement) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
+	resource, ok := apiDefinition.Resources["ActionRules"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `ActionRules`")
+	}
+
+	modelNames := []string{
+		"ActionGroup",
+		"Diagnostics",
+		"Suppression",
+	}
+
+	for _, name := range modelNames {
+		model, ok := resource.Models[name]
+		if !ok {
+			return nil, fmt.Errorf("expected a Model named `%s`", name)
+		}
+		model.DiscriminatedValue = pointer.To(name)
+		model.ParentTypeName = pointer.To("ActionRuleProperties")
+		model.FieldNameContainingDiscriminatedValue = pointer.To("Type")
+
+		resource.Models[name] = model
+	}
+	apiDefinition.Resources["ActionRules"] = resource
+
+	return &apiDefinition, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -12,6 +12,7 @@ import (
 
 var workarounds = []workaround{
 	// These workarounds are related to issues with the upstream API Definitions
+	workaroundAlertsManagement{},
 	workaroundAuthorization25080{},
 	workaroundDigitalTwins25120{},
 	workaroundAutomation25108{},

--- a/tools/importer-rest-api-specs/components/parser/load_and_parse.go
+++ b/tools/importer-rest-api-specs/components/parser/load_and_parse.go
@@ -92,6 +92,19 @@ func LoadAndParseFiles(directory string, fileNames []string, serviceName, apiVer
 
 	out = *output
 
+	for _, service := range out {
+		for resource, details := range service.Resources {
+			models, constants, resourceIdNamesToUris := removeUnusedItems(details.Operations, details.ResourceIds, details.Models, details.Constants)
+			service.Resources[resource] = importerModels.AzureApiResource{
+				Constants:   constants,
+				Models:      models,
+				Operations:  details.Operations,
+				ResourceIds: resourceIdNamesToUris,
+				Terraform:   details.Terraform,
+			}
+		}
+	}
+
 	if len(out) > 1 {
 		return nil, fmt.Errorf("internal-error:the Swagger files for Service %q / API Version %q contained multiple resources (%d total)", serviceName, apiVersion, len(out))
 	}

--- a/tools/importer-rest-api-specs/components/parser/swagger_resources.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_resources.go
@@ -58,19 +58,16 @@ func (d *SwaggerDefinition) parseResourcesWithinSwaggerTag(tag *string, resource
 	// then switch out any custom types (e.g. Identity)
 	result = switchOutCustomTypesAsNeeded(result)
 
-	// finally remove any models and constants which aren't referenced / have been replaced
-	constantsAndModels, resourceIdNamesToUris := removeUnusedItems(*operations, resourceIds.NamesToResourceIDs, result)
-
 	// if there's nothing here, there's no point generating a package
 	if len(*operations) == 0 {
 		return nil, nil
 	}
 
 	resource := importerModels.AzureApiResource{
-		Constants:   constantsAndModels.Constants,
-		Models:      constantsAndModels.Models,
+		Constants:   result.Constants,
+		Models:      result.Models,
 		Operations:  *operations,
-		ResourceIds: resourceIdNamesToUris,
+		ResourceIds: resourceIds.NamesToResourceIDs,
 	}
 
 	// first Normalize the names, meaning `foo` -> `Foo` for consistency


### PR DESCRIPTION
This PR
- Adds a data workaround for the `ActionRules` resource in `AlertsManagement` which will allow us to remove `AlertsManagement` entirely from the provider
- Moves where we call `removeUnusedItems`, this was previously called everytime we parsed data associated with a swagger tag, but this results in the removal of models that might need to referenced in data workarounds. `removeUnusedItems` is now called after all the processing has been done for a service
- Refactors `removeUnusedItems` to take separate constants and models argument instead of a `result` argument of type `ParseResult`

The effects of this on the existing API definitions is minimal, all of the changes listed below will not affect any resources in the provider
```
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    api-definitions/resource-manager/DataFactory/2018-06-01/DataFlowDebugSession/Constant-IntegrationRuntimeReferenceType.json
        deleted:    api-definitions/resource-manager/DataFactory/2018-06-01/DataFlows/Model-PowerQuerySink.json
        deleted:    api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DataFlowSink.json
        deleted:    api-definitions/resource-manager/DataMigration/2021-06-30/Commons/Model-MongoDbConnectionInfo.json

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        api-definitions/resource-manager/AlertsManagement/2019-05-05-preview/ActionRules/Constant-SuppressionType.json
        api-definitions/resource-manager/AlertsManagement/2019-05-05-preview/ActionRules/Model-ActionGroup.json
        api-definitions/resource-manager/AlertsManagement/2019-05-05-preview/ActionRules/Model-Diagnostics.json
        api-definitions/resource-manager/AlertsManagement/2019-05-05-preview/ActionRules/Model-Suppression.json
        api-definitions/resource-manager/AlertsManagement/2019-05-05-preview/ActionRules/Model-SuppressionConfig.json
        api-definitions/resource-manager/AlertsManagement/2019-05-05-preview/ActionRules/Model-SuppressionSchedule.json
```