### PR TITLE
`tools/importer-rest-api-specs`: handling the case of `ManagementGroupSubscriptions` being truncated to `Ubscriptions`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/normalization.go
+++ b/tools/importer-rest-api-specs/components/parser/normalization.go
@@ -4,6 +4,7 @@
 package parser
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
@@ -17,11 +18,18 @@ func normalizeOperationName(operationId string, tag *string) string {
 		// to account for the casing of the tag being different
 		if strings.HasPrefix(strings.ToLower(operationName), strings.ToLower(*tag)) {
 			operationName = operationName[len(*tag):]
+
+			// however if the Tag is `ManagementGroupsSubscriptions`, then we need to keep the extra `S` around
+			if *tag == "ManagementGroups" && !strings.HasPrefix(operationName, "_") {
+				operationName = fmt.Sprintf("S%s", operationName)
+			}
 		}
 	}
 	operationName = strings.ReplaceAll(operationName, "_", "")
 	operationName = strings.TrimPrefix(operationName, "Operations") // sanity checking
-	operationName = strings.TrimPrefix(operationName, "s")          // plurals
+	if !strings.HasPrefix(strings.ToLower(operationName), "subscriptions") {
+		operationName = strings.TrimPrefix(operationName, "s") // plurals
+	}
 	operationName = strings.TrimPrefix(operationName, "_")
 	operationName = cleanup.NormalizeName(operationName)
 	return operationName


### PR DESCRIPTION
This PR fixes OperationIDs such as `ManagementGroupSubscriptions_Example` being parsed as `Ubscriptions_Example` (and then normalised to `UbscriptionsExample`, as shown in https://github.com/hashicorp/go-azure-sdk/issues/1025)

Running `make import` on this shows the following diff:

```
❯ git status
On branch b/ubscriptions
Your branch is up to date with 'origin/b/ubscriptions'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Operation-UbscriptionsCreate.json -> ../../api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Operation-SubscriptionsCreate.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2023-04-01/ManagementGroups/Operation-UbscriptionsDelete.json -> ../../api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Operation-SubscriptionsDelete.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2023-04-01/ManagementGroups/Operation-UbscriptionsGetSubscription.json -> ../../api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Operation-SubscriptionsGetSubscription.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2023-04-01/ManagementGroups/Operation-UbscriptionsGetSubscriptionsUnderManagementGroup.json -> ../../api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Operation-SubscriptionsGetSubscriptionsUnderManagementGroup.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2023-04-01/ManagementGroups/Operation-UbscriptionsCreate.json -> ../../api-definitions/resource-manager/ManagementGroups/2021-04-01/ManagementGroups/Operation-SubscriptionsCreate.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Operation-UbscriptionsDelete.json -> ../../api-definitions/resource-manager/ManagementGroups/2021-04-01/ManagementGroups/Operation-SubscriptionsDelete.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2021-04-01/ManagementGroups/Operation-UbscriptionsGetSubscription.json -> ../../api-definitions/resource-manager/ManagementGroups/2021-04-01/ManagementGroups/Operation-SubscriptionsGetSubscription.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2021-04-01/ManagementGroups/Operation-UbscriptionsGetSubscriptionsUnderManagementGroup.json -> ../../api-definitions/resource-manager/ManagementGroups/2021-04-01/ManagementGroups/Operation-SubscriptionsGetSubscriptionsUnderManagementGroup.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2021-04-01/ManagementGroups/Operation-UbscriptionsCreate.json -> ../../api-definitions/resource-manager/ManagementGroups/2023-04-01/ManagementGroups/Operation-SubscriptionsCreate.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2021-04-01/ManagementGroups/Operation-UbscriptionsDelete.json -> ../../api-definitions/resource-manager/ManagementGroups/2023-04-01/ManagementGroups/Operation-SubscriptionsDelete.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Operation-UbscriptionsGetSubscription.json -> ../../api-definitions/resource-manager/ManagementGroups/2023-04-01/ManagementGroups/Operation-SubscriptionsGetSubscription.json
	renamed:    ../../api-definitions/resource-manager/ManagementGroups/2020-05-01/ManagementGroups/Operation-UbscriptionsGetSubscriptionsUnderManagementGroup.json -> ../../api-definitions/resource-manager/ManagementGroups/2023-04-01/ManagementGroups/Operation-SubscriptionsGetSubscriptionsUnderManagementGroup.json
```

Fixes https://github.com/hashicorp/go-azure-sdk/issues/1025

