### PR TITLE
`tools/importer-rest-api-specs`: ensuring that DateFormats are stored against the Field and not the ObjectDefinition

### DIFF
--- a/tools/data-api-repository/repository/internal/transforms/sdk_field_object_definition.go
+++ b/tools/data-api-repository/repository/internal/transforms/sdk_field_object_definition.go
@@ -6,7 +6,6 @@ package transforms
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/data-api-repository/repository/internal/helpers"
 	repositoryModels "github.com/hashicorp/pandora/tools/data-api-repository/repository/internal/models"
 	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
@@ -56,17 +55,7 @@ func mapSDKFieldObjectDefinitionToRepository(input sdkModels.SDKObjectDefinition
 		output.NestedItem = nestedItem
 	}
 
-	// TODO: come back to these after the SDK switch
-	//if definition.Maximum != nil {
-	//	output.MaxItems = definition.Maximum
-	//}
-	//if definition.Minimum != nil {
-	//	output.MinItems = definition.Minimum
-	//}
-	if output.Type == repositoryModels.DateTimeObjectDefinitionType {
-		// TODO: support additional types of Date Formats (#8)
-		output.DateFormat = pointer.To(repositoryModels.RFC3339DateFormat)
-	}
+	// consider storing min/max here in the future
 
 	// finally let's do some sanity-checking to ensure the data being output looks legit
 	if err := validateObjectDefinition(output, knownData); err != nil {

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -159,6 +159,12 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 		result.Append(*nestedResult)
 	}
 
+	// TODO: support for other date formats (RFC3339Nano etc)
+	// https://github.com/hashicorp/pandora/issues/8
+	if objectDefinition.Type == models.DateTimeSDKObjectDefinitionType {
+		field.DateFormat = pointer.To(models.RFC3339SDKDateFormat)
+	}
+
 	// if there are more than 1 allOf, it can not use a simple reference type, but a new definition
 	if len(value.Properties) > 0 || len(value.AllOf) > 1 {
 		// there's a nested model we need to pull out


### PR DESCRIPTION
Whilst this _is_ related to the ObjectDefinition, we'd want to expose the `Get` and `Set` methods that this information generates against the field, rather than the path to the Object Definition, so we should store this there.

Once this is merged there'll be a change to the Source Data, namely:

```diff
diff --git a/api-definitions/resource-manager/AAD/2021-05-01/DomainServices/Model-HealthAlert.json b/api-definitions/resource-manager/AAD/2021-05-01/DomainServices/Model-HealthAlert.json
index 5ff0b0af03..1e8ce1801b 100644
--- a/api-definitions/resource-manager/AAD/2021-05-01/DomainServices/Model-HealthAlert.json
+++ b/api-definitions/resource-manager/AAD/2021-05-01/DomainServices/Model-HealthAlert.json
@@ -29,12 +29,12 @@
     },
     {
       "containsDiscriminatedTypeValue": false,
+      "dateFormat": "RFC3339",
       "jsonName": "lastDetected",
       "name": "LastDetected",
       "objectDefinition": {
         "type": "DateTime",
-        "referenceName": null,
-        "dateFormat": "RFC3339"
+        "referenceName": null
       },
       "optional": true,
       "readOnly": false,
@@ -56,12 +56,12 @@
     },
     {
       "containsDiscriminatedTypeValue": false,
+      "dateFormat": "RFC3339",
       "jsonName": "raised",
       "name": "Raised",
       "objectDefinition": {
         "type": "DateTime",
-        "referenceName": null,
-        "dateFormat": "RFC3339"
+        "referenceName": null
       },
       "optional": true,
       "readOnly": false,
```