### PR TITLE
`importer-rest-api-specs` - update aks test template

### DIFF
--- a/tools/importer-rest-api-specs/components/terraform/testing/dependencies_template.go
+++ b/tools/importer-rest-api-specs/components/terraform/testing/dependencies_template.go
@@ -158,6 +158,9 @@ resource "%[1]s_kubernetes_cluster" "test" {
     node_count = 1
     vm_size    = "Standard_DS2_v2"
   }
+  upgrade_settings {
+      max_surge = "10%%"
+  }
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
Tests with this dependency are failing due to https://github.com/hashicorp/terraform-provider-azurerm/issues/24020