### PR TITLE
`tools/generator-go-sdk`: sorting the `ClientOptions` alphabetically / removing blank lines

### DIFF
--- a/tools/generator-go-sdk/README.md
+++ b/tools/generator-go-sdk/README.md
@@ -59,7 +59,7 @@ By default, the generated Go SDK will be output to your desktop (`~/Desktop/gene
 
 The `generator-go-sdk` tool supports a number of command-line arguments:
 
-* `--data-api=http://some-uri:2022` - specifies the URI for the Data API (defaults to `http://localhost:5000`).
+* `--data-api=http://some-uri:2022` - specifies the URI for the Data API (defaults to `http://localhost:8080`).
 * `--output-dir=/some/custom/path` - specifies the directory where the Go SDK should be generated (defaults to `~/Desktop/generated-sdk-dev`).
 * `--services=Service1,Service2` - generates the Go SDK for only the specified Services for expediency - the Service Names coming from the `name` field [within the Configuration File that defines which Service should be imported](`../../config/resource-manager.hcl`).
 

--- a/tools/generator-go-sdk/internal/cmd/generate.go
+++ b/tools/generator-go-sdk/internal/cmd/generate.go
@@ -76,7 +76,7 @@ func (g GenerateCommand) Run(args []string) int {
 	var serviceNames string
 
 	f := flag.NewFlagSet("generator-go-sdk", flag.ExitOnError)
-	f.StringVar(&input.apiServerEndpoint, "data-api", "http://localhost:5000", "-data-api=http://localhost:5000")
+	f.StringVar(&input.apiServerEndpoint, "data-api", "http://localhost:8080", "-data-api=http://localhost:8080")
 	f.StringVar(&input.outputDirectory, "output-dir", "", "-output-dir=../generated-sdk-dev")
 	f.StringVar(&serviceNames, "services", "", "A list of comma separated Service named from the Data API to import")
 	if err := f.Parse(args); err != nil {

--- a/tools/generator-go-sdk/internal/generator/templater_id_parser_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_id_parser_test.go
@@ -130,7 +130,7 @@ var _ resourceids.ResourceId = &BasicTestId{}
 	func (id BasicTestId) Segments() []resourceids.Segment {
 		return []resourceids.Segment{
 			resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
-			resourceids.SubscriptionIdSegment("subscriptionId", "11112222-3333-4444-555566667777"),
+			resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		}
 	}
 

--- a/tools/generator-go-sdk/internal/generator/templater_methods.go
+++ b/tools/generator-go-sdk/internal/generator/templater_methods.go
@@ -528,29 +528,27 @@ func (c methodsPandoraTemplater) requestOptions() (*string, error) {
 			path = "id.ID()"
 		}
 	}
-	options := ""
+
+	items := []string{
+		fmt.Sprintf("ContentType: %q", c.operation.ContentType),
+		fmt.Sprintf(`ExpectedStatusCodes: []int{
+			%s,
+}`, strings.Join(expectedStatusCodes, ",\n\t\t\t")),
+		fmt.Sprintf("HttpMethod: http.Method%s", method),
+		fmt.Sprintf("Path: %s", path),
+	}
 	if len(c.operation.Options) > 0 {
-		options = "OptionsObject: options,"
+		items = append(items, "OptionsObject: options")
 	}
-
-	customPagerOption := ""
 	if c.operation.FieldContainingPaginationDetails != nil {
-		customPagerOption = fmt.Sprintf("Pager: &%sCustomPager{},", c.operationName)
+		items = append(items, fmt.Sprintf("Pager: &%sCustomPager{}", c.operationName))
 	}
-
-	contentType := c.operation.ContentType
+	sort.Strings(items)
 
 	out := fmt.Sprintf(`client.RequestOptions{
-		ContentType: %[1]q,
-		ExpectedStatusCodes: []int{
-			%[2]s,
-		},
-		HttpMethod: http.Method%[3]s,
-		%[6]s
-		Path: %[4]s,
-		%[5]s
+		%s,
 	}
-`, contentType, strings.Join(expectedStatusCodes, ",\n\t\t\t"), method, path, options, customPagerOption)
+`, strings.Join(items, ",\n\t\t"))
 	return &out, nil
 }
 


### PR DESCRIPTION
This PR fixes an issue spotted in the regeneration from https://github.com/hashicorp/pandora/pull/3958, where an extra new line is added to each Operation - leading to the big diff seen in https://github.com/hashicorp/go-azure-sdk/pull/1038

This PR also fixes the default port for the Data API used by the Go SDK Generator to be 8080 (to match V2) rather than 5000 (which was for V1).

Running a diff on the generated output from this branch, vs main shows:

![Screenshot 2024-06-28 at 16 23 59](https://github.com/hashicorp/pandora/assets/666005/483a787e-d9ba-4a1b-ae85-05652639d6c8)
