### PR TITLE
`importer-rest-api-specs` - fix aks test template

### DIFF
--- a/tools/importer-rest-api-specs/components/terraform/testing/dependencies_template.go
+++ b/tools/importer-rest-api-specs/components/terraform/testing/dependencies_template.go
@@ -157,9 +157,9 @@ resource "%[1]s_kubernetes_cluster" "test" {
     name       = "default"
     node_count = 1
     vm_size    = "Standard_DS2_v2"
-  }
-  upgrade_settings {
+    upgrade_settings {
       max_surge = "10%%%%"
+    }
   }
 
   identity {


### PR DESCRIPTION
To fix the following tests:

```
=== RUN   TestAccKubernetesClusterTrustedAccessRoleBinding_basic
=== PAUSE TestAccKubernetesClusterTrustedAccessRoleBinding_basic
=== CONT  TestAccKubernetesClusterTrustedAccessRoleBinding_basic
    testcase.go:113: Step 1/2 error: Error running pre-apply refresh: exit status 1
        Error: Unsupported block type
          on terraform_plugin_test.tf line 79, in resource "azurerm_kubernetes_cluster" "test":
          79:   upgrade_settings {
        Blocks of type "upgrade_settings" are not expected here.
--- FAIL: TestAccKubernetesClusterTrustedAccessRoleBinding_basic (3.63s)
FAIL
```