### PR TITLE
`tools/data-api`: fixing an issue where the input arguments weren't being picked up/used

### DIFF
--- a/tools/data-api-repository/repository/helpers_discovery.go
+++ b/tools/data-api-repository/repository/helpers_discovery.go
@@ -131,7 +131,7 @@ func discoverCommonTypesWithin(workingDirectory string, sourceDataType sdkModels
 			return nil, fmt.Errorf("parsing the Common Types within %q: %+v", commonTypesDirectory, err)
 		}
 		if commonTypes == nil {
-			logger.Debug("The directory at %q contained no Common Types - skipping")
+			logger.Debug(fmt.Sprintf("The directory at %q contained no Common Types - skipping", commonTypesDirectory))
 			continue
 		}
 		for apiVersion, value := range *commonTypes {

--- a/tools/data-api/internal/commands/args.go
+++ b/tools/data-api/internal/commands/args.go
@@ -29,7 +29,7 @@ type Arguments struct {
 }
 
 func (a *Arguments) Parse(input []string) error {
-	logging.Tracef("Parsing arguments..")
+	logging.Tracef("Parsing arguments (%+v)..", input)
 
 	var portVar int
 	var serviceNamesRaw string
@@ -39,6 +39,10 @@ func (a *Arguments) Parse(input []string) error {
 	f.IntVar(&portVar, "port", a.Port, "The Port the Data API Endpoint will run on (e.g. --port=8080")
 	f.StringVar(&dataDirectoryRaw, "data-directory", a.DataDirectory, "The path to the directory the data will be read from")
 	f.Parse(input)
+
+	if dataDirectoryRaw != "" {
+		a.DataDirectory = dataDirectoryRaw
+	}
 
 	if serviceNamesRaw != "" {
 		a.ServiceNames = pointer.To(strings.Split(serviceNamesRaw, ","))
@@ -62,6 +66,10 @@ func (a *Arguments) Parse(input []string) error {
 		return fmt.Errorf("determining the absolute path for %q: %+v", a.DataDirectory, err)
 	}
 	a.DataDirectory = abs
+
+	logging.Log.Info(fmt.Sprintf("Using Service Names [%+v]..", a.ServiceNames))
+	logging.Log.Info(fmt.Sprintf("Using the Port %d..", a.Port))
+	logging.Log.Info(fmt.Sprintf("Using the Data Directory %q..", a.DataDirectory))
 
 	return nil
 }

--- a/tools/data-api/main.go
+++ b/tools/data-api/main.go
@@ -21,20 +21,10 @@ func main() {
 	logging.Log = hclog.New(loggingOpts)
 	logging.Infof("Data API launched..")
 
-	args := commands.Arguments{
-		// defaults
-		DataDirectory: "../../api-definitions/",
-		Port:          8080,
-		ServiceNames:  nil,
-	}
-	if err := args.Parse(os.Args[1:]); err != nil {
-		log.Fatalf(err.Error())
-	}
-
 	c := cli.NewCLI("data-api", "1.0.0")
 	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
-		"serve": commands.NewServeCommand(args),
+		"serve": commands.NewServeCommand(),
 	}
 
 	exitStatus, err := c.Run()


### PR DESCRIPTION
When testing this I was running the `data-api` from within `./tools/data-api` and totally missed that we weren't picking up non-default paths 🙃 