### PR TITLE
`tools/importer-rest-api-specs`: adding a workaround for https://github.com/Azure/azure-rest-api-specs/issues/20254

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_subscription_20254.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_subscription_20254.go
@@ -1,0 +1,50 @@
+package dataworkarounds
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+var _ workaround = workaroundSubscriptions20254{}
+
+// workaroundSubscriptions20254 works around the `SubscriptionCancel` API not exposing the `IgnoreResourceCheck` querystring parameter
+// Swagger Issue: https://github.com/Azure/azure-rest-api-specs/issues/20254
+type workaroundSubscriptions20254 struct {
+}
+
+func (w workaroundSubscriptions20254) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
+	return apiDefinition.ServiceName == "Subscription" && apiDefinition.ApiVersion == "2021-10-01"
+}
+
+func (w workaroundSubscriptions20254) Name() string {
+	return "Subscription / 20254"
+}
+
+func (w workaroundSubscriptions20254) Process(input importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
+	output := input
+
+	subscriptionResource, ok := input.Resources["Subscriptions"]
+	if !ok {
+		return nil, fmt.Errorf("expected an APIResource named `Subscriptions` but didn't get one")
+	}
+	operation, ok := subscriptionResource.Operations["SubscriptionCancel"]
+	if !ok {
+		return nil, fmt.Errorf("expected an Operation named `SubscriptionCancel` but didn't get one")
+	}
+	operation.Options = map[string]models.SDKOperationOption{
+		// IgnoreResourceCheck allows deleting a Subscription even if it contains nested Resources
+		"IgnoreResourceCheck": {
+			QueryStringName: pointer.To("IgnoreResourceCheck"),
+			ObjectDefinition: models.SDKOperationOptionObjectDefinition{
+				Type: models.BooleanSDKOperationOptionObjectDefinitionType,
+			},
+			Required: false,
+		},
+	}
+	subscriptionResource.Operations["SubscriptionCancel"] = operation
+	output.Resources["Subscriptions"] = subscriptionResource
+
+	return &output, nil
+}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -28,6 +28,7 @@ var workarounds = []workaround{
 	workaroundOperationalinsights27524{},
 	workaroundRecoveryServicesSiteRecovery26680{},
 	workaroundStreamAnalytics27577{},
+	workaroundSubscriptions20254{},
 
 	// These workarounds relate to Terraform specific overrides we want to apply (for example for Resource Generation)
 	workaroundDevCenterIdToRequired{},


### PR DESCRIPTION
This PR adds a workaround for [this issue](https://github.com/Azure/azure-rest-api-specs/issues/20254) - which enables deleting a Subscription containing Nested Resources.

Whilst this is obviously a dangerous operation, and wants a feature-flag accordingly, it's still useful to have at any rate.

Related https://github.com/hashicorp/terraform-provider-azurerm/issues/12264