### PR TITLE
`tools/importer-rest-api-specs`: support for parsing the Data Factory custom types into regular Object Definitions

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -5,7 +5,6 @@ package parser
 
 import (
 	"fmt"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/featureflags"
 	"strings"
 
 	"github.com/go-openapi/spec"
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/constants"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/featureflags"
 )
 
 func (d *SwaggerDefinition) parseModel(name string, input spec.Schema) (*internal.ParseResult, error) {
@@ -725,7 +725,7 @@ func (d SwaggerDefinition) parseObjectDefinition(
 
 func (d SwaggerDefinition) parseDataFactoryCustomTypes(input *spec.Schema, known internal.ParseResult) (*models.SDKObjectDefinition, *internal.ParseResult, error) {
 	formatVal := ""
-	if featureflags.ParseDataFactoryCustomTypesAsRegularObjectDefinitionTypes && input.Type.Contains("object") {
+	if input.Type.Contains("object") {
 		formatVal, _ = input.Extensions.GetString("x-ms-format")
 	}
 	if formatVal == "" {
@@ -765,7 +765,7 @@ func (d SwaggerDefinition) parseDataFactoryCustomTypes(input *spec.Schema, known
 	}
 
 	// DataFactory has some specific reimplementations of List too..
-	if strings.EqualFold(formatVal, "dfe-list-generic") {
+	if strings.EqualFold(formatVal, "dfe-list-generic") && featureflags.ParseDataFactoryListsOfReferencesAsRegularObjectDefinitionTypes {
 		// NOTE: it's also possible to have
 		elementType, ok := input.Extensions.GetString("x-ms-format-element-type")
 		if !ok {

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -5,6 +5,7 @@ package parser
 
 import (
 	"fmt"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/featureflags"
 	"strings"
 
 	"github.com/go-openapi/spec"
@@ -700,12 +701,110 @@ func (d SwaggerDefinition) parseObjectDefinition(
 		}, &result, nil
 	}
 
+	// Data Factory has a bunch of Custom Types, so we need to check for/handle those
+	dataFactoryObjectDefinition, parseResult, err := d.parseDataFactoryCustomTypes(input, known)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing the Data Factory Object Definition: %+v", err)
+	}
+	if dataFactoryObjectDefinition != nil {
+		if parseResult != nil {
+			if err := result.Append(*parseResult); err != nil {
+				return nil, nil, fmt.Errorf("appending parseResult: %+v", err)
+			}
+		}
+		return dataFactoryObjectDefinition, &result, nil
+	}
+
 	// if it's a simple type, there'll be no other objects
 	if nativeType := d.parseNativeType(input); nativeType != nil {
 		return nativeType, &result, nil
 	}
 
 	return nil, nil, fmt.Errorf("unimplemented object definition")
+}
+
+func (d SwaggerDefinition) parseDataFactoryCustomTypes(input *spec.Schema, known internal.ParseResult) (*models.SDKObjectDefinition, *internal.ParseResult, error) {
+	formatVal := ""
+	if featureflags.ParseDataFactoryCustomTypesAsRegularObjectDefinitionTypes && input.Type.Contains("object") {
+		formatVal, _ = input.Extensions.GetString("x-ms-format")
+	}
+	if formatVal == "" {
+		return nil, nil, nil
+	}
+
+	// DataFactory has a bunch of CustomTypes, which use `"type": "object" and "x-ms-format"` to describe the type
+	// as such we need to handle that here
+	// Simple Types
+	if strings.EqualFold(formatVal, "dfe-bool") {
+		return &models.SDKObjectDefinition{
+			Type: models.BooleanSDKObjectDefinitionType,
+		}, nil, nil
+	}
+	if strings.EqualFold(formatVal, "dfe-double") {
+		return &models.SDKObjectDefinition{
+			Type: models.FloatSDKObjectDefinitionType,
+		}, nil, nil
+	}
+	if strings.EqualFold(formatVal, "dfe-key-value-pairs") {
+		return &models.SDKObjectDefinition{
+			Type: models.DictionarySDKObjectDefinitionType,
+			NestedItem: &models.SDKObjectDefinition{
+				Type: models.StringSDKObjectDefinitionType,
+			},
+		}, nil, nil
+	}
+	if strings.EqualFold(formatVal, "dfe-int") {
+		return &models.SDKObjectDefinition{
+			Type: models.IntegerSDKObjectDefinitionType,
+		}, nil, nil
+	}
+	if strings.EqualFold(formatVal, "dfe-string") {
+		return &models.SDKObjectDefinition{
+			Type: models.StringSDKObjectDefinitionType,
+		}, nil, nil
+	}
+
+	// DataFactory has some specific reimplementations of List too..
+	if strings.EqualFold(formatVal, "dfe-list-generic") {
+		// NOTE: it's also possible to have
+		elementType, ok := input.Extensions.GetString("x-ms-format-element-type")
+		if !ok {
+			return nil, nil, fmt.Errorf("when `x-ms-format` is set to `dfe-list-generic` a `x-ms-format-element-type` must be set - but was not found")
+		}
+		referencedModel, err := d.findTopLevelObject(elementType)
+		if err != nil {
+			return nil, nil, fmt.Errorf("finding the top-level-object %q: %+v", elementType, err)
+		}
+		parseResult, err := d.parseModel(elementType, *referencedModel)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing the Model %q: %+v", elementType, err)
+		}
+		if err := known.Append(*parseResult); err != nil {
+			return nil, nil, fmt.Errorf("appending `parseResult`: %+v", err)
+		}
+		return &models.SDKObjectDefinition{
+			Type: models.ListSDKObjectDefinitionType,
+			NestedItem: &models.SDKObjectDefinition{
+				Type:          models.ReferenceSDKObjectDefinitionType,
+				ReferenceName: pointer.To(elementType),
+			},
+		}, &known, nil
+	}
+
+	if strings.EqualFold(formatVal, "dfe-list-string") {
+		return &models.SDKObjectDefinition{
+			Type: models.ListSDKObjectDefinitionType,
+			NestedItem: &models.SDKObjectDefinition{
+				Type: models.StringSDKObjectDefinitionType,
+			},
+		}, nil, nil
+	}
+
+	// otherwise let this fall through, since the "least bad" thing to do here is to mark this as an object
+
+	return &models.SDKObjectDefinition{
+		Type: models.RawObjectSDKObjectDefinitionType,
+	}, nil, nil
 }
 
 func (d SwaggerDefinition) parseNativeType(input *spec.Schema) *models.SDKObjectDefinition {
@@ -743,6 +842,7 @@ func (d SwaggerDefinition) parseNativeType(input *spec.Schema) *models.SDKObject
 				Type: models.RawFileSDKObjectDefinitionType,
 			}
 		}
+
 		return &models.SDKObjectDefinition{
 			Type: models.RawObjectSDKObjectDefinitionType,
 		}

--- a/tools/importer-rest-api-specs/components/parser/models_datafactorycustom_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_datafactorycustom_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/featureflags"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+)
+
+func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
+	// This test ensures that we parse the Data Factory Custom Types out to regular Object Definitions.
+	if !featureflags.ParseDataFactoryCustomTypesAsRegularObjectDefinitionTypes {
+		t.Fatalf("Skipping since `ParseDataFactoryCustomTypesAsRegularObjectDefinitionTypes` is disabled")
+	}
+
+	actual, err := ParseSwaggerFileForTesting(t, "model_using_datafactory_custom_types.json", nil)
+	if err != nil {
+		t.Fatalf("parsing: %+v", err)
+	}
+
+	expected := importerModels.AzureApiDefinition{
+		ServiceName: "Example",
+		ApiVersion:  "2020-01-01",
+		Resources: map[string]importerModels.AzureApiResource{
+			"Example": {
+				Models: map[string]models.SDKModel{
+					"Model": {
+						Fields: map[string]models.SDKField{
+							// Simple Types
+							"BooleanField": {
+								JsonName: "booleanField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.BooleanSDKObjectDefinitionType,
+								},
+								Required: false,
+							},
+							"DoubleField": {
+								JsonName: "doubleField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.FloatSDKObjectDefinitionType,
+								},
+								Required: false,
+							},
+							"KeyValuePairField": {
+								JsonName: "keyValuePairField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.DictionarySDKObjectDefinitionType,
+									NestedItem: &models.SDKObjectDefinition{
+										Type: models.StringSDKObjectDefinitionType,
+									},
+								},
+								Required: false,
+							},
+							"IntegerField": {
+								JsonName: "integerField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.IntegerSDKObjectDefinitionType,
+								},
+								Required: false,
+							},
+							"StringField": {
+								JsonName: "stringField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.StringSDKObjectDefinitionType,
+								},
+								Required: false,
+							},
+							"UnknownField": {
+								// In this case, the `dfe-*` value is unknown, so we should return an object
+								// this is the default behaviour, mostly for sanity-checking
+								JsonName: "unknownField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.RawObjectSDKObjectDefinitionType,
+								},
+								Required: false,
+							},
+
+							// Dictionaries of a Simple Type (using the regular Swagger/OpenAPI syntax)
+							"DictionaryOfBooleanField": {
+								JsonName: "dictionaryOfBooleanField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.DictionarySDKObjectDefinitionType,
+									NestedItem: &models.SDKObjectDefinition{
+										Type: models.BooleanSDKObjectDefinitionType,
+									},
+								},
+								Required: false,
+							},
+							"DictionaryOfDoubleField": {
+								JsonName: "dictionaryOfDoubleField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.DictionarySDKObjectDefinitionType,
+									NestedItem: &models.SDKObjectDefinition{
+										Type: models.FloatSDKObjectDefinitionType,
+									},
+								},
+								Required: false,
+							},
+							"DictionaryOfIntegerField": {
+								JsonName: "dictionaryOfIntegerField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.DictionarySDKObjectDefinitionType,
+									NestedItem: &models.SDKObjectDefinition{
+										Type: models.IntegerSDKObjectDefinitionType,
+									},
+								},
+								Required: false,
+							},
+							"DictionaryOfStringField": {
+								JsonName: "dictionaryOfStringField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.DictionarySDKObjectDefinitionType,
+									NestedItem: &models.SDKObjectDefinition{
+										Type: models.StringSDKObjectDefinitionType,
+									},
+								},
+								Required: false,
+							},
+							"DictionaryOfUnknownField": {
+								// In this case, the `dfe-*` value is unknown, so we should return an object
+								// this is the default behaviour, mostly for sanity-checking
+								JsonName: "dictionaryOfUnknownField",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.DictionarySDKObjectDefinitionType,
+									NestedItem: &models.SDKObjectDefinition{
+										Type: models.RawObjectSDKObjectDefinitionType,
+									},
+								},
+								Required: false,
+							},
+
+							// DFE specific List implementations
+							"DfeCustomListOfString": {
+								JsonName: "dfeCustomListOfString",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.ListSDKObjectDefinitionType,
+									NestedItem: &models.SDKObjectDefinition{
+										Type: models.StringSDKObjectDefinitionType,
+									},
+								},
+								Required: false,
+							},
+							"DfeCustomListOfAnotherObject": {
+								JsonName: "dfeCustomListOfAnotherObject",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.ListSDKObjectDefinitionType,
+									NestedItem: &models.SDKObjectDefinition{
+										Type:          models.ReferenceSDKObjectDefinitionType,
+										ReferenceName: pointer.To("SecondModel"),
+									},
+								},
+								Required: false,
+							},
+						},
+					},
+					"SecondModel": {
+						Fields: map[string]models.SDKField{
+							"Example": {
+								JsonName: "example",
+								ObjectDefinition: models.SDKObjectDefinition{
+									Type: models.StringSDKObjectDefinitionType,
+								},
+							},
+						},
+					},
+				},
+				Operations: map[string]models.SDKOperation{
+					"Test": {
+						ContentType:         "application/json",
+						ExpectedStatusCodes: []int{200},
+						Method:              "PUT",
+						RequestObject: &models.SDKObjectDefinition{
+							ReferenceName: pointer.To("Model"),
+							Type:          models.ReferenceSDKObjectDefinitionType,
+						},
+						ResponseObject: &models.SDKObjectDefinition{
+							ReferenceName: pointer.To("Model"),
+							Type:          models.ReferenceSDKObjectDefinitionType,
+						},
+						URISuffix: pointer.To("/example"),
+					},
+				},
+			},
+		},
+	}
+	validateParsedSwaggerResultMatches(t, expected, actual)
+}

--- a/tools/importer-rest-api-specs/components/parser/testdata/model_using_datafactory_custom_types.json
+++ b/tools/importer-rest-api-specs/components/parser/testdata/model_using_datafactory_custom_types.json
@@ -1,0 +1,139 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Example",
+    "description": "Example",
+    "version": "2020-01-01"
+  },
+  "host": "management.mysite.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [],
+  "securityDefinitions": {},
+  "paths": {
+    "/example": {
+      "put": {
+        "tags": [
+          "Example"
+        ],
+        "operationId": "Example_Test",
+        "description": "Tests parsing of a simple model.",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model"
+            },
+            "description": "Wrapper class."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Model"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Model": {
+      "description": "The Resource definition.",
+      "properties": {
+        "booleanField": {
+          "type": "object",
+          "x-ms-format": "dfe-bool"
+        },
+        "doubleField": {
+          "type": "object",
+          "x-ms-format": "dfe-double"
+        },
+        "keyValuePairField": {
+          "type": "object",
+          "x-ms-format": "dfe-key-value-pairs"
+        },
+        "integerField": {
+          "type": "object",
+          "x-ms-format": "dfe-int"
+        },
+        "stringField": {
+          "type": "object",
+          "x-ms-format": "dfe-string"
+        },
+        "unknownField": {
+          "type": "object",
+          "x-ms-format": "dfe-somethingnew"
+        },
+
+        "dictionaryOfBooleanField": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "x-ms-format": "dfe-bool"
+          }
+        },
+        "dictionaryOfDoubleField": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "x-ms-format": "dfe-double"
+          }
+        },
+        "dictionaryOfIntegerField": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "x-ms-format": "dfe-int"
+          }
+        },
+        "dictionaryOfStringField": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "x-ms-format": "dfe-string"
+          }
+        },
+        "dictionaryOfUnknownField": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "x-ms-format": "dfe-somethingnew"
+          }
+        },
+
+        "dfeCustomListOfString": {
+          "type": "object",
+          "x-ms-format": "dfe-list-string"
+        },
+        "dfeCustomListOfAnotherObject": {
+          "type": "object",
+          "x-ms-format": "dfe-list-generic",
+          "x-ms-format-element-type": "SecondModel"
+        }
+      },
+      "required": [],
+      "title": "Example",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "SecondModel": {
+      "properties": {
+        "example": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/tools/importer-rest-api-specs/internal/featureflags/constants.go
+++ b/tools/importer-rest-api-specs/internal/featureflags/constants.go
@@ -8,11 +8,12 @@ package featureflags
 // issues are resolved - since the Swagger should define canonical names for these Enums.
 const AllowConstantsWithoutXMSEnum = true
 
-// ParseDataFactoryCustomTypesAsRegularObjectDefinitionTypes specifies whether the Custom Types
+// ParseDataFactoryListsOfReferencesAsRegularObjectDefinitionTypes specifies whether the Custom Types
 // used by Data Factory (defined as `"type": "object" and "format": "dfe-XXX"`) should be parsed
-// into regular ObjectDefinitions, rather than left as Objects.
+// into regular ObjectDefinitions, rather than left as Objects - when these contain a Reference to
+// a List of Objects.
 //
-// @tombuildsstuff: this Feature Flag is currently disabled, since it requires loading Types
-// from the Nested files first, which wants to be done post the ongoing refactor.
-// As such I'll pick this up once https://github.com/hashicorp/pandora/issues/3754 is completed.
-const ParseDataFactoryCustomTypesAsRegularObjectDefinitionTypes = false
+// This feature-toggle is specific to the List of a Reference option, with the other Object Definition
+// Types being enabled. However enabling this requires shifting the loading of nested types around which
+// wants to be done post the ongoing refactor is completed (https://github.com/hashicorp/pandora/issues/3754).
+const ParseDataFactoryListsOfReferencesAsRegularObjectDefinitionTypes = false

--- a/tools/importer-rest-api-specs/internal/featureflags/constants.go
+++ b/tools/importer-rest-api-specs/internal/featureflags/constants.go
@@ -7,3 +7,12 @@ package featureflags
 // an x-ms-enum extension. This is intended to be a temporary stop-gap whilst the data
 // issues are resolved - since the Swagger should define canonical names for these Enums.
 const AllowConstantsWithoutXMSEnum = true
+
+// ParseDataFactoryCustomTypesAsRegularObjectDefinitionTypes specifies whether the Custom Types
+// used by Data Factory (defined as `"type": "object" and "format": "dfe-XXX"`) should be parsed
+// into regular ObjectDefinitions, rather than left as Objects.
+//
+// @tombuildsstuff: this Feature Flag is currently disabled, since it requires loading Types
+// from the Nested files first, which wants to be done post the ongoing refactor.
+// As such I'll pick this up once https://github.com/hashicorp/pandora/issues/3754 is completed.
+const ParseDataFactoryCustomTypesAsRegularObjectDefinitionTypes = false


### PR DESCRIPTION
This PR parses the DataFactory custom types into regular Object Definitions, meaning that rather than outputting these as Objects we're correctly outputting these as whatever the type is.

I've currently enabled this for all of the Data Factory Custom Types **except** a List of a Reference - since these reference models outside the Swagger file we're loading and thus need to be loaded ahead of time. Once the remaining refactoring work is completed we can circle back and enable the remaining functionality - but this gets us the majority of the benefits for now, and we can rejig the loading order post-refactor.

Fixes https://github.com/hashicorp/pandora/issues/4026 - I'll open a replacement issue to track support for Data Factory references of a custom type

---

This causes a change in:

```
 $ git diff --name-only  api-definitions/resource-manager/DataFactory/2018-06-01/                                                                                                                     (f/parsing-datafactory-custom-types ⚡)
api-definitions/resource-manager/DataFactory/2018-06-01/Credentials/Model-AzureKeyVaultSecretReference.json
api-definitions/resource-manager/DataFactory/2018-06-01/Credentials/Model-ServicePrincipalCredentialTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/DataFlowDebugSession/Model-DataFlowStagingInfo.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AmazonRdsForOracleTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AmazonRdsForSqlServerTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AmazonRedshiftTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AmazonS3CompatibleLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AmazonS3DatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AmazonS3Location.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AvroDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureBlobDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureBlobFSDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureBlobFSLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureBlobStorageLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureDataExplorerDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureDataLakeStoreDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureDatabricksDeltaLakeDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureMySqlTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzurePostgreSqlTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureSearchIndexDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureSqlDWTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureSqlMITableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureSqlTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-AzureTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-CassandraTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-CommonDataServiceForAppsEntityDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-CosmosDbMongoDbApiCollectionDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-CosmosDbSqlApiCollectionDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DatasetCompression.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DatasetLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DatasetStorageFormat.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-Db2TableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DelimitedTextDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DocumentDbCollectionDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DrillDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DynamicsAXResourceDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DynamicsCrmEntityDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-DynamicsEntityDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-ExcelDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-FileShareDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-GenericDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-GoogleBigQueryDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-GoogleBigQueryV2DatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-GoogleCloudStorageLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-GreenplumDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-HTTPDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-HTTPServerLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-HiveDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-ImpalaDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-InformixTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-JsonDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-JsonFormat.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-LakeHouseTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-MicrosoftAccessTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-MongoDbAtlasCollectionDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-MongoDbCollectionDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-MongoDbV2CollectionDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-MySqlTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-NetezzaTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-ODataResourceDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-OdbcTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-Office365DatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-OracleCloudStorageLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-OracleTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-OrcDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-ParquetDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-PhoenixDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-PostgreSqlTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-PostgreSqlV2TableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-PrestoDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-RelationalTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-RestResourceDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SalesforceObjectDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SalesforceServiceCloudObjectDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SalesforceServiceCloudV2ObjectDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SalesforceV2ObjectDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SapCloudForCustomerResourceDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SapEccResourceDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SapHanaTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SapOdpResourceDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SapOpenHubTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SapTableResourceDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SharePointOnlineListDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SnowflakeDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SparkDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SqlServerTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-SybaseTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-TeradataTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-TextFormat.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-VerticaDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-WarehouseTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-WebTableDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Datasets/Model-XmlDatasetTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/IntegrationRuntimes/Model-CmdkeySetupTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AmazonMWSLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AmazonRdsForLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AmazonRdsForSqlServerLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AmazonRedshiftLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AmazonS3CompatibleLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AmazonS3LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AppFiguresLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureBatchLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureBlobFSLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureBlobStorageLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureDataExplorerLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureDataLakeAnalyticsLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureDataLakeStoreLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureDatabricksDetltaLakeLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureDatabricksLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureFileStorageLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureFunctionLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureKeyVaultLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureKeyVaultSecretReference.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureMLLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureMLServiceLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureMariaDBLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureMySqlLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzurePostgreSqlLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureSearchLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureSqlDWLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureSqlDatabaseLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureSqlMILinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureStorageLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-AzureSynapseArtifactsLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-CassandraLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-CommonDataServiceForAppsLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ConcurLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-CosmosDbLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-CosmosDbMongoDbApiLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-CouchbaseLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-Db2LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-DrillLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-DynamicsAXLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-DynamicsCrmLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-DynamicsLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-EloquaLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-FileServerLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-FtpServerLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-GoogleAdWordsLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-GoogleBigQueryLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-GoogleBigQueryV2LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-GoogleCloudStorageLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-GreenplumLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-HBaseLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-HDInsightLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-HDInsightOnDemandLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-HTTPLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-HdfsLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-HiveLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-HubspotLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ImpalaLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-InformixLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-JiraLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-LakeHouseLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-MagentoLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-MariaDBLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-MarketoLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-MicrosoftAccessLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-MongoDbAtlasLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-MongoDbLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-MongoDbV2LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-MySqlLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-NetezzaLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ODataLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-OdbcLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-Office365LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-OracleCloudStorageLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-OracleLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-OracleServiceCloudLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-PaypalLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-PhoenixLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-PostgreSqlLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-PostgreSqlV2LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-PrestoLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-QuickBooksLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-QuickbaseLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ResponsysLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-RestServiceLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SalesforceLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SalesforceMarketingCloudLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SalesforceServiceCloudLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SalesforceServiceCloudV2LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SalesforceV2LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SapBWLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SapCloudForCustomerLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SapEccLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SapHanaLinkedServiceProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SapOdpLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SapOpenHubLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SapTableLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ServiceNowLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ServiceNowV2LinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SftpServerLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SharePointOnlineListLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ShopifyLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SnowflakeLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SnowflakeLinkedV2ServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SparkLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SqlAlwaysEncryptedProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SqlServerLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SquareLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-SybaseLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-TeamDeskLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-TeradataLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-TwilioLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-VerticaLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-WarehouseLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-WebBasicAuthentication.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-WebLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-XeroLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ZendeskLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/LinkedServices/Model-ZohoLinkedServiceTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ActivityPolicy.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AmazonMWSSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AmazonRdsForOraclePartitionSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AmazonRdsForOracleSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AmazonRdsForSqlServerSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AmazonRedshiftSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AmazonS3CompatibleReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AmazonS3ReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AvroWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureBlobFSReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureBlobFSSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureBlobFSSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureBlobFSWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureBlobStorageReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureBlobStorageWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDataExplorerCommandActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDataExplorerSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDataExplorerSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDataLakeStoreReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDataLakeStoreSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDataLakeStoreSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDataLakeStoreWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDatabricksDeltaLakeExportCommand.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDatabricksDeltaLakeImportCommand.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDatabricksDeltaLakeSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureDatabricksDeltaLakeSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureFileStorageReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureFunctionActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureMLBatchExecutionActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureMLExecutePipelineActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureMLUpdateResourceActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureMLWebServiceFile.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureMariaDBSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureMySqlSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureMySqlSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzurePostgreSqlSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzurePostgreSqlSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureSqlSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureSqlSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureTableSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-AzureTableSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-BigDataPoolParametrizationReference.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-BlobSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-BlobSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CassandraSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CommonDataServiceForAppsSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CommonDataServiceForAppsSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ConcurSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ContinuationSettingsReference.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CopyActivityLogSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CopyActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CopySink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CopySource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CosmosDbMongoDbApiSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CosmosDbMongoDbApiSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CosmosDbSqlApiSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CosmosDbSqlApiSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CouchbaseSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-CustomActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DataFlowStagingInfo.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DataLakeAnalyticsUSQLActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DatabricksNotebookActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DatabricksSparkJarActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DatabricksSparkPythonActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-Db2Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DeleteActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DelimitedTextReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DelimitedTextWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DistcpSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DocumentDbCollectionSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DocumentDbCollectionSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DrillSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DynamicsAXSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DynamicsCrmSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DynamicsCrmSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DynamicsSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-DynamicsSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-EloquaSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ExecuteDataFlowActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ExecuteDataFlowActivityTypePropertiesCompute.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ExecutePowerQueryActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ExecuteSSISPackageActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-FailActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-FileServerReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-FileSystemSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-FileSystemSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-FtpReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-GetMetadataActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-GoogleAdWordsSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-GoogleBigQuerySource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-GoogleBigQueryV2Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-GoogleCloudStorageReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-GreenplumSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HBaseSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HDInsightHiveActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HDInsightMapReduceActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HDInsightPigActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HDInsightSparkActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HDInsightStreamingActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HTTPReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HTTPSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HdfsReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HdfsSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HiveSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-HubspotSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ImpalaSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-InformixSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-InformixSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-JiraSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-JsonWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-LakeHouseReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-LakeHouseTableSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-LakeHouseTableSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-LogLocationSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-LogSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-LogStorageSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-LookupActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MagentoSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MariaDBSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MarketoSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MetadataItem.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MicrosoftAccessSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MicrosoftAccessSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MongoDbAtlasSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MongoDbAtlasSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MongoDbCursorMethodsProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MongoDbSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MongoDbV2Sink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MongoDbV2Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-MySqlSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-NetezzaPartitionSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-NetezzaSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-NotebookParameter.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ODataSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-OdbcSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-OdbcSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-Office365Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-OracleCloudStorageReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-OraclePartitionSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-OracleServiceCloudSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-OracleSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-OracleSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-OrcWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ParquetWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-PaypalSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-PhoenixSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-Pipeline.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-PolybaseSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-PostgreSqlSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-PostgreSqlV2Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-PrestoSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-QuickBooksSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-RedirectIncompatibleRowSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-RedshiftUnloadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-RelationalSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ResponsysSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-RestSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-RestSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISAccessCredential.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISChildPackage.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISExecutionCredential.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISExecutionParameter.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISLogLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISLogLocationTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISPackageLocation.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISPackageLocationTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SSISPropertyOverride.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceMarketingCloudSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceServiceCloudSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceServiceCloudSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceServiceCloudV2Sink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceServiceCloudV2Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceV2Sink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SalesforceV2Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapBwSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapCloudForCustomerSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapCloudForCustomerSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapEccSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapHanaPartitionSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapHanaSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapOdpSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapOpenHubSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapTablePartitionSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SapTableSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ScriptActivityParameter.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ScriptActivityScriptBlock.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ScriptActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ServiceNowSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ServiceNowV2Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SftpReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SftpWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SharePointOnlineListSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ShopifySource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SkipErrorFile.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SnowflakeExportCopyCommand.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SnowflakeImportCopyCommand.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SnowflakeSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SnowflakeSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SnowflakeV2Sink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SnowflakeV2Source.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SparkConfigurationParametrizationReference.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SparkSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlDWSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlDWSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlDWUpsertSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlMISink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlMISource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlPartitionSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlServerSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlServerSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlServerStoredProcedureActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SqlUpsertSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SquareSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-StagingSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-StoreReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-StoreWriteSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SybaseSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SynapseNotebookActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SynapseNotebookReference.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SynapseSparkJobActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-SynapseSparkJobReference.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-TabularSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-TabularTranslator.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-TarGZipReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-TarReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-TeradataPartitionSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-TeradataSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-TypeConversionSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-UntilActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-UserProperty.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ValidationActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-VerticaSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-WaitActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-WarehouseSink.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-WarehouseSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-WebActivityAuthentication.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-WebActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-WebHookActivityTypeProperties.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-XeroSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-XmlReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ZipDeflateReadSettings.json
api-definitions/resource-manager/DataFactory/2018-06-01/Pipelines/Model-ZohoSource.json
api-definitions/resource-manager/DataFactory/2018-06-01/Triggers/Model-RetryPolicy.json
api-definitions/resource-manager/DataFactory/2018-06-01/Triggers/Model-TumblingWindowTriggerTypeProperties.json
```

However the majority of these aren't used by the Provider right now, so this is a minimal compilation change.