### PR TITLE
`importer-rest-api-specs` - updating model name to `LoadTestResourceUpdate` in workaround

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_loadtest_20961.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_loadtest_20961.go
@@ -33,20 +33,20 @@ func (workaroundLoadTest20961) Process(apiDefinition importerModels.AzureApiDefi
 	if !ok {
 		return nil, fmt.Errorf("couldn't find API Resource LoadTests")
 	}
-	model, ok := resource.Models["LoadTestResourcePatchRequestBody"]
+	model, ok := resource.Models["LoadTestResourceUpdate"]
 	if !ok {
-		return nil, fmt.Errorf("couldn't find Model LoadTestResourcePatchRequestBody")
+		return nil, fmt.Errorf("couldn't find Model LoadTestResourceUpdate")
 	}
 	field, ok := model.Fields["Tags"]
 	if !ok {
-		return nil, fmt.Errorf("couldn't find field Tags within model LoadTestResourcePatchRequestBody")
+		return nil, fmt.Errorf("couldn't find field Tags within model LoadTestResourceUpdate")
 	}
 	field.ObjectDefinition = models.SDKObjectDefinition{
 		Type: models.TagsSDKObjectDefinitionType,
 	}
 
 	model.Fields["Tags"] = field
-	resource.Models["LoadTestResourcePatchRequestBody"] = model
+	resource.Models["LoadTestResourceUpdate"] = model
 	apiDefinition.Resources["LoadTests"] = resource
 	return &apiDefinition, nil
 }


### PR DESCRIPTION
The Model `LoadTestResourcePatchRequestBody` was removed and replaced with `LoadTestResourceUpdate`

See https://github.com/Azure/azure-rest-api-specs/commit/3e81da30a1358b6ffcbc7ff222aae5f483971d32
Unblocks https://github.com/hashicorp/pandora/pull/4033