### PR TITLE
LoadTestService: comment out the load test encryption check from the builder

### DIFF
--- a/tools/importer-rest-api-specs/components/terraform/schema/builder.go
+++ b/tools/importer-rest-api-specs/components/terraform/schema/builder.go
@@ -296,16 +296,20 @@ func (b Builder) schemaFromTopLevelModel(input resourcemanager.TerraformResource
 		return nil, nil
 	}
 
-	// @tombuildsstuff: this is a temporary workaround to strip out the `encryption` block for the Load Test Service
-	// the fix is tracked in https://github.com/hashicorp/pandora/issues/2608
-	// NOTE: other resources shouldn't use this approach and should instead fix the issue blocking generation - this
-	// is temporary to unblock this migration, since this has already shipped.
-	if input.SchemaModelName == "LoadTestResource" {
-		modelsUsedWithinProperties, mappings, err = applyTemporaryWorkaroundToLoadTestModelsAndMappings(*modelsUsedWithinProperties, mappings)
-		if err != nil {
-			return nil, fmt.Errorf("applying temporary workaround for Load Test: %+v", err)
+	/* @mbfrahry: this is a temporary workaround to re-add the `encryption block for the Load Test Service
+	              We've disabled the Terraform generation for the Load Test Service so we can get a requested feature in
+	              We'll want to un-comment this check when github.com/hashicorp/pandora/pull/4061 is reverted
+		// @tombuildsstuff: this is a temporary workaround to strip out the `encryption` block for the Load Test Service
+		// the fix is tracked in https://github.com/hashicorp/pandora/issues/2608
+		// NOTE: other resources shouldn't use this approach and should instead fix the issue blocking generation - this
+		// is temporary to unblock this migration, since this has already shipped.
+		if input.SchemaModelName == "LoadTestResource" {
+			modelsUsedWithinProperties, mappings, err = applyTemporaryWorkaroundToLoadTestModelsAndMappings(*modelsUsedWithinProperties, mappings)
+			if err != nil {
+				return nil, fmt.Errorf("applying temporary workaround for Load Test: %+v", err)
+			}
 		}
-	}
+	*/
 
 	return &modelParseResult{
 		mappings: *mappings,


### PR DESCRIPTION
This PR comments out a workaround for the LoadTestService that removes the Encryption block from the sdk as it was blocking Terraform generation. 

Depends on #4061

We'll want to add this check back in when we look to re-enable Terraform generation for LoadTest