### PR TITLE
add containerservice@2023-09-02-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -117,7 +117,7 @@ service "containerregistry" {
 }
 service "containerservice" {
   name      = "ContainerService"
-  available = ["2019-08-01", "2022-09-02-preview", "2023-03-02-preview", "2023-04-02-preview", "2023-06-02-preview", "2023-10-01", "2023-10-15", "2024-01-01", "2024-02-01"]
+  available = ["2019-08-01", "2022-09-02-preview", "2023-03-02-preview", "2023-04-02-preview", "2023-06-02-preview", "2023-09-02-preview", "2023-10-01", "2023-10-15", "2024-01-01", "2024-02-01"]
 }
 service "cosmos-db" {
   name      = "CosmosDB"


### PR DESCRIPTION
We're receiving two GA feature requests which require the minimum api-version 2023-09-02-preview.