### PR TITLE
config: adding cost-management @ 2023-07-01-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -125,7 +125,7 @@ service "cosmos-db" {
 }
 service "cost-management" {
   name      = "CostManagement"
-  available = ["2021-10-01", "2022-06-01-preview", "2022-10-01", "2023-03-01", "2023-08-01", "2023-11-01"]
+  available = ["2021-10-01", "2022-06-01-preview", "2022-10-01", "2023-03-01", "2023-07-01-preview", "2023-08-01", "2023-11-01"]
 }
 service "customproviders" {
   name      = "CustomProviders"


### PR DESCRIPTION
Add 2023-07-01-preview for cost-management API.

This will allow addressing hashicorp/terraform-provider-azurerm#23747 . According to a sniff of the network inspector while managing Cost Exports in the Azure portal, this is the only API version in existence which contains the `partitionData` and `dataOverwriteBehavior` field for the export properties, and the `dataVersion` for the export dataset configuration, which in turn allows usage of the Exports API to [seed historical data](https://learn.microsoft.com/en-us/azure/cost-management-billing/automate/tutorial-seed-historical-cost-dataset-exports-api) - not possible unless you are using a new enough `dataVersion` according to the portal.