### PR TITLE
loadtestservice: disable terraform generation until we support encryption

### DIFF
--- a/config/resources/loadtestservice.hcl
+++ b/config/resources/loadtestservice.hcl
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+/*
 service "LoadTestService" {
   terraform_package = "loadtestservice"
 
@@ -15,3 +16,4 @@ service "LoadTestService" {
     }
   }
 }
+*/


### PR DESCRIPTION
With the ongoing refactor, it doesn't seem like we'll get to expanded terraform generation features for some time so I'm hoping we can disable that generation for load test service to get a much requested feature in quickly