### PR TITLE
`generator-go-sdk`: set `LatestHttpResponse` for List method even HTTP responses error

### DIFF
--- a/tools/generator-go-sdk/internal/generator/templater_methods.go
+++ b/tools/generator-go-sdk/internal/generator/templater_methods.go
@@ -339,6 +339,7 @@ func (c %[1]s) %[2]sCompleteMatchingPredicate(ctx context.Context%[4]s, predicat
 
 	resp, err := c.%[2]s(ctx%[6]s)
 	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %%+v", err)
 		return
 	}
@@ -365,6 +366,7 @@ func (c %[1]s) %[2]sComplete(ctx context.Context%[3]s) (result %[2]sCompleteResu
 
 	resp, err := c.%[2]s(ctx%[4]s)
 	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %%+v", err)
 		return
 	}

--- a/tools/generator-go-sdk/internal/generator/templater_methods_discriminators_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_methods_discriminators_test.go
@@ -347,6 +347,7 @@ func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, predicat
 	items := make([]PandaPop, 0)
 	resp, err := c.List(ctx)
 	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %%+v", err)
 		return
 	}
@@ -498,6 +499,7 @@ func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, predicat
 	items := make([]FizzyDrink, 0)
 	resp, err := c.List(ctx)
 	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %%+v", err)
 		return
 	}

--- a/tools/generator-go-sdk/internal/generator/templater_methods_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_methods_test.go
@@ -299,6 +299,7 @@ func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, id Panda
 
 	resp, err := c.List(ctx, id)
 	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %%+v", err)
 		return
 	}
@@ -410,6 +411,7 @@ func (c pandaClient) ListComplete(ctx context.Context, id PandaPop) (result List
 
 	resp, err := c.List(ctx, id)
 	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %%+v", err)
 		return
 	}
@@ -524,6 +526,7 @@ func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, id Panda
 
 	resp, err := c.List(ctx, id)
 	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
 		err = fmt.Errorf("loading results: %%+v", err)
 		return
 	}


### PR DESCRIPTION
Fixes: #4128