### PR TITLE
`hdinsight`: removing `2024-05-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -259,7 +259,7 @@ service "hardwaresecuritymodules" {
 }
 service "hdinsight" {
   name      = "HDInsight"
-  available = ["2021-06-01", "2024-05-01"]
+  available = ["2021-06-01"]
 }
 service "healthbot" {
   name      = "HealthBot"


### PR DESCRIPTION
The Service Team have pulled this version, despite it being Stable - so I guess we're removing support for this.

Works around https://github.com/Azure/azure-rest-api-specs/pull/29441