### PR TITLE
`tools/importer-rest-api-specs`: foundational refactoring of `parser`

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_edge_zone.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_edge_zone.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -15,14 +15,14 @@ var _ customFieldMatcher = edgeZoneFieldMatcher{}
 type edgeZoneFieldMatcher struct {
 }
 
-func (e edgeZoneFieldMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.EdgeZoneSDKObjectDefinitionType,
+func (e edgeZoneFieldMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.EdgeZoneSDKObjectDefinitionType,
 	}
 }
 
-func (e edgeZoneFieldMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (e edgeZoneFieldMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -42,7 +42,7 @@ func (e edgeZoneFieldMatcher) IsMatch(field models.SDKField, known internal.Pars
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_legacy_system_and_user_assigned_list.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_legacy_system_and_user_assigned_list.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = legacySystemAndUserAssignedIdentityListMatcher{}
 
 type legacySystemAndUserAssignedIdentityListMatcher struct{}
 
-func (legacySystemAndUserAssignedIdentityListMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.LegacySystemAndUserAssignedIdentityListSDKObjectDefinitionType,
+func (legacySystemAndUserAssignedIdentityListMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.LegacySystemAndUserAssignedIdentityListSDKObjectDefinitionType,
 	}
 }
 
-func (legacySystemAndUserAssignedIdentityListMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (legacySystemAndUserAssignedIdentityListMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -49,10 +49,10 @@ func (legacySystemAndUserAssignedIdentityListMatcher) IsMatch(field models.SDKFi
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a List of Strings
-			if fieldVal.ObjectDefinition.Type != models.ListSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ListSDKObjectDefinitionType {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.StringSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != sdkModels.StringSDKObjectDefinitionType {
 				continue
 			}
 
@@ -61,7 +61,7 @@ func (legacySystemAndUserAssignedIdentityListMatcher) IsMatch(field models.SDKFi
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_legacy_system_and_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_legacy_system_and_user_assigned_map.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = legacySystemAndUserAssignedIdentityMapMatcher{}
 
 type legacySystemAndUserAssignedIdentityMapMatcher struct{}
 
-func (legacySystemAndUserAssignedIdentityMapMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.LegacySystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
+func (legacySystemAndUserAssignedIdentityMapMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.LegacySystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
 	}
 }
 
-func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -49,7 +49,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKFie
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a Map of an Object containing ClientId/PrincipalId
-			if fieldVal.ObjectDefinition.Type == models.DictionarySDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type == sdkModels.DictionarySDKObjectDefinitionType {
 				// however some Swaggers don't define the internals e.g. DataFactory
 				//type FactoryIdentity struct {
 				//	PrincipalId            *string                 `json:"principalId,omitempty"`
@@ -60,7 +60,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKFie
 				hasUserAssignedIdentities = true
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 
@@ -73,7 +73,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKFie
 			innerHasPrincipalId := false
 			for innerName, innerVal := range inlinedModel.Fields {
 				if strings.EqualFold(innerName, "ClientId") {
-					if innerVal.ObjectDefinition.Type != models.StringSDKObjectDefinitionType {
+					if innerVal.ObjectDefinition.Type != sdkModels.StringSDKObjectDefinitionType {
 						continue
 					}
 
@@ -82,7 +82,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKFie
 				}
 
 				if strings.EqualFold(innerName, "PrincipalId") {
-					if innerVal.ObjectDefinition.Type != models.StringSDKObjectDefinitionType {
+					if innerVal.ObjectDefinition.Type != sdkModels.StringSDKObjectDefinitionType {
 						continue
 					}
 
@@ -98,7 +98,7 @@ func (legacySystemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKFie
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_and_user_assigned_list.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_and_user_assigned_list.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = systemAndUserAssignedIdentityListMatcher{}
 
 type systemAndUserAssignedIdentityListMatcher struct{}
 
-func (systemAndUserAssignedIdentityListMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.SystemAndUserAssignedIdentityListSDKObjectDefinitionType,
+func (systemAndUserAssignedIdentityListMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.SystemAndUserAssignedIdentityListSDKObjectDefinitionType,
 	}
 }
 
-func (systemAndUserAssignedIdentityListMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (systemAndUserAssignedIdentityListMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -49,10 +49,10 @@ func (systemAndUserAssignedIdentityListMatcher) IsMatch(field models.SDKField, k
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a List of Strings
-			if fieldVal.ObjectDefinition.Type != models.ListSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ListSDKObjectDefinitionType {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.StringSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != sdkModels.StringSDKObjectDefinitionType {
 				continue
 			}
 
@@ -61,7 +61,7 @@ func (systemAndUserAssignedIdentityListMatcher) IsMatch(field models.SDKField, k
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_and_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_and_user_assigned_map.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = systemAndUserAssignedIdentityMapMatcher{}
 
 type systemAndUserAssignedIdentityMapMatcher struct{}
 
-func (systemAndUserAssignedIdentityMapMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.SystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
+func (systemAndUserAssignedIdentityMapMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.SystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
 	}
 }
 
-func (systemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (systemAndUserAssignedIdentityMapMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -49,10 +49,10 @@ func (systemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, kn
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a Map of an Object containing ClientId/PrincipalId
-			if fieldVal.ObjectDefinition.Type != models.DictionarySDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.DictionarySDKObjectDefinitionType {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 
@@ -65,7 +65,7 @@ func (systemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, kn
 			innerHasPrincipalId := false
 			for innerName, innerVal := range inlinedModel.Fields {
 				if strings.EqualFold(innerName, "ClientId") {
-					if innerVal.ObjectDefinition.Type != models.StringSDKObjectDefinitionType {
+					if innerVal.ObjectDefinition.Type != sdkModels.StringSDKObjectDefinitionType {
 						continue
 					}
 
@@ -74,7 +74,7 @@ func (systemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, kn
 				}
 
 				if strings.EqualFold(innerName, "PrincipalId") {
-					if innerVal.ObjectDefinition.Type != models.StringSDKObjectDefinitionType {
+					if innerVal.ObjectDefinition.Type != sdkModels.StringSDKObjectDefinitionType {
 						continue
 					}
 
@@ -90,7 +90,7 @@ func (systemAndUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, kn
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_assigned.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_assigned.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -15,14 +15,14 @@ var _ customFieldMatcher = systemAssignedIdentityMatcher{}
 
 type systemAssignedIdentityMatcher struct{}
 
-func (systemAssignedIdentityMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.SystemAssignedIdentitySDKObjectDefinitionType,
+func (systemAssignedIdentityMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.SystemAssignedIdentitySDKObjectDefinitionType,
 	}
 }
 
-func (systemAssignedIdentityMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (systemAssignedIdentityMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -48,7 +48,7 @@ func (systemAssignedIdentityMatcher) IsMatch(field models.SDKField, known intern
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]
@@ -69,8 +69,8 @@ func (systemAssignedIdentityMatcher) IsMatch(field models.SDKField, known intern
 	return hasMatchingType && hasPrincipalId && hasTenantId
 }
 
-func validateIdentityConstantValues(input models.SDKConstant, expected map[string]string) bool {
-	if input.Type != models.StringSDKConstantType {
+func validateIdentityConstantValues(input sdkModels.SDKConstant, expected map[string]string) bool {
+	if input.Type != sdkModels.StringSDKConstantType {
 		return false
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_or_user_assigned_list.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_or_user_assigned_list.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = systemOrUserAssignedIdentityListMatcher{}
 
 type systemOrUserAssignedIdentityListMatcher struct{}
 
-func (systemOrUserAssignedIdentityListMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.SystemOrUserAssignedIdentityListSDKObjectDefinitionType,
+func (systemOrUserAssignedIdentityListMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.SystemOrUserAssignedIdentityListSDKObjectDefinitionType,
 	}
 }
 
-func (systemOrUserAssignedIdentityListMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (systemOrUserAssignedIdentityListMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -49,10 +49,10 @@ func (systemOrUserAssignedIdentityListMatcher) IsMatch(field models.SDKField, kn
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a List of Strings
-			if fieldVal.ObjectDefinition.Type != models.ListSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ListSDKObjectDefinitionType {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.StringSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != sdkModels.StringSDKObjectDefinitionType {
 				continue
 			}
 
@@ -61,7 +61,7 @@ func (systemOrUserAssignedIdentityListMatcher) IsMatch(field models.SDKField, kn
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_or_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_system_or_user_assigned_map.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = systemOrUserAssignedIdentityMapMatcher{}
 
 type systemOrUserAssignedIdentityMapMatcher struct{}
 
-func (systemOrUserAssignedIdentityMapMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
+func (systemOrUserAssignedIdentityMapMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
 	}
 }
 
-func (systemOrUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (systemOrUserAssignedIdentityMapMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -49,10 +49,10 @@ func (systemOrUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, kno
 
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a Map of an Object containing ClientId/PrincipalId
-			if fieldVal.ObjectDefinition.Type != models.DictionarySDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.DictionarySDKObjectDefinitionType {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 
@@ -65,7 +65,7 @@ func (systemOrUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, kno
 			innerHasPrincipalId := false
 			for innerName, innerVal := range inlinedModel.Fields {
 				if strings.EqualFold(innerName, "ClientId") {
-					if innerVal.ObjectDefinition.Type != models.StringSDKObjectDefinitionType {
+					if innerVal.ObjectDefinition.Type != sdkModels.StringSDKObjectDefinitionType {
 						continue
 					}
 
@@ -74,7 +74,7 @@ func (systemOrUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, kno
 				}
 
 				if strings.EqualFold(innerName, "PrincipalId") {
-					if innerVal.ObjectDefinition.Type != models.StringSDKObjectDefinitionType {
+					if innerVal.ObjectDefinition.Type != sdkModels.StringSDKObjectDefinitionType {
 						continue
 					}
 
@@ -90,7 +90,7 @@ func (systemOrUserAssignedIdentityMapMatcher) IsMatch(field models.SDKField, kno
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_list.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_list.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = userAssignedIdentityListMatcher{}
 
 type userAssignedIdentityListMatcher struct{}
 
-func (userAssignedIdentityListMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.UserAssignedIdentityListSDKObjectDefinitionType,
+func (userAssignedIdentityListMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.UserAssignedIdentityListSDKObjectDefinitionType,
 	}
 }
 
-func (userAssignedIdentityListMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (userAssignedIdentityListMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -36,10 +36,10 @@ func (userAssignedIdentityListMatcher) IsMatch(field models.SDKField, known inte
 	for fieldName, fieldVal := range model.Fields {
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a List of Strings
-			if fieldVal.ObjectDefinition.Type != models.ListSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ListSDKObjectDefinitionType {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.StringSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != sdkModels.StringSDKObjectDefinitionType {
 				continue
 			}
 
@@ -51,7 +51,7 @@ func (userAssignedIdentityListMatcher) IsMatch(field models.SDKField, known inte
 		// https://github.com/Azure/azure-rest-api-specs/blob/c803720c6bcfcb0fcf4c97f3463ec33a18f9e55c/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabricManagedClusters/stable/2021-05-01/nodetype.json#L763
 		// as such we're only concerned if it's defined and doesn't match
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_map.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_identity_user_assigned_map.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = userAssignedIdentityMapMatcher{}
 
 type userAssignedIdentityMapMatcher struct{}
 
-func (userAssignedIdentityMapMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.UserAssignedIdentityMapSDKObjectDefinitionType,
+func (userAssignedIdentityMapMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.UserAssignedIdentityMapSDKObjectDefinitionType,
 	}
 }
 
-func (userAssignedIdentityMapMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (userAssignedIdentityMapMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -37,10 +37,10 @@ func (userAssignedIdentityMapMatcher) IsMatch(field models.SDKField, known inter
 	for fieldName, fieldVal := range model.Fields {
 		if strings.EqualFold(fieldName, "UserAssignedIdentities") {
 			// this should be a Map of an Object containing ClientId/PrincipalId
-			if fieldVal.ObjectDefinition.Type != models.DictionarySDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.DictionarySDKObjectDefinitionType {
 				continue
 			}
-			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.NestedItem == nil || fieldVal.ObjectDefinition.NestedItem.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 
@@ -53,7 +53,7 @@ func (userAssignedIdentityMapMatcher) IsMatch(field models.SDKField, known inter
 			innerHasPrincipalId := false
 			for innerName, innerVal := range inlinedModel.Fields {
 				if strings.EqualFold(innerName, "ClientId") {
-					if innerVal.ObjectDefinition.Type != models.StringSDKObjectDefinitionType {
+					if innerVal.ObjectDefinition.Type != sdkModels.StringSDKObjectDefinitionType {
 						continue
 					}
 
@@ -62,7 +62,7 @@ func (userAssignedIdentityMapMatcher) IsMatch(field models.SDKField, known inter
 				}
 
 				if strings.EqualFold(innerName, "PrincipalId") {
-					if innerVal.ObjectDefinition.Type != models.StringSDKObjectDefinitionType {
+					if innerVal.ObjectDefinition.Type != sdkModels.StringSDKObjectDefinitionType {
 						continue
 					}
 
@@ -79,7 +79,7 @@ func (userAssignedIdentityMapMatcher) IsMatch(field models.SDKField, known inter
 		}
 
 		if strings.EqualFold(fieldName, "Type") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 			constant, ok := known.Constants[*fieldVal.ObjectDefinition.ReferenceName]

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_location.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_location.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,12 +14,12 @@ var _ customFieldMatcher = locationMatcher{}
 
 type locationMatcher struct{}
 
-func (l locationMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.LocationSDKObjectDefinitionType,
+func (l locationMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.LocationSDKObjectDefinitionType,
 	}
 }
 
-func (l locationMatcher) IsMatch(field models.SDKField, _ internal.ParseResult) bool {
-	return strings.EqualFold(field.JsonName, "location") && field.ObjectDefinition.Type == models.StringSDKObjectDefinitionType
+func (l locationMatcher) IsMatch(field sdkModels.SDKField, _ internal.ParseResult) bool {
+	return strings.EqualFold(field.JsonName, "location") && field.ObjectDefinition.Type == sdkModels.StringSDKObjectDefinitionType
 }

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_system_data.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_system_data.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -15,14 +15,14 @@ var _ customFieldMatcher = systemDataMatcher{}
 
 type systemDataMatcher struct{}
 
-func (systemDataMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.SystemDataSDKObjectDefinitionType,
+func (systemDataMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.SystemDataSDKObjectDefinitionType,
 	}
 }
 
-func (systemDataMatcher) IsMatch(field models.SDKField, known internal.ParseResult) bool {
-	if field.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+func (systemDataMatcher) IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool {
+	if field.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 		return false
 	}
 
@@ -62,16 +62,16 @@ func (systemDataMatcher) IsMatch(field models.SDKField, known internal.ParseResu
 		}
 
 		if strings.EqualFold(fieldName, "CreatedByType") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 
-			if fieldVal.ObjectDefinition.Type == models.StringSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type == sdkModels.StringSDKObjectDefinitionType {
 				// Sometimes this field is a string.
 				// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/stable/2021-05-01/managedcluster.json#L1322-L1325
 				hasCreatedByType = true
 				continue
-			} else if fieldVal.ObjectDefinition.Type == models.ReferenceSDKObjectDefinitionType {
+			} else if fieldVal.ObjectDefinition.Type == sdkModels.ReferenceSDKObjectDefinitionType {
 				// Sometimes it's not ...
 				// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/azurearcdata/resource-manager/Microsoft.AzureArcData/stable/2021-08-01/azurearcdata.json#L1294-L1297
 				expected := map[string]string{
@@ -91,15 +91,15 @@ func (systemDataMatcher) IsMatch(field models.SDKField, known internal.ParseResu
 		}
 
 		if strings.EqualFold(fieldName, "LastModifiedByType") {
-			if fieldVal.ObjectDefinition.Type != models.ReferenceSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type != sdkModels.ReferenceSDKObjectDefinitionType {
 				continue
 			}
 
 			// Sometimes this field is a string.
 			// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/stable/2021-05-01/managedcluster.json#L1322-L1325
-			if fieldVal.ObjectDefinition.Type == models.StringSDKObjectDefinitionType {
+			if fieldVal.ObjectDefinition.Type == sdkModels.StringSDKObjectDefinitionType {
 				hasLastModifiedbyType = true
-			} else if fieldVal.ObjectDefinition.Type == models.ReferenceSDKObjectDefinitionType {
+			} else if fieldVal.ObjectDefinition.Type == sdkModels.ReferenceSDKObjectDefinitionType {
 				// Sometimes it's not ...
 				// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/azurearcdata/resource-manager/Microsoft.AzureArcData/stable/2021-08-01/azurearcdata.json#L1294-L1297
 				expected := map[string]string{
@@ -124,8 +124,8 @@ func (systemDataMatcher) IsMatch(field models.SDKField, known internal.ParseResu
 	return hasCreatedByType && hasCreatedBy && hasLastModifiedbyType && hasLastModifiedAt && hasLastModifiedBy && hasCreatedAt
 }
 
-func validateSystemDataConstantValues(input models.SDKConstant, expected map[string]string) bool {
-	if input.Type != models.StringSDKConstantType {
+func validateSystemDataConstantValues(input sdkModels.SDKConstant, expected map[string]string) bool {
+	if input.Type != sdkModels.StringSDKConstantType {
 		return false
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_tags.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_tags.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -14,14 +14,14 @@ var _ customFieldMatcher = tagsMatcher{}
 
 type tagsMatcher struct{}
 
-func (tagsMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.TagsSDKObjectDefinitionType,
+func (tagsMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.TagsSDKObjectDefinitionType,
 	}
 }
 
-func (tagsMatcher) IsMatch(field models.SDKField, _ internal.ParseResult) bool {
+func (tagsMatcher) IsMatch(field sdkModels.SDKField, _ internal.ParseResult) bool {
 	nameMatches := strings.EqualFold(field.JsonName, "tags")
-	typeMatches := field.ObjectDefinition.Type == models.DictionarySDKObjectDefinitionType && field.ObjectDefinition.NestedItem.Type == models.StringSDKObjectDefinitionType
+	typeMatches := field.ObjectDefinition.Type == sdkModels.DictionarySDKObjectDefinitionType && field.ObjectDefinition.NestedItem.Type == sdkModels.StringSDKObjectDefinitionType
 	return nameMatches && typeMatches
 }

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_zone.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_zone.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -15,14 +15,14 @@ var _ customFieldMatcher = zoneFieldMatcher{}
 type zoneFieldMatcher struct {
 }
 
-func (zoneFieldMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.ZoneSDKObjectDefinitionType,
+func (zoneFieldMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.ZoneSDKObjectDefinitionType,
 	}
 }
 
-func (zoneFieldMatcher) IsMatch(field models.SDKField, _ internal.ParseResult) bool {
+func (zoneFieldMatcher) IsMatch(field sdkModels.SDKField, _ internal.ParseResult) bool {
 	nameMatches := strings.EqualFold(field.JsonName, "availabilityZone") || strings.EqualFold(field.JsonName, "zone")
-	typeMatches := field.ObjectDefinition.Type == models.StringSDKObjectDefinitionType
+	typeMatches := field.ObjectDefinition.Type == sdkModels.StringSDKObjectDefinitionType
 	return nameMatches && typeMatches
 }

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_zones.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_field_zones.go
@@ -6,7 +6,7 @@ package commonschema
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
@@ -15,14 +15,14 @@ var _ customFieldMatcher = zonesFieldMatcher{}
 type zonesFieldMatcher struct {
 }
 
-func (zonesFieldMatcher) ReplacementObjectDefinition() models.SDKObjectDefinition {
-	return models.SDKObjectDefinition{
-		Type: models.ZonesSDKObjectDefinitionType,
+func (zonesFieldMatcher) ReplacementObjectDefinition() sdkModels.SDKObjectDefinition {
+	return sdkModels.SDKObjectDefinition{
+		Type: sdkModels.ZonesSDKObjectDefinitionType,
 	}
 }
 
-func (zonesFieldMatcher) IsMatch(field models.SDKField, _ internal.ParseResult) bool {
+func (zonesFieldMatcher) IsMatch(field sdkModels.SDKField, _ internal.ParseResult) bool {
 	nameMatches := strings.EqualFold(field.JsonName, "availabilityZones") || strings.EqualFold(field.JsonName, "zones")
-	typesMatch := field.ObjectDefinition.Type == models.ListSDKObjectDefinitionType && field.ObjectDefinition.NestedItem != nil && field.ObjectDefinition.NestedItem.Type == models.StringSDKObjectDefinitionType
+	typesMatch := field.ObjectDefinition.Type == sdkModels.ListSDKObjectDefinitionType && field.ObjectDefinition.NestedItem != nil && field.ObjectDefinition.NestedItem.Type == sdkModels.StringSDKObjectDefinitionType
 	return nameMatches && typesMatch
 }

--- a/tools/importer-rest-api-specs/components/parser/commonschema/custom_fields.go
+++ b/tools/importer-rest-api-specs/components/parser/commonschema/custom_fields.go
@@ -4,18 +4,18 @@
 package commonschema
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
 type customFieldMatcher interface {
 	// IsMatch returns whether the field and definition provided match this Custom Field Matcher
 	// meaning that the types should be replaced with the CustomFieldType found in customFieldType
-	IsMatch(field models.SDKField, known internal.ParseResult) bool
+	IsMatch(field sdkModels.SDKField, known internal.ParseResult) bool
 
 	// ReplacementObjectDefinition returns the replacement SDKObjectDefinition which should be used
 	// in place of the parsed SDKObjectDefinition for this SDKField.
-	ReplacementObjectDefinition() models.SDKObjectDefinition
+	ReplacementObjectDefinition() sdkModels.SDKObjectDefinition
 }
 
 var CustomFieldMatchers = []customFieldMatcher{

--- a/tools/importer-rest-api-specs/components/parser/constants/interface.go
+++ b/tools/importer-rest-api-specs/components/parser/constants/interface.go
@@ -5,16 +5,16 @@ package constants
 
 import (
 	"fmt"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/go-openapi/spec"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/featureflags"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 )
 
 type constantExtension struct {
@@ -29,7 +29,7 @@ type constantExtension struct {
 
 type ParsedConstant struct {
 	Name    string
-	Details models.SDKConstant
+	Details sdkModels.SDKConstant
 }
 
 func MapConstant(typeVal spec.StringOrArray, fieldName string, modelName *string, values []interface{}, extensions spec.Extensions) (*ParsedConstant, error) {
@@ -61,16 +61,16 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, modelName *string
 		constantName = constExtension.name
 	}
 
-	constantType := models.StringSDKConstantType
+	constantType := sdkModels.StringSDKConstantType
 	if typeVal.Contains("integer") {
-		constantType = models.IntegerSDKConstantType
+		constantType = sdkModels.IntegerSDKConstantType
 	} else if typeVal.Contains("number") {
-		constantType = models.FloatSDKConstantType
+		constantType = sdkModels.FloatSDKConstantType
 	}
 
 	keysAndValues := make(map[string]string)
 	for i, raw := range values {
-		if constantType == models.StringSDKConstantType {
+		if constantType == sdkModels.StringSDKConstantType {
 			value, ok := raw.(string)
 			if !ok {
 				return nil, fmt.Errorf("expected a string but got %+v for the %d value for %q", raw, i, constExtension.name)
@@ -94,7 +94,7 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, modelName *string
 			continue
 		}
 
-		if constantType == models.IntegerSDKConstantType {
+		if constantType == sdkModels.IntegerSDKConstantType {
 			// This gets parsed out as a float64 even though it's an Integer :upside_down_smile:
 			value, ok := raw.(float64)
 			if !ok {
@@ -128,7 +128,7 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, modelName *string
 			continue
 		}
 
-		if constantType == models.FloatSDKConstantType {
+		if constantType == sdkModels.FloatSDKConstantType {
 			value, ok := raw.(float64)
 			if !ok {
 				return nil, fmt.Errorf("expected an float but got %+v for the %d value for %q", raw, i, constExtension.name)
@@ -146,12 +146,12 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, modelName *string
 
 	// allows us to parse out the actual types above then force a string here if needed
 	if constExtension == nil {
-		constantType = models.StringSDKConstantType
+		constantType = sdkModels.StringSDKConstantType
 	}
 
 	return &ParsedConstant{
 		Name: constantName,
-		Details: models.SDKConstant{
+		Details: sdkModels.SDKConstant{
 			Values: keysAndValues,
 			Type:   constantType,
 		},

--- a/tools/importer-rest-api-specs/components/parser/constants_test.go
+++ b/tools/importer-rest-api-specs/components/parser/constants_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -21,11 +21,11 @@ func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.IntegerSDKConstantType,
+						Type: sdkModels.IntegerSDKConstantType,
 						Values: map[string]string{
 							"One":              "1",
 							"Two":              "2",
@@ -34,28 +34,28 @@ func TestParseConstantsIntegersTopLevelAsInts(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -77,11 +77,11 @@ func TestParseConstantsIntegersTopLevelAsIntsWithDisplayName(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.IntegerSDKConstantType,
+						Type: sdkModels.IntegerSDKConstantType,
 						Values: map[string]string{
 							"First":  "1",
 							"Second": "2",
@@ -89,28 +89,28 @@ func TestParseConstantsIntegersTopLevelAsIntsWithDisplayName(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -131,11 +131,11 @@ func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.IntegerSDKConstantType,
+						Type: sdkModels.IntegerSDKConstantType,
 						Values: map[string]string{
 							"One":   "1",
 							"Two":   "2",
@@ -143,28 +143,28 @@ func TestParseConstantsIntegersTopLevelAsStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -185,11 +185,11 @@ func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.IntegerSDKConstantType,
+						Type: sdkModels.IntegerSDKConstantType,
 						Values: map[string]string{
 							"One":   "1",
 							"Two":   "2",
@@ -197,28 +197,28 @@ func TestParseConstantsIntegersInlinedAsInts(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -240,11 +240,11 @@ func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.IntegerSDKConstantType,
+						Type: sdkModels.IntegerSDKConstantType,
 						Values: map[string]string{
 							"First":  "1",
 							"Second": "2",
@@ -252,28 +252,28 @@ func TestParseConstantsIntegersInlinedAsIntsWithDisplayName(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -293,11 +293,11 @@ func TestParseConstantsMultipleTypeEnums(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"AnimalType": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -305,47 +305,47 @@ func TestParseConstantsMultipleTypeEnums(t *testing.T) {
 						},
 					},
 					"PlanetType": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"Mercury": "mercury",
 							"Saturn":  "saturn",
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"Planet": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("PlanetType"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Animal": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Animal"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/animal"),
 					},
@@ -353,9 +353,9 @@ func TestParseConstantsMultipleTypeEnums(t *testing.T) {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Planet"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/planet"),
 					},
@@ -376,11 +376,11 @@ func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.IntegerSDKConstantType,
+						Type: sdkModels.IntegerSDKConstantType,
 						Values: map[string]string{
 							"One":   "1",
 							"Two":   "2",
@@ -388,28 +388,28 @@ func TestParseConstantsIntegersInlinedAsStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -430,11 +430,11 @@ func TestParseConstantsFloatsTopLevelAsFloats(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.FloatSDKConstantType,
+						Type: sdkModels.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -442,28 +442,28 @@ func TestParseConstantsFloatsTopLevelAsFloats(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -484,11 +484,11 @@ func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.FloatSDKConstantType,
+						Type: sdkModels.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -496,28 +496,28 @@ func TestParseConstantsFloatsTopLevelAsStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -538,11 +538,11 @@ func TestParseConstantsFloatsInlinedAsFloats(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.FloatSDKConstantType,
+						Type: sdkModels.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -550,28 +550,28 @@ func TestParseConstantsFloatsInlinedAsFloats(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -592,11 +592,11 @@ func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.FloatSDKConstantType,
+						Type: sdkModels.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -604,28 +604,28 @@ func TestParseConstantsFloatsInlinedAsStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -645,11 +645,11 @@ func TestParseConstantsStringsTopLevel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"AnimalType": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -658,28 +658,28 @@ func TestParseConstantsStringsTopLevel(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -702,11 +702,11 @@ func TestParseConstantsStringsTopLevelAsNonStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"AnimalType": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -714,28 +714,28 @@ func TestParseConstantsStringsTopLevelAsNonStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -755,11 +755,11 @@ func TestParseConstantsStringsInlined(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"AnimalType": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -767,28 +767,28 @@ func TestParseConstantsStringsInlined(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -808,11 +808,11 @@ func TestParseConstantsStringsInlinedAsNonStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"AnimalType": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat":   "cat",
 							"Dog":   "dog",
@@ -820,28 +820,28 @@ func TestParseConstantsStringsInlinedAsNonStrings(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -862,11 +862,11 @@ func TestParseConstantsStringsTopLevelContainingFloats(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -874,28 +874,28 @@ func TestParseConstantsStringsTopLevelContainingFloats(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -916,11 +916,11 @@ func TestParseConstantsStringsInlinedContainingFloats(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"TableNumber": {
-						Type: models.FloatSDKConstantType,
+						Type: sdkModels.FloatSDKConstantType,
 						Values: map[string]string{
 							"OnePointOne":                     "1.1",
 							"TwoPointTwo":                     "2.2",
@@ -928,28 +928,28 @@ func TestParseConstantsStringsInlinedContainingFloats(t *testing.T) {
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteTable": {
 								JsonName: "favouriteTable",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("TableNumber"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -987,15 +987,15 @@ func TestParseConstantsFromParameters(t *testing.T) {
 	if len(resource.Operations) != 1 {
 		t.Fatalf("expected 1 operation but got %d", len(resource.Operations))
 	}
-	if len(resource.ResourceIds) != 1 {
-		t.Fatalf("expected 1 Resource ID but got %d", len(resource.ResourceIds))
+	if len(resource.ResourceIDs) != 1 {
+		t.Fatalf("expected 1 Resource ID but got %d", len(resource.ResourceIDs))
 	}
 
 	favouriteTable, ok := resource.Constants["MediaType"]
 	if !ok {
 		t.Fatalf("resource.Constants['TableNumber'] was not found")
 	}
-	if favouriteTable.Type != models.StringSDKConstantType {
+	if favouriteTable.Type != sdkModels.StringSDKConstantType {
 		t.Fatalf("expected resource.Constants['TableNumber'].Type to be 'String' but got %q", favouriteTable.Type)
 	}
 	if len(favouriteTable.Values) != 3 {

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/interface.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/interface.go
@@ -3,9 +3,7 @@
 
 package dataworkarounds
 
-import (
-	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
-)
+import importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 
 type workaround interface {
 	// IsApplicable determines whether this workaround is applicable for this AzureApiDefinition

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_authorization_25080.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_authorization_25080.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -33,9 +33,9 @@ func (workaroundAuthorization25080) Process(apiDefinition importerModels.AzureAp
 	if !ok {
 		return nil, fmt.Errorf("expected an Operation named `ListForScope` but didn't get one")
 	}
-	operation.Options["Filter"] = models.SDKOperationOption{
-		ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-			Type: models.StringSDKOperationOptionObjectDefinitionType,
+	operation.Options["Filter"] = sdkModels.SDKOperationOption{
+		ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+			Type: sdkModels.StringSDKOperationOptionObjectDefinitionType,
 		},
 		QueryStringName: pointer.To("$filter"),
 		Required:        false,

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
@@ -53,15 +53,15 @@ func (workaroundBotService27351) Process(input importerModels.AzureApiDefinition
 		return nil, fmt.Errorf("expected a Resource named `Channel` but didn't get one")
 	}
 	// ensure we've got the Resource ID we're going to switch over to
-	if _, ok := resource.ResourceIds["BotServiceChannelId"]; !ok {
+	if _, ok := resource.ResourceIDs["BotServiceChannelId"]; !ok {
 		return nil, fmt.Errorf("expected a Resource ID named `BotServiceChannelId` but didn't get one")
 	}
 
 	// ensure we've got the mismatched Resource ID in order to remove it
-	if _, ok := resource.ResourceIds["ChannelId"]; !ok {
+	if _, ok := resource.ResourceIDs["ChannelId"]; !ok {
 		return nil, fmt.Errorf("expected a Resource ID named `ChannelId` but didn't get one")
 	}
-	delete(resource.ResourceIds, "ChannelId")
+	delete(resource.ResourceIDs, "ChannelId")
 
 	for operationName, operation := range resource.Operations {
 		if operation.ResourceIDName != nil && *operation.ResourceIDName == "ChannelId" {

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_botservice_27351.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -75,7 +75,7 @@ func (workaroundBotService27351) Process(input importerModels.AzureApiDefinition
 	if !ok {
 		return nil, fmt.Errorf("expected a Constant named `EmailChannelAuthMethod` but didn't get one")
 	}
-	constant.Type = models.IntegerSDKConstantType
+	constant.Type = sdkModels.IntegerSDKConstantType
 	resource.Constants["EmailChannelAuthMethod"] = constant
 
 	output.Resources["Channel"] = resource

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_datafactory_23013.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_datafactory_23013.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -33,12 +33,12 @@ func (workaroundDataFactory23013) Process(apiDefinition importerModels.AzureApiD
 	}
 
 	// add the new discriminated parent type
-	resource.Models["Reference"] = models.SDKModel{
+	resource.Models["Reference"] = sdkModels.SDKModel{
 		FieldNameContainingDiscriminatedValue: pointer.To("Type"),
-		Fields: map[string]models.SDKField{
+		Fields: map[string]sdkModels.SDKField{
 			"Type": {
-				ObjectDefinition: models.SDKObjectDefinition{
-					Type: models.StringSDKObjectDefinitionType,
+				ObjectDefinition: sdkModels.SDKObjectDefinition{
+					Type: sdkModels.StringSDKObjectDefinitionType,
 				},
 				Required: true,
 				JsonName: "type",

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_digitaltwins_25120.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_digitaltwins_25120.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -41,8 +41,8 @@ func (workaroundDigitalTwins25120) Process(apiDefinition importerModels.AzureApi
 	if !ok {
 		return nil, fmt.Errorf("expected a Field named `RecordPropertyAndItemRemovals`")
 	}
-	field.ObjectDefinition = models.SDKObjectDefinition{
-		Type: models.BooleanSDKObjectDefinitionType,
+	field.ObjectDefinition = sdkModels.SDKObjectDefinition{
+		Type: sdkModels.BooleanSDKObjectDefinitionType,
 	}
 	model.Fields["RecordPropertyAndItemRemovals"] = field
 	resource.Models["AzureDataExplorerConnectionProperties"] = model

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_hdinsight_26838.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -54,8 +54,8 @@ func (workaroundHDInsight26838) Process(apiDefinition importerModels.AzureApiDef
 	if !ok {
 		return nil, fmt.Errorf("expected a Field named `Kind`")
 	}
-	field.ObjectDefinition = models.SDKObjectDefinition{
-		Type:          models.ReferenceSDKObjectDefinitionType,
+	field.ObjectDefinition = sdkModels.SDKObjectDefinition{
+		Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 		ReferenceName: pointer.To("ClusterKind"),
 	}
 	model.Fields["Kind"] = field
@@ -65,8 +65,8 @@ func (workaroundHDInsight26838) Process(apiDefinition importerModels.AzureApiDef
 	if v, ok := resource.Constants["ClusterKind"]; ok {
 		return nil, fmt.Errorf("an existing Constant exists with the name `ClusterKind`: %+v", v)
 	}
-	resource.Constants["ClusterKind"] = models.SDKConstant{
-		Type: models.StringSDKConstantType,
+	resource.Constants["ClusterKind"] = sdkModels.SDKConstant{
+		Type: sdkModels.StringSDKConstantType,
 		Values: map[string]string{
 			"Hadoop":          "HADOOP",
 			"HBase":           "HBASE",

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
@@ -26,21 +26,21 @@ func (workaroundInconsistentlyDefinedSegments) Name() string {
 }
 
 func (workaroundInconsistentlyDefinedSegments) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
-	resources := make(map[string]importerModels.AzureApiResource, 0)
+	resources := make(map[string]sdkModels.APIResource, 0)
 	for resourceName := range apiDefinition.Resources {
 		resource := apiDefinition.Resources[resourceName]
 
-		ids := make(map[string]models.ResourceID)
-		for key := range resource.ResourceIds {
-			id := resource.ResourceIds[key]
-			segments := make([]models.ResourceIDSegment, 0)
+		ids := make(map[string]sdkModels.ResourceID)
+		for key := range resource.ResourceIDs {
+			id := resource.ResourceIDs[key]
+			segments := make([]sdkModels.ResourceIDSegment, 0)
 			for i, val := range id.Segments {
-				if i > 0 && val.Type == models.UserSpecifiedResourceIDSegmentType {
+				if i > 0 && val.Type == sdkModels.UserSpecifiedResourceIDSegmentType {
 					// switch out the name of the User Specified Segment presuming it's not an `{val}Id` or `{val}Key`, since these names make more sense
 					// this works around issues in the Swagger where the same URI may be defined differently depending on the endpoint
 					if !strings.HasSuffix(val.Name, "Alias") && !strings.HasSuffix(val.Name, "Id") && !strings.HasSuffix(val.Name, "Key") && !strings.HasSuffix(val.Name, "Identifier") {
 						previous := segments[i-1]
-						if previous.Type == models.StaticResourceIDSegmentType && previous.FixedValue != nil {
+						if previous.Type == sdkModels.StaticResourceIDSegmentType && previous.FixedValue != nil {
 							singularNameOfPrevious := cleanup.GetSingular(*previous.FixedValue)
 							val.Name = singularNameOfPrevious
 							if !strings.HasSuffix(val.Name, "Name") {
@@ -55,7 +55,7 @@ func (workaroundInconsistentlyDefinedSegments) Process(apiDefinition importerMod
 			id.ExampleValue = helpers.DisplayValueForResourceID(id)
 			ids[key] = id
 		}
-		resource.ResourceIds = ids
+		resource.ResourceIDs = ids
 		resources[resourceName] = resource
 	}
 	apiDefinition.Resources = resources

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_invalid_go_package_names.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_invalid_go_package_names.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -28,7 +29,7 @@ func (workaroundInvalidGoPackageNames) Name() string {
 }
 
 func (workaroundInvalidGoPackageNames) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
-	resources := make(map[string]importerModels.AzureApiResource, 0)
+	resources := make(map[string]sdkModels.APIResource, 0)
 
 	for resourceName := range apiDefinition.Resources {
 		originalName := resourceName

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_loadtest_20961.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_loadtest_20961.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -41,8 +41,8 @@ func (workaroundLoadTest20961) Process(apiDefinition importerModels.AzureApiDefi
 	if !ok {
 		return nil, fmt.Errorf("couldn't find field Tags within model LoadTestResourceUpdate")
 	}
-	field.ObjectDefinition = models.SDKObjectDefinition{
-		Type: models.TagsSDKObjectDefinitionType,
+	field.ObjectDefinition = sdkModels.SDKObjectDefinition{
+		Type: sdkModels.TagsSDKObjectDefinitionType,
 	}
 
 	model.Fields["Tags"] = field

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_newrelic_29256.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_newrelic_29256.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -49,8 +49,8 @@ func (workaroundNewRelic29256) Process(apiDefinition importerModels.AzureApiDefi
 		if !ok {
 			return nil, fmt.Errorf("expected the Model `%s` to have a field `Identity` but it didn't exist", modelName)
 		}
-		field.ObjectDefinition = models.SDKObjectDefinition{
-			Type: models.SystemAssignedIdentitySDKObjectDefinitionType,
+		field.ObjectDefinition = sdkModels.SDKObjectDefinition{
+			Type: sdkModels.SystemAssignedIdentitySDKObjectDefinitionType,
 		}
 		model.Fields["Identity"] = field
 		resource.Models[modelName] = model

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_recoveryservicessiterecovery_26680.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_recoveryservicessiterecovery_26680.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -55,13 +55,13 @@ func (w workaroundRecoveryServicesSiteRecovery26680) Process(apiDefinition impor
 	}
 
 	// 1. Add the missing model
-	resource.Models["CertificateCreateOptions"] = models.SDKModel{
-		Fields: map[string]models.SDKField{
+	resource.Models["CertificateCreateOptions"] = sdkModels.SDKModel{
+		Fields: map[string]sdkModels.SDKField{
 			"ValidityInHours": {
 				Required: false,
 				JsonName: "validityInHours",
-				ObjectDefinition: models.SDKObjectDefinition{
-					Type: models.IntegerSDKObjectDefinitionType,
+				ObjectDefinition: sdkModels.SDKObjectDefinition{
+					Type: sdkModels.IntegerSDKObjectDefinitionType,
 				},
 			},
 		},
@@ -72,15 +72,15 @@ func (w workaroundRecoveryServicesSiteRecovery26680) Process(apiDefinition impor
 	if !ok {
 		return nil, fmt.Errorf("expected a Model named `CertificateRequest` but didn't get one")
 	}
-	model.Fields["CertificateCreateOptions"] = models.SDKField{
+	model.Fields["CertificateCreateOptions"] = sdkModels.SDKField{
 		Required:    false,
 		ReadOnly:    false,
 		Sensitive:   false,
 		JsonName:    "certificateCreateOptions",
 		Description: "",
-		ObjectDefinition: models.SDKObjectDefinition{
+		ObjectDefinition: sdkModels.SDKObjectDefinition{
 			ReferenceName: pointer.To("CertificateCreateOptions"),
-			Type:          models.ReferenceSDKObjectDefinitionType,
+			Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 		},
 	}
 	resource.Models["CertificateRequest"] = model

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_redis_22407.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_redis_22407.go
@@ -4,7 +4,7 @@
 package dataworkarounds
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -26,14 +26,14 @@ func (w workaroundRedis22407) Process(apiDefinition importerModels.AzureApiDefin
 		if model, ok := resource.Models["RedisCommonPropertiesRedisConfiguration"]; ok {
 
 			if _, ok := model.Fields["NotifyKeyspaceEvents"]; !ok {
-				model.Fields["NotifyKeyspaceEvents"] = models.SDKField{
+				model.Fields["NotifyKeyspaceEvents"] = sdkModels.SDKField{
 					Required:    false,
 					ReadOnly:    false,
 					Sensitive:   false,
 					JsonName:    "notify-keyspace-events",
 					Description: "The KeySpace Events which should be monitored.",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.StringSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.StringSDKObjectDefinitionType,
 					},
 				}
 			}

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_streamanalytics_27577.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_streamanalytics_27577.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -54,12 +54,12 @@ func (w workaroundStreamAnalytics27577) Process(apiDefinition importerModels.Azu
 		}
 
 		// update the reference to be a System OR UserAssigned identity
-		field.ObjectDefinition = models.SDKObjectDefinition{
-			Type: models.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
+		field.ObjectDefinition = sdkModels.SDKObjectDefinition{
+			Type: sdkModels.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
 		}
 		if apiDefinition.ApiVersion == "2020-03-01" {
 			// however API version 2020-03-01 only supports SystemAssigned
-			field.ObjectDefinition.Type = models.SystemAssignedIdentitySDKObjectDefinitionType
+			field.ObjectDefinition.Type = sdkModels.SystemAssignedIdentitySDKObjectDefinitionType
 		}
 
 		model.Fields["Identity"] = field

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_subscription_20254.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_subscription_20254.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -37,12 +37,12 @@ func (w workaroundSubscriptions20254) Process(input importerModels.AzureApiDefin
 	if !ok {
 		return nil, fmt.Errorf("expected an Operation named `SubscriptionCancel` but didn't get one")
 	}
-	operation.Options = map[string]models.SDKOperationOption{
+	operation.Options = map[string]sdkModels.SDKOperationOption{
 		// IgnoreResourceCheck allows deleting a Subscription even if it contains nested Resources
 		"IgnoreResourceCheck": {
 			QueryStringName: pointer.To("IgnoreResourceCheck"),
-			ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-				Type: models.BooleanSDKOperationOptionObjectDefinitionType,
+			ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+				Type: sdkModels.BooleanSDKOperationOptionObjectDefinitionType,
 			},
 			Required: false,
 		},

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_temp_readonly_fields.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
+	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 var _ workaround = workaroundTempReadOnlyFields{}
@@ -14,7 +14,7 @@ var _ workaround = workaroundTempReadOnlyFields{}
 type workaroundTempReadOnlyFields struct {
 }
 
-func (w workaroundTempReadOnlyFields) IsApplicable(apiDefinition *models.AzureApiDefinition) bool {
+func (w workaroundTempReadOnlyFields) IsApplicable(apiDefinition *importerModels.AzureApiDefinition) bool {
 	if apiDefinition.ServiceName == "ContainerService" && apiDefinition.ApiVersion == "2022-09-02-preview" {
 		return true
 	}
@@ -38,7 +38,7 @@ func (w workaroundTempReadOnlyFields) Name() string {
 	return "Temp - Mark readonly fields as readonly"
 }
 
-func (w workaroundTempReadOnlyFields) Process(apiDefinition models.AzureApiDefinition) (*models.AzureApiDefinition, error) {
+func (w workaroundTempReadOnlyFields) Process(apiDefinition importerModels.AzureApiDefinition) (*importerModels.AzureApiDefinition, error) {
 	if apiDefinition.ServiceName == "ContainerService" && apiDefinition.ApiVersion == "2022-09-02-preview" {
 		definition, err := w.markFieldAsComputed(apiDefinition, "Fleets", "FleetHubProfile", "Fqdn")
 		if err != nil {
@@ -98,7 +98,7 @@ func (w workaroundTempReadOnlyFields) Process(apiDefinition models.AzureApiDefin
 	return nil, fmt.Errorf("unexpected Service %q / API Version %q", apiDefinition.ServiceName, apiDefinition.ApiVersion)
 }
 
-func (w workaroundTempReadOnlyFields) markFieldAsComputed(input models.AzureApiDefinition, apiResourceName, modelName, fieldName string) (*models.AzureApiDefinition, error) {
+func (w workaroundTempReadOnlyFields) markFieldAsComputed(input importerModels.AzureApiDefinition, apiResourceName, modelName, fieldName string) (*importerModels.AzureApiDefinition, error) {
 	resource, ok := input.Resources[apiResourceName]
 	if !ok {
 		return nil, fmt.Errorf("expected an APIResource %q but didn't get one", apiResourceName)

--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workarounds.go
@@ -6,7 +6,7 @@ package dataworkarounds
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -40,13 +40,13 @@ var workarounds = []workaround{
 	workaroundInvalidGoPackageNames{},
 }
 
-func ApplyWorkarounds(input []importerModels.AzureApiDefinition, logger hclog.Logger) (*[]importerModels.AzureApiDefinition, error) {
+func ApplyWorkarounds(input []importerModels.AzureApiDefinition) (*[]importerModels.AzureApiDefinition, error) {
 	output := make([]importerModels.AzureApiDefinition, 0)
-	logger.Trace("Processing Swagger Data Workarounds..")
+	logging.Tracef("Processing Swagger Data Workarounds..")
 	for _, item := range input {
 		for _, fix := range workarounds {
 			if fix.IsApplicable(&item) {
-				logger.Trace(fmt.Sprintf("Applying Swagger Data Workaround %q to Service %q / API Version %q", fix.Name(), item.ServiceName, item.ApiVersion))
+				logging.Tracef("Applying Swagger Data Workaround %q to Service %q / API Version %q", fix.Name(), item.ServiceName, item.ApiVersion)
 				updated, err := fix.Process(item)
 				if err != nil {
 					return nil, fmt.Errorf("applying Swagger Data Workaround %q to Service %q / API Version %q: %+v", fix.Name(), item.ServiceName, item.ApiVersion, err)

--- a/tools/importer-rest-api-specs/components/parser/definition.go
+++ b/tools/importer-rest-api-specs/components/parser/definition.go
@@ -6,14 +6,11 @@ package parser
 import (
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/spec"
-	"github.com/hashicorp/go-hclog"
 )
 
 type SwaggerDefinition struct {
 	// Name is the name of this Swagger file
 	Name string
-
-	logger hclog.Logger
 
 	// swaggerSpecExpanded is a flattened version of the Swagger spec into a single file
 	swaggerSpecExpanded *analysis.Spec

--- a/tools/importer-rest-api-specs/components/parser/flattener.go
+++ b/tools/importer-rest-api-specs/components/parser/flattener.go
@@ -11,13 +11,12 @@ import (
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
-	"github.com/hashicorp/go-hclog"
 )
 
 // load loads the swagger document and flattens it to ensure this contains
 // all of the properties within a single file, which makes this easier to parse-out
 // This can then be used with the Parser
-func load(directory string, fileName string, logger hclog.Logger) (*SwaggerDefinition, error) {
+func load(directory string, fileName string) (*SwaggerDefinition, error) {
 	filePath := filepath.Join(directory, fileName)
 
 	// parsing this twice looks silly, so why are we doing this?
@@ -79,7 +78,6 @@ func load(directory string, fileName string, logger hclog.Logger) (*SwaggerDefin
 
 	return &SwaggerDefinition{
 		Name:                      serviceName,
-		logger:                    logger,
 		swaggerSpecExpanded:       swaggerSpecExpanded,
 		swaggerSpecWithReferences: swaggerSpecWithReferences,
 		swaggerSpecRaw:            swaggerSpecWithReferencesRaw,

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -58,23 +58,23 @@ func validateParsedSwaggerResultMatches(t *testing.T, expected importerModels.Az
 	validateMapsMatch(t, expected.Resources, actual.Resources, "API Resource", validateParsedApiResourceMatches)
 }
 
-func validateParsedApiResourceMatches(t *testing.T, expected importerModels.AzureApiResource, actual importerModels.AzureApiResource, apiResourceName string) {
+func validateParsedApiResourceMatches(t *testing.T, expected, actual sdkModels.APIResource, apiResourceName string) {
 	t.Logf("Validating API Resource %q..", apiResourceName)
 	// Validate each of the maps matches what we're expecting
 	validateMapsMatch(t, expected.Constants, actual.Constants, "Constants", validateParsedConstantsMatch)
 	validateMapsMatch(t, expected.Models, actual.Models, "Models", validateParsedSDKModelsMatch)
 	validateMapsMatch(t, expected.Operations, actual.Operations, "Operations", validateParsedOperationsMatch)
-	validateMapsMatch(t, expected.ResourceIds, actual.ResourceIds, "Resource IDs", validateParsedResourceIDsMatch)
+	validateMapsMatch(t, expected.ResourceIDs, actual.ResourceIDs, "Resource IDs", validateParsedResourceIDsMatch)
 }
 
-func validateParsedConstantsMatch(t *testing.T, expected, actual models.SDKConstant, constantName string) {
+func validateParsedConstantsMatch(t *testing.T, expected, actual sdkModels.SDKConstant, constantName string) {
 	if expected.Type != actual.Type {
 		t.Fatalf("expected Type to be %q but got %q for Constant %q", string(expected.Type), string(actual.Type), constantName)
 	}
 	validateMapsMatch(t, expected.Values, actual.Values, "Values", validateStringsMatch)
 }
 
-func validateParsedSDKFieldsMatch(t *testing.T, expected, actual models.SDKField, fieldName string) {
+func validateParsedSDKFieldsMatch(t *testing.T, expected, actual sdkModels.SDKField, fieldName string) {
 	if expected.JsonName != actual.JsonName {
 		t.Fatalf("expected `JsonName` to be %q but got %q for Field %q", expected.JsonName, actual.JsonName, fieldName)
 	}
@@ -92,7 +92,7 @@ func validateParsedSDKFieldsMatch(t *testing.T, expected, actual models.SDKField
 	validateParsedObjectDefinitionsMatch(t, expected.ObjectDefinition, actual.ObjectDefinition, fieldName)
 }
 
-func validateParsedSDKModelsMatch(t *testing.T, expected, actual models.SDKModel, modelName string) {
+func validateParsedSDKModelsMatch(t *testing.T, expected, actual sdkModels.SDKModel, modelName string) {
 	t.Logf("Validating Model %q...", modelName)
 	if pointer.From(expected.ParentTypeName) != pointer.From(actual.ParentTypeName) {
 		// NOTE: this should be nil when unset, otherwise a value
@@ -113,7 +113,7 @@ func validateParsedSDKModelsMatch(t *testing.T, expected, actual models.SDKModel
 	validateMapsMatch(t, expected.Fields, actual.Fields, "Fields", validateParsedSDKFieldsMatch)
 }
 
-func validateParsedObjectDefinitionsMatch(t *testing.T, expected, actual models.SDKObjectDefinition, fieldName string) {
+func validateParsedObjectDefinitionsMatch(t *testing.T, expected, actual sdkModels.SDKObjectDefinition, fieldName string) {
 	if expected.Type != actual.Type {
 		t.Fatalf("expected `Type` to be %q but got %q for Field %q", string(expected.Type), string(actual.Type), fieldName)
 	}
@@ -134,7 +134,7 @@ func validateParsedObjectDefinitionsMatch(t *testing.T, expected, actual models.
 	validateObjectsMatch(t, expected.NestedItem, actual.NestedItem, "NestedItem", validateParsedObjectDefinitionsMatch)
 }
 
-func validateParsedOperationsMatch(t *testing.T, expected, actual models.SDKOperation, operationName string) {
+func validateParsedOperationsMatch(t *testing.T, expected, actual sdkModels.SDKOperation, operationName string) {
 	t.Logf("Validating Operation %q..", operationName)
 	if expected.ContentType != actual.ContentType {
 		t.Fatalf("expected `ContentType` to be %q but got %q for Operation %q", expected.ContentType, actual.ContentType, operationName)
@@ -160,7 +160,7 @@ func validateParsedOperationsMatch(t *testing.T, expected, actual models.SDKOper
 	}
 }
 
-func validateParsedOptionsMatch(t *testing.T, expected, actual models.SDKOperationOption, optionName string) {
+func validateParsedOptionsMatch(t *testing.T, expected, actual sdkModels.SDKOperationOption, optionName string) {
 	if pointer.From(expected.HeaderName) != pointer.From(actual.HeaderName) {
 		t.Errorf("expected `HeaderName` to be %q but got %q for Option %q", pointer.From(expected.HeaderName), pointer.From(actual.HeaderName), optionName)
 	}
@@ -173,7 +173,7 @@ func validateParsedOptionsMatch(t *testing.T, expected, actual models.SDKOperati
 	validateParsedOptionsObjectDefinitionsMatch(t, expected.ObjectDefinition, actual.ObjectDefinition, "OptionObjectDefinition")
 }
 
-func validateParsedOptionsObjectDefinitionsMatch(t *testing.T, expected, actual models.SDKOperationOptionObjectDefinition, fieldName string) {
+func validateParsedOptionsObjectDefinitionsMatch(t *testing.T, expected, actual sdkModels.SDKOperationOptionObjectDefinition, fieldName string) {
 	if expected.Type != actual.Type {
 		t.Fatalf("expected `Type` to be %q but got %q for Field %q", string(expected.Type), string(actual.Type), fieldName)
 	}
@@ -184,7 +184,7 @@ func validateParsedOptionsObjectDefinitionsMatch(t *testing.T, expected, actual 
 	validateObjectsMatch(t, expected.NestedItem, actual.NestedItem, "NestedItem", validateParsedOptionsObjectDefinitionsMatch)
 }
 
-func validateParsedResourceIDsMatch(t *testing.T, expected, actual models.ResourceID, resourceIdName string) {
+func validateParsedResourceIDsMatch(t *testing.T, expected, actual sdkModels.ResourceID, resourceIdName string) {
 	if pointer.From(expected.CommonIDAlias) != pointer.From(actual.CommonIDAlias) {
 		t.Errorf("expected `CommonIDAlias` to be %q but got %q for Resource ID %q", pointer.From(expected.CommonIDAlias), pointer.From(actual.CommonIDAlias), resourceIdName)
 	}
@@ -192,7 +192,7 @@ func validateParsedResourceIDsMatch(t *testing.T, expected, actual models.Resour
 	validateSlicesMatch(t, expected.Segments, actual.Segments, "Segments", validateParsedResourceIDSegmentsMatch)
 }
 
-func validateParsedResourceIDSegmentsMatch(t *testing.T, expected, actual models.ResourceIDSegment, segmentName string) {
+func validateParsedResourceIDSegmentsMatch(t *testing.T, expected, actual sdkModels.ResourceIDSegment, segmentName string) {
 	if pointer.From(expected.ConstantReference) != pointer.From(actual.ConstantReference) {
 		t.Errorf("expected `ConstantReference` to be %q but got %q for %s", pointer.From(expected.ConstantReference), pointer.From(actual.ConstantReference), segmentName)
 	}

--- a/tools/importer-rest-api-specs/components/parser/helpers_test.go
+++ b/tools/importer-rest-api-specs/components/parser/helpers_test.go
@@ -9,14 +9,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-hclog"
 	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 func ParseSwaggerFileForTesting(t *testing.T, file string, serviceName *string) (*importerModels.AzureApiDefinition, error) {
 	// TODO: make this function private
-	parsed, err := load("testdata/", file, hclog.New(hclog.DefaultOptions))
+	parsed, err := load("testdata/", file)
 	if err != nil {
 		t.Fatalf("loading: %+v", err)
 	}

--- a/tools/importer-rest-api-specs/components/parser/internal/structs.go
+++ b/tools/importer-rest-api-specs/components/parser/internal/structs.go
@@ -9,24 +9,24 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 type ParseResult struct {
-	Constants map[string]models.SDKConstant
-	Models    map[string]models.SDKModel
+	Constants map[string]sdkModels.SDKConstant
+	Models    map[string]sdkModels.SDKModel
 }
 
 func (r *ParseResult) Append(other ParseResult) error {
 	if r.Constants == nil {
-		r.Constants = make(map[string]models.SDKConstant)
+		r.Constants = make(map[string]sdkModels.SDKConstant)
 	}
 	if err := r.AppendConstants(other.Constants); err != nil {
 		return fmt.Errorf("appending constants: %+v", err)
 	}
 
 	if r.Models == nil {
-		r.Models = make(map[string]models.SDKModel)
+		r.Models = make(map[string]sdkModels.SDKModel)
 	}
 	if err := r.AppendModels(other.Models); err != nil {
 		return fmt.Errorf("appending models: %+v", err)
@@ -35,7 +35,7 @@ func (r *ParseResult) Append(other ParseResult) error {
 	return nil
 }
 
-func (r *ParseResult) AppendConstants(other map[string]models.SDKConstant) error {
+func (r *ParseResult) AppendConstants(other map[string]sdkModels.SDKConstant) error {
 	for k, v := range other {
 		existing, hasExisting := r.Constants[k]
 		if !hasExisting {
@@ -55,7 +55,7 @@ func (r *ParseResult) AppendConstants(other map[string]models.SDKConstant) error
 	return nil
 }
 
-func (r *ParseResult) AppendModels(other map[string]models.SDKModel) error {
+func (r *ParseResult) AppendModels(other map[string]sdkModels.SDKModel) error {
 	for k, v := range other {
 		existing, hasExisting := r.Models[k]
 		if !hasExisting {
@@ -81,7 +81,7 @@ func (r *ParseResult) AppendModels(other map[string]models.SDKModel) error {
 	return nil
 }
 
-func compareFields(first map[string]models.SDKField, second map[string]models.SDKField) error {
+func compareFields(first map[string]sdkModels.SDKField, second map[string]sdkModels.SDKField) error {
 	if len(first) != len(second) {
 		return fmt.Errorf("first had %d fields but second had %d fields", len(first), len(second))
 	}
@@ -114,7 +114,7 @@ func compareFields(first map[string]models.SDKField, second map[string]models.SD
 	return nil
 }
 
-func objectDefinitionsMatch(first, second models.SDKObjectDefinition) error {
+func objectDefinitionsMatch(first, second sdkModels.SDKObjectDefinition) error {
 	if first.NestedItem != nil && second.NestedItem == nil {
 		return fmt.Errorf("`first` had a nested item but `second` didn't. First: %+v. Second: %+v", first, second)
 	}

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/constants"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
@@ -19,8 +19,8 @@ import (
 
 func (d *SwaggerDefinition) parseModel(name string, input spec.Schema) (*internal.ParseResult, error) {
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 
 	// 1. find any constants used within this model
@@ -61,8 +61,8 @@ func (d *SwaggerDefinition) parseModel(name string, input spec.Schema) (*interna
 func (d *SwaggerDefinition) findConstantsWithinModel(fieldName string, modelName *string, input spec.Schema, known internal.ParseResult) (*internal.ParseResult, error) {
 	// NOTE: both Models and Fields are passed in here
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 	result.Append(known)
 
@@ -133,16 +133,16 @@ func (d *SwaggerDefinition) findConstantsWithinModel(fieldName string, modelName
 	return &result, nil
 }
 
-func (d *SwaggerDefinition) detailsForField(modelName string, propertyName string, value spec.Schema, isRequired bool, known internal.ParseResult) (*models.SDKField, *internal.ParseResult, error) {
+func (d *SwaggerDefinition) detailsForField(modelName string, propertyName string, value spec.Schema, isRequired bool, known internal.ParseResult) (*sdkModels.SDKField, *internal.ParseResult, error) {
 	logging.Tracef("Parsing details for field %q in %q..", propertyName, modelName)
 
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 	result.Append(known)
 
-	field := models.SDKField{
+	field := sdkModels.SDKField{
 		Required:    isRequired,
 		Optional:    !isRequired, //TODO: re-enable readonly && !value.ReadOnly,
 		ReadOnly:    false,       // TODO: re-enable readonly value.ReadOnly,
@@ -163,15 +163,15 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 
 	// TODO: support for other date formats (RFC3339Nano etc)
 	// https://github.com/hashicorp/pandora/issues/8
-	if objectDefinition.Type == models.DateTimeSDKObjectDefinitionType {
-		field.DateFormat = pointer.To(models.RFC3339SDKDateFormat)
+	if objectDefinition.Type == sdkModels.DateTimeSDKObjectDefinitionType {
+		field.DateFormat = pointer.To(sdkModels.RFC3339SDKDateFormat)
 	}
 
 	// if there are more than 1 allOf, it can not use a simple reference type, but a new definition
 	if len(value.Properties) > 0 || len(value.AllOf) > 1 {
 		// there's a nested model we need to pull out
 		inlinedName := inlinedModelName(modelName, propertyName)
-		nestedFields := make(map[string]models.SDKField, 0)
+		nestedFields := make(map[string]sdkModels.SDKField, 0)
 		for propName, propVal := range value.Properties {
 			nestedFieldRequired := false
 			for _, field := range value.Required {
@@ -226,7 +226,7 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 		}
 		result.Models[inlinedName] = *inlinedModelDetails
 		// then swap out the reference
-		objectDefinition.Type = models.ReferenceSDKObjectDefinitionType
+		objectDefinition.Type = sdkModels.ReferenceSDKObjectDefinitionType
 		objectDefinition.ReferenceName = &inlinedName
 	}
 
@@ -237,11 +237,11 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 	return &field, &result, err
 }
 
-func (d *SwaggerDefinition) fieldsForModel(modelName string, input spec.Schema, known internal.ParseResult) (*map[string]models.SDKField, *internal.ParseResult, error) {
-	fields := make(map[string]models.SDKField, 0)
+func (d *SwaggerDefinition) fieldsForModel(modelName string, input spec.Schema, known internal.ParseResult) (*map[string]sdkModels.SDKField, *internal.ParseResult, error) {
+	fields := make(map[string]sdkModels.SDKField, 0)
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 	result.Append(known)
 
@@ -376,8 +376,8 @@ func (d *SwaggerDefinition) findTopLevelObject(name string) (*spec.Schema, error
 	return nil, fmt.Errorf("the top level object %q was not found", name)
 }
 
-func (d *SwaggerDefinition) modelDetailsFromObject(modelName string, input spec.Schema, fields map[string]models.SDKField) (*models.SDKModel, error) {
-	details := models.SDKModel{
+func (d *SwaggerDefinition) modelDetailsFromObject(modelName string, input spec.Schema, fields map[string]sdkModels.SDKField) (*sdkModels.SDKModel, error) {
+	details := sdkModels.SDKModel{
 		Fields: fields,
 	}
 
@@ -454,8 +454,8 @@ func (d *SwaggerDefinition) findAncestorType(input spec.Schema) (*string, *strin
 
 func (d *SwaggerDefinition) findOrphanedDiscriminatedModels(serviceName string) (*internal.ParseResult, error) {
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 
 	for modelName, definition := range d.swaggerSpecRaw.Definitions {
@@ -500,7 +500,7 @@ func (d *SwaggerDefinition) findOrphanedDiscriminatedModels(serviceName string) 
 
 	// this will also pull out the parent model in the file which will already have been parsed, but that's ok
 	// since they will be de-duplicated when we call combineResourcesWith
-	nestedResult, err := d.findNestedItemsYetToBeParsed(map[string]models.SDKOperation{}, result)
+	nestedResult, err := d.findNestedItemsYetToBeParsed(map[string]sdkModels.SDKOperation{}, result)
 	if err != nil {
 		return nil, fmt.Errorf("finding nested items yet to be parsed: %+v", err)
 	}
@@ -517,12 +517,12 @@ func (d SwaggerDefinition) parseObjectDefinition(
 	input *spec.Schema,
 	known internal.ParseResult,
 	parsingModel bool,
-) (*models.SDKObjectDefinition, *internal.ParseResult, error) {
+) (*sdkModels.SDKObjectDefinition, *internal.ParseResult, error) {
 	// find the object and any models and constants etc we can find
 	// however _don't_ look for discriminator implementations - since that should be done when we're completely done
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 	result.Append(known)
 
@@ -534,8 +534,8 @@ func (d SwaggerDefinition) parseObjectDefinition(
 		}
 		result.Constants[constant.Name] = constant.Details
 
-		definition := models.SDKObjectDefinition{
-			Type:          models.ReferenceSDKObjectDefinitionType,
+		definition := sdkModels.SDKObjectDefinition{
+			Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 			ReferenceName: &constant.Name,
 		}
 
@@ -563,15 +563,15 @@ func (d SwaggerDefinition) parseObjectDefinition(
 		}
 
 		knownIncludingPlaceholder := internal.ParseResult{
-			Constants: map[string]models.SDKConstant{},
-			Models:    map[string]models.SDKModel{},
+			Constants: map[string]sdkModels.SDKConstant{},
+			Models:    map[string]sdkModels.SDKModel{},
 		}
 
 		if err := knownIncludingPlaceholder.Append(result); err != nil {
 			return nil, nil, fmt.Errorf("appending nestedResult: %+v", err)
 		}
 		if *objectName != "" {
-			knownIncludingPlaceholder.Models[*objectName] = models.SDKModel{
+			knownIncludingPlaceholder.Models[*objectName] = sdkModels.SDKModel{
 				// add a placeholder to avoid circular references
 			}
 		}
@@ -624,8 +624,8 @@ func (d SwaggerDefinition) parseObjectDefinition(
 			}
 		}
 
-		definition := models.SDKObjectDefinition{
-			Type:          models.ReferenceSDKObjectDefinitionType,
+		definition := sdkModels.SDKObjectDefinition{
+			Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 			ReferenceName: &modelName,
 		}
 		// TODO: re-enable min/max/unique
@@ -660,8 +660,8 @@ func (d SwaggerDefinition) parseObjectDefinition(
 		if err := result.Append(*nestedResult); err != nil {
 			return nil, nil, fmt.Errorf("appending nestedResult: %+v", err)
 		}
-		return &models.SDKObjectDefinition{
-			Type:       models.DictionarySDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type:       sdkModels.DictionarySDKObjectDefinitionType,
 			NestedItem: nestedItem,
 		}, &result, nil
 	}
@@ -696,8 +696,8 @@ func (d SwaggerDefinition) parseObjectDefinition(
 		if err := result.Append(*nestedResult); err != nil {
 			return nil, nil, fmt.Errorf("appending nestedResult: %+v", err)
 		}
-		return &models.SDKObjectDefinition{
-			Type:       models.ListSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type:       sdkModels.ListSDKObjectDefinitionType,
 			NestedItem: nestedItem,
 		}, &result, nil
 	}
@@ -724,7 +724,7 @@ func (d SwaggerDefinition) parseObjectDefinition(
 	return nil, nil, fmt.Errorf("unimplemented object definition")
 }
 
-func (d SwaggerDefinition) parseDataFactoryCustomTypes(input *spec.Schema, known internal.ParseResult) (*models.SDKObjectDefinition, *internal.ParseResult, error) {
+func (d SwaggerDefinition) parseDataFactoryCustomTypes(input *spec.Schema, known internal.ParseResult) (*sdkModels.SDKObjectDefinition, *internal.ParseResult, error) {
 	formatVal := ""
 	if input.Type.Contains("object") {
 		formatVal, _ = input.Extensions.GetString("x-ms-format")
@@ -737,31 +737,31 @@ func (d SwaggerDefinition) parseDataFactoryCustomTypes(input *spec.Schema, known
 	// as such we need to handle that here
 	// Simple Types
 	if strings.EqualFold(formatVal, "dfe-bool") {
-		return &models.SDKObjectDefinition{
-			Type: models.BooleanSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.BooleanSDKObjectDefinitionType,
 		}, nil, nil
 	}
 	if strings.EqualFold(formatVal, "dfe-double") {
-		return &models.SDKObjectDefinition{
-			Type: models.FloatSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.FloatSDKObjectDefinitionType,
 		}, nil, nil
 	}
 	if strings.EqualFold(formatVal, "dfe-key-value-pairs") {
-		return &models.SDKObjectDefinition{
-			Type: models.DictionarySDKObjectDefinitionType,
-			NestedItem: &models.SDKObjectDefinition{
-				Type: models.StringSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.DictionarySDKObjectDefinitionType,
+			NestedItem: &sdkModels.SDKObjectDefinition{
+				Type: sdkModels.StringSDKObjectDefinitionType,
 			},
 		}, nil, nil
 	}
 	if strings.EqualFold(formatVal, "dfe-int") {
-		return &models.SDKObjectDefinition{
-			Type: models.IntegerSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.IntegerSDKObjectDefinitionType,
 		}, nil, nil
 	}
 	if strings.EqualFold(formatVal, "dfe-string") {
-		return &models.SDKObjectDefinition{
-			Type: models.StringSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.StringSDKObjectDefinitionType,
 		}, nil, nil
 	}
 
@@ -783,69 +783,69 @@ func (d SwaggerDefinition) parseDataFactoryCustomTypes(input *spec.Schema, known
 		if err := known.Append(*parseResult); err != nil {
 			return nil, nil, fmt.Errorf("appending `parseResult`: %+v", err)
 		}
-		return &models.SDKObjectDefinition{
-			Type: models.ListSDKObjectDefinitionType,
-			NestedItem: &models.SDKObjectDefinition{
-				Type:          models.ReferenceSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.ListSDKObjectDefinitionType,
+			NestedItem: &sdkModels.SDKObjectDefinition{
+				Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 				ReferenceName: pointer.To(elementType),
 			},
 		}, &known, nil
 	}
 
 	if strings.EqualFold(formatVal, "dfe-list-string") {
-		return &models.SDKObjectDefinition{
-			Type: models.ListSDKObjectDefinitionType,
-			NestedItem: &models.SDKObjectDefinition{
-				Type: models.StringSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.ListSDKObjectDefinitionType,
+			NestedItem: &sdkModels.SDKObjectDefinition{
+				Type: sdkModels.StringSDKObjectDefinitionType,
 			},
 		}, nil, nil
 	}
 
 	// otherwise let this fall through, since the "least bad" thing to do here is to mark this as an object
 
-	return &models.SDKObjectDefinition{
-		Type: models.RawObjectSDKObjectDefinitionType,
+	return &sdkModels.SDKObjectDefinition{
+		Type: sdkModels.RawObjectSDKObjectDefinitionType,
 	}, nil, nil
 }
 
-func (d SwaggerDefinition) parseNativeType(input *spec.Schema) *models.SDKObjectDefinition {
+func (d SwaggerDefinition) parseNativeType(input *spec.Schema) *sdkModels.SDKObjectDefinition {
 	if input == nil {
 		return nil
 	}
 
 	if input.Type.Contains("bool") || input.Type.Contains("boolean") {
-		return &models.SDKObjectDefinition{
-			Type: models.BooleanSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.BooleanSDKObjectDefinitionType,
 		}
 	}
 
 	if input.Type.Contains("file") {
-		return &models.SDKObjectDefinition{
-			Type: models.RawFileSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.RawFileSDKObjectDefinitionType,
 		}
 	}
 
 	if input.Type.Contains("integer") {
-		return &models.SDKObjectDefinition{
-			Type: models.IntegerSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.IntegerSDKObjectDefinitionType,
 		}
 	}
 
 	if input.Type.Contains("number") {
-		return &models.SDKObjectDefinition{
-			Type: models.FloatSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.FloatSDKObjectDefinitionType,
 		}
 	}
 
 	if input.Type.Contains("object") {
 		if strings.EqualFold(input.Format, "file") {
-			return &models.SDKObjectDefinition{
-				Type: models.RawFileSDKObjectDefinitionType,
+			return &sdkModels.SDKObjectDefinition{
+				Type: sdkModels.RawFileSDKObjectDefinitionType,
 			}
 		}
 
-		return &models.SDKObjectDefinition{
-			Type: models.RawObjectSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.RawObjectSDKObjectDefinitionType,
 		}
 	}
 
@@ -853,23 +853,23 @@ func (d SwaggerDefinition) parseNativeType(input *spec.Schema) *models.SDKObject
 	// that this could have no Type value but a Format value, so we have to check this separately.
 	if strings.EqualFold(input.Format, "date-time") {
 		// TODO: handle there being a custom format - for now we assume these are all using RFC3339 (#8)
-		return &models.SDKObjectDefinition{
-			Type: models.DateTimeSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.DateTimeSDKObjectDefinitionType,
 		}
 	}
 
 	if input.Type.Contains("string") {
 		// TODO: handle the `format` of `arm-id` (#1289)
-		return &models.SDKObjectDefinition{
-			Type: models.StringSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.StringSDKObjectDefinitionType,
 		}
 	}
 
 	// whilst all fields _should_ have a Type field, it's not guaranteed that they do
 	// NOTE: this is _intentionally_ not part of the Object comparison above
 	if len(input.Type) == 0 {
-		return &models.SDKObjectDefinition{
-			Type: models.RawObjectSDKObjectDefinitionType,
+		return &sdkModels.SDKObjectDefinition{
+			Type: sdkModels.RawObjectSDKObjectDefinitionType,
 		}
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/models_commonschema_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_commonschema_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -26,36 +26,36 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedList(t *test
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.LegacySystemAndUserAssignedIdentityListSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.LegacySystemAndUserAssignedIdentityListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -75,36 +75,36 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap(t *testi
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.LegacySystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.LegacySystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -126,36 +126,36 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap_ExtraFie
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.LegacySystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.LegacySystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -175,36 +175,36 @@ func TestParseModel_CommonSchema_IdentityLegacySystemAndUserAssignedMap_GenericD
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.LegacySystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.LegacySystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -224,36 +224,36 @@ func TestParseModel_CommonSchema_IdentitySystemAssigned(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.SystemAssignedIdentitySDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.SystemAssignedIdentitySDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -273,36 +273,36 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedList(t *testing.T)
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.SystemAndUserAssignedIdentityListSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.SystemAndUserAssignedIdentityListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -322,36 +322,36 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedMap(t *testing.T) 
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.SystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.SystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -373,36 +373,36 @@ func TestParseModel_CommonSchema_IdentitySystemAndUserAssignedMap_ExtraFields(t 
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.SystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.SystemAndUserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -422,36 +422,36 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedList(t *testing.T) 
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.SystemOrUserAssignedIdentityListSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.SystemOrUserAssignedIdentityListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -471,36 +471,36 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -522,36 +522,36 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap_DelegatedResour
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -573,36 +573,36 @@ func TestParseModel_CommonSchema_IdentitySystemOrUserAssignedMap_ExtraFields(t *
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.SystemOrUserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -622,36 +622,36 @@ func TestParseModel_CommonSchema_IdentityUserAssignedList(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.UserAssignedIdentityListSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.UserAssignedIdentityListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -671,36 +671,36 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.UserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.UserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -720,36 +720,36 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap_PrincipalID(t *testing.
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.UserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.UserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -769,36 +769,36 @@ func TestParseModel_CommonSchema_IdentityUserAssignedMap_TenantID(t *testing.T) 
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.UserAssignedIdentityMapSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.UserAssignedIdentityMapSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -818,36 +818,36 @@ func TestParseModel_CommonSchema_Location(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Resource": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Location": {
 								JsonName: "location",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.LocationSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.LocationSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},

--- a/tools/importer-rest-api-specs/components/parser/models_datafactorycustom_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_datafactorycustom_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/featureflags"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
@@ -19,45 +19,45 @@ func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
 		t.Fatalf("parsing: %+v", err)
 	}
 
-	expectedModels := map[string]models.SDKModel{
+	expectedModels := map[string]sdkModels.SDKModel{
 		"Model": {
-			Fields: map[string]models.SDKField{
+			Fields: map[string]sdkModels.SDKField{
 				// Simple Types
 				"BooleanField": {
 					JsonName: "booleanField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.BooleanSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.BooleanSDKObjectDefinitionType,
 					},
 					Required: false,
 				},
 				"DoubleField": {
 					JsonName: "doubleField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.FloatSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.FloatSDKObjectDefinitionType,
 					},
 					Required: false,
 				},
 				"KeyValuePairField": {
 					JsonName: "keyValuePairField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.DictionarySDKObjectDefinitionType,
-						NestedItem: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.DictionarySDKObjectDefinitionType,
+						NestedItem: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 					},
 					Required: false,
 				},
 				"IntegerField": {
 					JsonName: "integerField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.IntegerSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.IntegerSDKObjectDefinitionType,
 					},
 					Required: false,
 				},
 				"StringField": {
 					JsonName: "stringField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.StringSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.StringSDKObjectDefinitionType,
 					},
 					Required: false,
 				},
@@ -65,8 +65,8 @@ func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
 					// In this case, the `dfe-*` value is unknown, so we should return an object
 					// this is the default behaviour, mostly for sanity-checking
 					JsonName: "unknownField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.RawObjectSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.RawObjectSDKObjectDefinitionType,
 					},
 					Required: false,
 				},
@@ -74,40 +74,40 @@ func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
 				// Dictionaries of a Simple Type (using the regular Swagger/OpenAPI syntax)
 				"DictionaryOfBooleanField": {
 					JsonName: "dictionaryOfBooleanField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.DictionarySDKObjectDefinitionType,
-						NestedItem: &models.SDKObjectDefinition{
-							Type: models.BooleanSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.DictionarySDKObjectDefinitionType,
+						NestedItem: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.BooleanSDKObjectDefinitionType,
 						},
 					},
 					Required: false,
 				},
 				"DictionaryOfDoubleField": {
 					JsonName: "dictionaryOfDoubleField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.DictionarySDKObjectDefinitionType,
-						NestedItem: &models.SDKObjectDefinition{
-							Type: models.FloatSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.DictionarySDKObjectDefinitionType,
+						NestedItem: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.FloatSDKObjectDefinitionType,
 						},
 					},
 					Required: false,
 				},
 				"DictionaryOfIntegerField": {
 					JsonName: "dictionaryOfIntegerField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.DictionarySDKObjectDefinitionType,
-						NestedItem: &models.SDKObjectDefinition{
-							Type: models.IntegerSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.DictionarySDKObjectDefinitionType,
+						NestedItem: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.IntegerSDKObjectDefinitionType,
 						},
 					},
 					Required: false,
 				},
 				"DictionaryOfStringField": {
 					JsonName: "dictionaryOfStringField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.DictionarySDKObjectDefinitionType,
-						NestedItem: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.DictionarySDKObjectDefinitionType,
+						NestedItem: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 					},
 					Required: false,
@@ -116,10 +116,10 @@ func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
 					// In this case, the `dfe-*` value is unknown, so we should return an object
 					// this is the default behaviour, mostly for sanity-checking
 					JsonName: "dictionaryOfUnknownField",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.DictionarySDKObjectDefinitionType,
-						NestedItem: &models.SDKObjectDefinition{
-							Type: models.RawObjectSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.DictionarySDKObjectDefinitionType,
+						NestedItem: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.RawObjectSDKObjectDefinitionType,
 						},
 					},
 					Required: false,
@@ -128,20 +128,20 @@ func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
 				// DFE specific List implementations
 				"DfeCustomListOfString": {
 					JsonName: "dfeCustomListOfString",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.ListSDKObjectDefinitionType,
-						NestedItem: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.ListSDKObjectDefinitionType,
+						NestedItem: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 					},
 					Required: false,
 				},
 				"DfeCustomListOfAnotherObject": {
 					JsonName: "dfeCustomListOfAnotherObject",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.ListSDKObjectDefinitionType,
-						NestedItem: &models.SDKObjectDefinition{
-							Type:          models.ReferenceSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.ListSDKObjectDefinitionType,
+						NestedItem: &sdkModels.SDKObjectDefinition{
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 							ReferenceName: pointer.To("SecondModel"),
 						},
 					},
@@ -150,11 +150,11 @@ func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
 			},
 		},
 		"SecondModel": {
-			Fields: map[string]models.SDKField{
+			Fields: map[string]sdkModels.SDKField{
 				"Example": {
 					JsonName: "example",
-					ObjectDefinition: models.SDKObjectDefinition{
-						Type: models.StringSDKObjectDefinitionType,
+					ObjectDefinition: sdkModels.SDKObjectDefinition{
+						Type: sdkModels.StringSDKObjectDefinitionType,
 					},
 				},
 			},
@@ -163,10 +163,10 @@ func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
 
 	if !featureflags.ParseDataFactoryListsOfReferencesAsRegularObjectDefinitionTypes {
 		delete(expectedModels, "SecondModel")
-		expectedModels["Model"].Fields["DfeCustomListOfAnotherObject"] = models.SDKField{
+		expectedModels["Model"].Fields["DfeCustomListOfAnotherObject"] = sdkModels.SDKField{
 			JsonName: "dfeCustomListOfAnotherObject",
-			ObjectDefinition: models.SDKObjectDefinition{
-				Type: models.RawObjectSDKObjectDefinitionType,
+			ObjectDefinition: sdkModels.SDKObjectDefinition{
+				Type: sdkModels.RawObjectSDKObjectDefinitionType,
 			},
 			Required: false,
 		}
@@ -175,21 +175,21 @@ func TestParseModelWithDataFactoryCustomTypes(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
 				Models: expectedModels,
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},

--- a/tools/importer-rest-api-specs/components/parser/models_dictionaries_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_dictionaries_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -20,24 +20,24 @@ func TestParseModelWithADictionaryOfIntegers(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.DictionarySDKObjectDefinitionType,
-									NestedItem: &models.SDKObjectDefinition{
-										Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
+									NestedItem: &sdkModels.SDKObjectDefinition{
+										Type: sdkModels.IntegerSDKObjectDefinitionType,
 									},
 								},
 								Required: false,
@@ -45,14 +45,14 @@ func TestParseModelWithADictionaryOfIntegers(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -72,24 +72,24 @@ func TestParseModelWithADictionaryOfIntegersInlined(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.DictionarySDKObjectDefinitionType,
-									NestedItem: &models.SDKObjectDefinition{
-										Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
+									NestedItem: &sdkModels.SDKObjectDefinition{
+										Type: sdkModels.IntegerSDKObjectDefinitionType,
 									},
 								},
 								Required: false,
@@ -97,14 +97,14 @@ func TestParseModelWithADictionaryOfIntegersInlined(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -124,72 +124,72 @@ func TestParseModelWithADictionaryOfAnObject(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("MapFieldProperties"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.DictionarySDKObjectDefinitionType,
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"MapFieldProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Line1": {
 								JsonName: "line1",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Line2": {
 								JsonName: "line2",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"City": {
 								JsonName: "city",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -209,72 +209,72 @@ func TestParseModelWithADictionaryOfAnObjectInlined(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("MapFieldProperties"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.DictionarySDKObjectDefinitionType,
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"MapFieldProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Line1": {
 								JsonName: "line1",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Line2": {
 								JsonName: "line2",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"City": {
 								JsonName: "city",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -294,24 +294,24 @@ func TestParseModelWithADictionaryOfString(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.DictionarySDKObjectDefinitionType,
-									NestedItem: &models.SDKObjectDefinition{
-										Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
+									NestedItem: &sdkModels.SDKObjectDefinition{
+										Type: sdkModels.StringSDKObjectDefinitionType,
 									},
 								},
 								Required: false,
@@ -319,14 +319,14 @@ func TestParseModelWithADictionaryOfString(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -346,24 +346,24 @@ func TestParseModelWithADictionaryOfStringInlined(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"MapField": {
 								JsonName: "mapField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.DictionarySDKObjectDefinitionType,
-									NestedItem: &models.SDKObjectDefinition{
-										Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
+									NestedItem: &sdkModels.SDKObjectDefinition{
+										Type: sdkModels.StringSDKObjectDefinitionType,
 									},
 								},
 								Required: false,
@@ -371,14 +371,14 @@ func TestParseModelWithADictionaryOfStringInlined(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},

--- a/tools/importer-rest-api-specs/components/parser/models_discriminators_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_discriminators_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -20,27 +20,27 @@ func TestParseDiscriminatorsTopLevel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Animal"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -51,18 +51,18 @@ func TestParseDiscriminatorsTopLevel(t *testing.T) {
 						ParentTypeName:                        pointer.To("Animal"),
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 						DiscriminatedValue:                    pointer.To("cat"),
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -72,32 +72,32 @@ func TestParseDiscriminatorsTopLevel(t *testing.T) {
 						ParentTypeName:                        pointer.To("Animal"),
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 						DiscriminatedValue:                    pointer.To("dog"),
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -117,30 +117,30 @@ func TestParseDiscriminatorsWithinArray(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"BiologicalEntities": {
 								JsonName: "biologicalEntities",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("BiologicalEntity"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 					"BiologicalEntity": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -151,18 +151,18 @@ func TestParseDiscriminatorsWithinArray(t *testing.T) {
 						ParentTypeName:                        pointer.To("BiologicalEntity"),
 						FieldNameContainingDiscriminatedValue: pointer.To("TypeName"),
 						DiscriminatedValue:                    pointer.To("cat"),
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -172,39 +172,39 @@ func TestParseDiscriminatorsWithinArray(t *testing.T) {
 						ParentTypeName:                        pointer.To("BiologicalEntity"),
 						FieldNameContainingDiscriminatedValue: pointer.To("TypeName"),
 						DiscriminatedValue:                    pointer.To("human"),
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -224,23 +224,23 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"FavouriteToy": {
 								JsonName: "favouriteToy",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Toy"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
@@ -248,18 +248,18 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 					},
 					"Bone": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Length": {
 								JsonName: "length",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.FloatSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.FloatSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"ToyType": {
 								JsonName: "toyType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -272,26 +272,26 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						ParentTypeName:                        pointer.To("Animal"),
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 						DiscriminatedValue:                    pointer.To("cat"),
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"FavouriteToy": {
 								JsonName: "favouriteToy",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Toy"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -301,63 +301,63 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						ParentTypeName:                        pointer.To("Animal"),
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 						DiscriminatedValue:                    pointer.To("dog"),
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"FavouriteToy": {
 								JsonName: "favouriteToy",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Toy"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Animal"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 					"LaserBeam": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Colour": {
 								JsonName: "colour",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Intensity": {
 								JsonName: "intensity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"ToyType": {
 								JsonName: "toyType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -367,11 +367,11 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("laser-beam"),
 					},
 					"Toy": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"ToyType": {
 								JsonName: "toyType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -379,14 +379,14 @@ func TestParseDiscriminatorsWithinDiscriminators(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("ToyType"),
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -409,29 +409,29 @@ func TestParseDiscriminatedParentTypeThatShouldntBe(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Type": {
 								JsonName: "type",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Animal"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -454,29 +454,29 @@ func TestParseDiscriminatedChildTypeThatShouldntBe(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Dog": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Dog"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -499,15 +499,15 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -515,18 +515,18 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -536,18 +536,18 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -557,26 +557,26 @@ func TestParseDiscriminatedChildTypeWhereParentShouldNotBeUsed(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("dog"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Dog"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -596,15 +596,15 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -612,18 +612,18 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -633,25 +633,25 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -661,26 +661,26 @@ func TestParseDiscriminatorsInheritingFromOtherDiscriminators(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("dog"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Animal"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -700,22 +700,22 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsPlantEater": {
 								JsonName: "isPlantEater",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -725,11 +725,11 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("animal"),
 					},
 					"BiologicalEntity": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -737,25 +737,25 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("TypeName"),
 					},
 					"Carnivore": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"IsPlantEater": {
 								JsonName: "isPlantEater",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsPredator": {
 								JsonName: "isPredator",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -765,32 +765,32 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("carnivore"),
 					},
 					"Cat": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsPlantEater": {
 								JsonName: "isPlantEater",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"IsPredator": {
 								JsonName: "isPredator",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -800,12 +800,12 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("cat"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"BiologicalEntity": {
 								JsonName: "biologicalEntity",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("BiologicalEntity"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -815,53 +815,53 @@ func TestParseDiscriminatorsDeepInheritance(t *testing.T) {
 						ParentTypeName:                        pointer.To("BiologicalEntity"),
 						FieldNameContainingDiscriminatedValue: pointer.To("TypeName"),
 						DiscriminatedValue:                    pointer.To("persian-cat"),
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFriendly": {
 								JsonName: "isFriendly",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsPlantEater": {
 								JsonName: "isPlantEater",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"IsPredator": {
 								JsonName: "isPredator",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -883,22 +883,22 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"BiologicalEntity": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -906,39 +906,39 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("TypeName"),
 					},
 					"Cat": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -948,51 +948,51 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("cat"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Item": {
 								JsonName: "item",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("BiologicalEntity"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 					"Human": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1005,14 +1005,14 @@ func TestParseDiscriminatorsWithMultipleParents(t *testing.T) {
 					// it's just an abstract type (defining the shared fields for Car and Human), rather than
 					// being directly used.
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1034,22 +1034,22 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Discriminator": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"BiologicalEntity": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1057,39 +1057,39 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("TypeName"),
 					},
 					"Cat": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1099,54 +1099,54 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("cat"),
 					},
 					"ExampleWrapper": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Items": {
 								JsonName: "items",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("BiologicalEntity"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 					"Human": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"FirstName": {
 								JsonName: "firstName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"LastName": {
 								JsonName: "lastName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"SomeField": {
 								JsonName: "someField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"TypeName": {
 								JsonName: "typeName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1159,14 +1159,14 @@ func TestParseDiscriminatorsWithMultipleParentsWithinArray(t *testing.T) {
 					// it's just an abstract type (defining the shared fields for Car and Human), rather than
 					// being directly used.
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleWrapper"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1186,18 +1186,18 @@ func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			// NOTE: since there's no Operations defined the Models are placed into an APIResource based on the
 			// File Name. Whilst in a normal scenario this would make sense - for testing purposes it leads to
 			// some unexpectedly named data, but this is fine providing the APIResource we're expecting exists.
 			"ModelDiscriminatorsOrphanedChildren": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1205,18 +1205,18 @@ func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1226,18 +1226,18 @@ func TestParseDiscriminatorsOrphanedChild(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1263,18 +1263,18 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			// NOTE: since there's no Operations defined the Models are placed into an APIResource based on the
 			// File Name. Whilst in a normal scenario this would make sense - for testing purposes it leads to
 			// some unexpectedly named data, but this is fine providing the APIResource we're expecting exists.
 			"ModelDiscriminatorsOrphanedChildWithNestedModels": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1282,18 +1282,18 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IsFluffy": {
 								JsonName: "isFluffy",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1303,29 +1303,29 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 						DiscriminatedValue:                    pointer.To("cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Barks": {
 								JsonName: "barks",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Parameters": {
 								JsonName: "parameters",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("KeyValuePair"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
@@ -1336,18 +1336,18 @@ func TestParseDiscriminatorsOrphanedChildWithNestedModel(t *testing.T) {
 					},
 					// ExampleWrapper is present in the Swagger but unused
 					"KeyValuePair": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Key": {
 								JsonName: "key",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Value": {
 								JsonName: "value",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1369,18 +1369,18 @@ func TestParseDiscriminatorsOrphanedChildWithoutDiscriminatorValue(t *testing.T)
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "DataFactory",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			// NOTE: since there's no Operations defined the Models are placed into an APIResource based on the
 			// File Name. Whilst in a normal scenario this would make sense - for testing purposes it leads to
 			// some unexpectedly named data, but this is fine providing the APIResource we're expecting exists.
 			"ModelDiscriminatorsOrphanedChildWithoutDiscriminatorValues": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1388,11 +1388,11 @@ func TestParseDiscriminatorsOrphanedChildWithoutDiscriminatorValue(t *testing.T)
 						FieldNameContainingDiscriminatedValue: pointer.To("AnimalType"),
 					},
 					"Cat": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1402,11 +1402,11 @@ func TestParseDiscriminatorsOrphanedChildWithoutDiscriminatorValue(t *testing.T)
 						DiscriminatedValue:                    pointer.To("Cat"),
 					},
 					"Dog": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"AnimalType": {
 								JsonName: "animalType",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1433,7 +1433,7 @@ func TestParseDiscriminatorsOrphanedChildWithoutDiscriminatorValueForDifferentSe
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Compute",
 		ApiVersion:  "2020-01-01",
-		Resources:   map[string]importerModels.AzureApiResource{},
+		Resources:   map[string]sdkModels.APIResource{},
 	}
 	validateParsedSwaggerResultMatches(t, expected, actual)
 }

--- a/tools/importer-rest-api-specs/components/parser/models_test.go
+++ b/tools/importer-rest-api-specs/components/parser/models_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -22,68 +22,68 @@ func TestParseModelTopLevel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Height": {
 								JsonName: "height",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.FloatSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.FloatSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Tags": {
 								JsonName: "tags",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.TagsSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.TagsSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Value": {
 								JsonName: "value",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.RawObjectSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.RawObjectSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -103,18 +103,18 @@ func TestParseModelTopLevelWithRawFile(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.RawFileSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.RawFileSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.RawFileSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.RawFileSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -134,87 +134,87 @@ func TestParseModelTopLevelWithInlinedModel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Properties": {
 								JsonName: "properties",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("ModelProperties"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ModelProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Height": {
 								JsonName: "height",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.FloatSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.FloatSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Nickname": {
 								JsonName: "nickname",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Tags": {
 								JsonName: "tags",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.TagsSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.TagsSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Value": {
 								JsonName: "value",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.RawObjectSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.RawObjectSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -234,33 +234,33 @@ func TestParseModelWithDateTimeNoType(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"SomeDateValue": {
 								JsonName: "someDateValue",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.DateTimeSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.DateTimeSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -280,67 +280,67 @@ func TestParseModelWithInlinedObject(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"ThingProps": {
 								JsonName: "thingProps",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("ThingProperties"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ThingProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"KeyName": {
 								JsonName: "keyName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"UserAssignedIdentities": {
 								JsonName: "userAssignedIdentities",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("UserAssignedIdentitiesProperties"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.DictionarySDKObjectDefinitionType,
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"UserAssignedIdentitiesProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"ClientId": {
 								JsonName: "clientId",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								ReadOnly: true,
 								Required: false,
 							},
 							"PrincipalId": {
 								JsonName: "principalId",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								ReadOnly: true,
 								Required: false,
@@ -348,14 +348,14 @@ func TestParseModelWithInlinedObject(t *testing.T) {
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -375,36 +375,36 @@ func TestParseModelWithNumberPrefixedField(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Five0PercentDone": {
 								JsonName: "50PercentDone",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -424,70 +424,70 @@ func TestParseModelWithReference(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"ThingProps": {
 								JsonName: "thingProps",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("ThingProperties"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ThingProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"KeyName": {
 								JsonName: "keyName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Identity": {
 								JsonName: "identity",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("UserAssignedIdentityProperties"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"UserAssignedIdentityProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"UserAssignedIdentity": {
 								JsonName: "userAssignedIdentity",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -507,56 +507,56 @@ func TestParseModelWithReferenceToArray(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Pets": {
 								JsonName: "pets",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("Pet"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 
 										// TODO: re-enable min/max/unique
 										// Minimum:     pointer.To(1),
 										// Maximum:     pointer.To(2),
 										// UniqueItems: pointer.To(true),
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"Pet": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -576,68 +576,68 @@ func TestParseModelWithReferenceToConstant(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"AnimalType": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"Cat": "Cat",
 							"Dog": "Dog",
 						},
 					},
 				},
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"ThingProps": {
 								JsonName: "thingProps",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("ThingProperties"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ThingProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Animal": {
 								JsonName: "animal",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("AnimalType"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"KeyName": {
 								JsonName: "keyName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -657,58 +657,58 @@ func TestParseModelWithReferenceToString(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"ThingProps": {
 								JsonName: "thingProps",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("ThingProperties"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ThingProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FullyQualifiedDomainName": {
 								JsonName: "fullyQualifiedDomainName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"KeyName": {
 								JsonName: "keyName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -728,89 +728,89 @@ func TestParseModelWithCircularReferences(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"FavouriteHouse": {
 								JsonName: "favouriteHouse",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("House"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"FavouriteHuman": {
 								JsonName: "favouriteHuman",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Human"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"House": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Address": {
 								JsonName: "address",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Residents": {
 								JsonName: "residents",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("Human"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"Human": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Pets": {
 								JsonName: "pets",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("Animal"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("House"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -830,31 +830,31 @@ func TestParseModelInheritingFromObjectWithNoExtraFields(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"FirstObject": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							// whilst the response model references SecondObject, it's only inheriting from FirstObject
 							// and doesn't contain any new fields, so it should be switched out
 							ReferenceName: pointer.To("FirstObject"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -874,48 +874,48 @@ func TestParseModelInheritingFromObjectWithNoExtraFieldsInlined(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"FirstObject": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Endpoints": {
 								JsonName: "endpoints",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("SecondObject"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"SecondObject": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("FirstObject"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -935,31 +935,31 @@ func TestParseModelInheritingFromObjectWithOnlyDescription(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"FirstObject": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							// whilst the response model references SecondObject, it's only inheriting from FirstObject
 							// and doesn't contain any new fields, so it should be switched out
 							ReferenceName: pointer.To("FirstObject"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -984,32 +984,32 @@ func TestParseModelInheritingFromObjectWithPropertiesWithinAllOf(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"SecondObject": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							// SecondObject is referenced as the Response Object, but because it inherits from one Model
 							// (FirstObject) and uses another (ThirdObject) it shouldn't be flattened into the parent type(s)
 							// and should instead remain `SecondObject`.
 							ReferenceName: pointer.To("SecondObject"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1029,40 +1029,40 @@ func TestParseModelContainingAllOfToTypeObject(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1082,40 +1082,40 @@ func TestParseModelContainingAllOfToTypeObjectWithProperties(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1135,66 +1135,66 @@ func TestParseModelContainingAllOfWithinProperties(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Properties": {
 								JsonName: "properties",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("ModelProperties"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ModelProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"MoreNested": {
 								JsonName: "moreNested",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1214,78 +1214,78 @@ func TestParseModelContainingMultipleAllOfWithinProperties(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Options": {
 								JsonName: "options",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("ResourceWithLocation"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Resource": {
 								JsonName: "resource",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("ModelResource"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ModelResource": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"MoreNested": {
 								JsonName: "moreNested",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Nested": {
 								JsonName: "nested",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ResourceWithLocation": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Country": {
 								JsonName: "country",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1305,73 +1305,73 @@ func TestParseModelContainingLists(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Animals": {
 								JsonName: "animals",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("Animal"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Plants": {
 								JsonName: "plants",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
-										Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
+										Type: sdkModels.StringSDKObjectDefinitionType,
 
 										// TODO: re-enable min/max/unique
 										// Maximum:     pointer.To(10),
 										// Minimum:     pointer.To(1),
 										// UniqueItems: pointer.To(true),
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"Animal": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1391,44 +1391,44 @@ func TestParseModelInlinedWithNoName(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Container": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Planets": {
 								JsonName: "planets",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("ContainerPlanetsInlined"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.ListSDKObjectDefinitionType,
+									Type: sdkModels.ListSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ContainerPlanetsInlined": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"ExampleField": {
 								JsonName: "exampleField",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Container"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1448,61 +1448,61 @@ func TestParseModelInheritingFromParent(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Model": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Height": {
 								JsonName: "height",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.FloatSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.FloatSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Tags": {
 								JsonName: "tags",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.TagsSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.TagsSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Model"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1522,82 +1522,82 @@ func TestParseModelMultipleTopLevelModelsAndOperations(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"GetExample": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Tags": {
 								JsonName: "tags",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.TagsSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.TagsSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"PutExample": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Age": {
 								JsonName: "age",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.IntegerSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.IntegerSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Enabled": {
 								JsonName: "enabled",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.BooleanSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.BooleanSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"Tags": {
 								JsonName: "tags",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.TagsSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.TagsSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Get": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("GetExample"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1605,13 +1605,13 @@ func TestParseModelMultipleTopLevelModelsAndOperations(t *testing.T) {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("PutExample"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("PutExample"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/example"),
 					},
@@ -1631,23 +1631,23 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"EnvironmentRole": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Description": {
 								JsonName: "description",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								ReadOnly: true,
 								Required: false,
 							},
 							"RoleName": {
 								JsonName: "roleName",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								ReadOnly: true,
 								Required: false,
@@ -1655,155 +1655,155 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 						},
 					},
 					"ExampleEnvironment": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Location": {
 								JsonName: "location",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.LocationSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.LocationSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Properties": {
 								JsonName: "properties",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("ExampleEnvironmentProperties"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ExampleEnvironmentProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"CreatorRoleAssignment": {
 								JsonName: "creatorRoleAssignment",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("ExampleEnvironmentUpdatePropertiesCreatorRoleAssignment"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"DeploymentTargetId": {
 								JsonName: "deploymentTargetId",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"ProvisioningState": {
 								JsonName: "provisioningState",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								ReadOnly: true,
 								Required: false,
 							},
 							"UserRoleAssignments": {
 								JsonName: "userRoleAssignments",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("UserRoleAssignment"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.DictionarySDKObjectDefinitionType,
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ExampleEnvironmentUpdate": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Example": {
 								JsonName: "example",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"Properties": {
 								JsonName: "properties",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("ExampleEnvironmentUpdateProperties"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ExampleEnvironmentUpdateProperties": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"CreatorRoleAssignment": {
 								JsonName: "creatorRoleAssignment",
-								ObjectDefinition: models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("ExampleEnvironmentUpdatePropertiesCreatorRoleAssignment"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"DeploymentTargetId": {
 								JsonName: "deploymentTargetId",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 							"UserRoleAssignments": {
 								JsonName: "userRoleAssignments",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("UserRoleAssignment"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.DictionarySDKObjectDefinitionType,
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"ExampleEnvironmentUpdatePropertiesCreatorRoleAssignment": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Roles": {
 								JsonName: "roles",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("EnvironmentRole"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.DictionarySDKObjectDefinitionType,
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 					"UserRoleAssignment": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Roles": {
 								JsonName: "roles",
-								ObjectDefinition: models.SDKObjectDefinition{
-									NestedItem: &models.SDKObjectDefinition{
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									NestedItem: &sdkModels.SDKObjectDefinition{
 										ReferenceName: pointer.To("EnvironmentRole"),
-										Type:          models.ReferenceSDKObjectDefinitionType,
+										Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 									},
-									Type: models.DictionarySDKObjectDefinitionType,
+									Type: sdkModels.DictionarySDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"CreateOrUpdate": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironment"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						ResourceIDName: pointer.To("EnvironmentId"),
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironment"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 					},
 					"Get": {
@@ -1811,31 +1811,31 @@ func TestParseModelBug2675DuplicateModel(t *testing.T) {
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
 						ResourceIDName:      pointer.To("EnvironmentId"),
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironment"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 					},
 					"Update": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PATCH",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironmentUpdate"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						ResourceIDName: pointer.To("EnvironmentId"),
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("ExampleEnvironment"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 					},
 				},
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"EnvironmentId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticEnvironments", "environments"),
-							models.NewUserSpecifiedResourceIDSegment("environmentName", "environmentName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticEnvironments", "environments"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("environmentName", "environmentName"),
 						},
 					},
 				},

--- a/tools/importer-rest-api-specs/components/parser/normalizer.go
+++ b/tools/importer-rest-api-specs/components/parser/normalizer.go
@@ -5,25 +5,24 @@ package parser
 
 import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
-	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 // normalizeAzureApiResource works through the parsed AzureApiResource and ensures
 // that all the Names and References are consistent (TitleCase) as a final effort
 // to ensure the Swagger Data is normalized.
-func normalizeAzureApiResource(input importerModels.AzureApiResource) importerModels.AzureApiResource {
-	normalizedConstants := make(map[string]models.SDKConstant)
+func normalizeAzureApiResource(input sdkModels.APIResource) sdkModels.APIResource {
+	normalizedConstants := make(map[string]sdkModels.SDKConstant)
 	for k, v := range input.Constants {
 		name := cleanup.NormalizeName(k)
 		normalizedConstants[name] = v
 	}
 
-	normalizedModels := make(map[string]models.SDKModel)
+	normalizedModels := make(map[string]sdkModels.SDKModel)
 	for k, v := range input.Models {
 		modelName := cleanup.NormalizeName(k)
-		fields := make(map[string]models.SDKField)
+		fields := make(map[string]sdkModels.SDKField)
 		for fieldName, fieldVal := range v.Fields {
 			normalizedFieldName := cleanup.NormalizeName(fieldName)
 			fieldVal.ObjectDefinition = normalizeSDKObjectDefinition(fieldVal.ObjectDefinition)
@@ -45,7 +44,7 @@ func normalizeAzureApiResource(input importerModels.AzureApiResource) importerMo
 		normalizedModels[modelName] = v
 	}
 
-	normalizedOperations := make(map[string]models.SDKOperation)
+	normalizedOperations := make(map[string]sdkModels.SDKOperation)
 	for k, v := range input.Operations {
 		if v.ResourceIDName != nil {
 			normalized := cleanup.NormalizeName(*v.ResourceIDName)
@@ -62,7 +61,7 @@ func normalizeAzureApiResource(input importerModels.AzureApiResource) importerMo
 			v.ResponseObject = pointer.To(response)
 		}
 
-		normalizedOptions := make(map[string]models.SDKOperationOption, 0)
+		normalizedOptions := make(map[string]sdkModels.SDKOperationOption, 0)
 		for optionKey, optionVal := range v.Options {
 			optionKey = cleanup.NormalizeName(optionKey)
 
@@ -75,9 +74,9 @@ func normalizeAzureApiResource(input importerModels.AzureApiResource) importerMo
 		normalizedOperations[k] = v
 	}
 
-	normalizedResourceIds := make(map[string]models.ResourceID)
-	for k, v := range input.ResourceIds {
-		segments := make([]models.ResourceIDSegment, 0)
+	normalizedResourceIds := make(map[string]sdkModels.ResourceID)
+	for k, v := range input.ResourceIDs {
+		segments := make([]sdkModels.ResourceIDSegment, 0)
 
 		normalizedConstantNames := make([]string, 0)
 		for _, cn := range v.ConstantNames {
@@ -98,15 +97,15 @@ func normalizeAzureApiResource(input importerModels.AzureApiResource) importerMo
 		normalizedResourceIds[k] = v
 	}
 
-	return importerModels.AzureApiResource{
+	return sdkModels.APIResource{
 		Constants:   normalizedConstants,
 		Models:      normalizedModels,
 		Operations:  normalizedOperations,
-		ResourceIds: normalizedResourceIds,
+		ResourceIDs: normalizedResourceIds,
 	}
 }
 
-func normalizeSDKObjectDefinition(input models.SDKObjectDefinition) models.SDKObjectDefinition {
+func normalizeSDKObjectDefinition(input sdkModels.SDKObjectDefinition) sdkModels.SDKObjectDefinition {
 	if input.ReferenceName != nil {
 		normalized := cleanup.NormalizeName(*input.ReferenceName)
 		input.ReferenceName = &normalized
@@ -120,7 +119,7 @@ func normalizeSDKObjectDefinition(input models.SDKObjectDefinition) models.SDKOb
 	return input
 }
 
-func normalizeOptionsObjectDefinition(input models.SDKOperationOptionObjectDefinition) models.SDKOperationOptionObjectDefinition {
+func normalizeOptionsObjectDefinition(input sdkModels.SDKOperationOptionObjectDefinition) sdkModels.SDKOperationOptionObjectDefinition {
 	if input.ReferenceName != nil {
 		normalized := cleanup.NormalizeName(*input.ReferenceName)
 		input.ReferenceName = &normalized

--- a/tools/importer-rest-api-specs/components/parser/operations.go
+++ b/tools/importer-rest-api-specs/components/parser/operations.go
@@ -5,17 +5,17 @@ package parser
 
 import (
 	"fmt"
-	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/go-openapi/spec"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/constants"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 )
 
 type operationsParser struct {
@@ -24,11 +24,11 @@ type operationsParser struct {
 	swaggerDefinition              *SwaggerDefinition
 }
 
-func (d *SwaggerDefinition) parseOperationsWithinTag(tag *string, operationIdsToParsedOperations map[string]resourceids.ParsedOperation, resourceProvider *string, found internal.ParseResult) (*map[string]models.SDKOperation, *internal.ParseResult, error) {
-	operations := make(map[string]models.SDKOperation, 0)
+func (d *SwaggerDefinition) parseOperationsWithinTag(tag *string, operationIdsToParsedOperations map[string]resourceids.ParsedOperation, resourceProvider *string, found internal.ParseResult) (*map[string]sdkModels.SDKOperation, *internal.ParseResult, error) {
+	operations := make(map[string]sdkModels.SDKOperation, 0)
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 	result.Append(found)
 
@@ -70,10 +70,10 @@ func (d *SwaggerDefinition) parseOperationsWithinTag(tag *string, operationIdsTo
 	return &operations, &result, nil
 }
 
-func (p operationsParser) parseOperation(operation parsedOperation, resourceProvider *string) (*models.SDKOperation, *internal.ParseResult, error) {
+func (p operationsParser) parseOperation(operation parsedOperation, resourceProvider *string) (*sdkModels.SDKOperation, *internal.ParseResult, error) {
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 
 	contentType := p.determineContentType(operation)
@@ -121,7 +121,7 @@ func (p operationsParser) parseOperation(operation parsedOperation, resourceProv
 		return nil, nil, nil
 	}
 
-	operationData := models.SDKOperation{
+	operationData := sdkModels.SDKOperation{
 		ContentType:                      contentType,
 		ExpectedStatusCodes:              expectedStatusCodes,
 		FieldContainingPaginationDetails: paginationField,
@@ -141,7 +141,7 @@ func (p operationsParser) parseOperation(operation parsedOperation, resourceProv
 	return &operationData, &result, nil
 }
 
-func (p operationsParser) determineObjectDefinitionForOption(input spec.Parameter) (*models.SDKOperationOptionObjectDefinition, error) {
+func (p operationsParser) determineObjectDefinitionForOption(input spec.Parameter) (*sdkModels.SDKOperationOptionObjectDefinition, error) {
 	if strings.EqualFold(input.Type, "array") {
 		// https://github.com/Azure/azure-rest-api-specs/blob/1b0ed8edd58bb7c9ade9a27430759527bd4eec8e/specification/trafficmanager/resource-manager/Microsoft.Network/stable/2018-03-01/trafficmanager.json#L735-L738
 		if input.Items == nil {
@@ -154,14 +154,14 @@ func (p operationsParser) determineObjectDefinitionForOption(input spec.Paramete
 		}
 
 		if strings.EqualFold(input.CollectionFormat, "csv") {
-			return &models.SDKOperationOptionObjectDefinition{
-				Type:       models.CSVSDKOperationOptionObjectDefinitionType,
+			return &sdkModels.SDKOperationOptionObjectDefinition{
+				Type:       sdkModels.CSVSDKOperationOptionObjectDefinitionType,
 				NestedItem: innerType,
 			}, nil
 		}
 
-		return &models.SDKOperationOptionObjectDefinition{
-			Type:       models.ListSDKOperationOptionObjectDefinitionType,
+		return &sdkModels.SDKOperationOptionObjectDefinition{
+			Type:       sdkModels.ListSDKOperationOptionObjectDefinitionType,
 			NestedItem: innerType,
 		}, nil
 	}
@@ -169,7 +169,7 @@ func (p operationsParser) determineObjectDefinitionForOption(input spec.Paramete
 	return p.determineObjectDefinitionForOptionRaw(input.Type, input.CollectionFormat, input.Format)
 }
 
-func (p operationsParser) determineObjectDefinitionForOptionRaw(paramType string, collectionFormat string, format string) (*models.SDKOperationOptionObjectDefinition, error) {
+func (p operationsParser) determineObjectDefinitionForOptionRaw(paramType string, collectionFormat string, format string) (*sdkModels.SDKOperationOptionObjectDefinition, error) {
 	switch strings.ToLower(paramType) {
 	case "array":
 		{
@@ -181,26 +181,26 @@ func (p operationsParser) determineObjectDefinitionForOptionRaw(paramType string
 		}
 
 	case "boolean":
-		return &models.SDKOperationOptionObjectDefinition{
-			Type: models.BooleanSDKOperationOptionObjectDefinitionType,
+		return &sdkModels.SDKOperationOptionObjectDefinition{
+			Type: sdkModels.BooleanSDKOperationOptionObjectDefinitionType,
 		}, nil
 
 	case "integer":
-		return &models.SDKOperationOptionObjectDefinition{
-			Type: models.IntegerSDKOperationOptionObjectDefinitionType,
+		return &sdkModels.SDKOperationOptionObjectDefinition{
+			Type: sdkModels.IntegerSDKOperationOptionObjectDefinitionType,
 		}, nil
 
 	case "number":
 		{
 			if strings.EqualFold(format, "double") {
-				return &models.SDKOperationOptionObjectDefinition{
-					Type: models.FloatSDKOperationOptionObjectDefinitionType,
+				return &sdkModels.SDKOperationOptionObjectDefinition{
+					Type: sdkModels.FloatSDKOperationOptionObjectDefinitionType,
 				}, nil
 			}
 
 			if strings.EqualFold(format, "decimal") {
-				return &models.SDKOperationOptionObjectDefinition{
-					Type: models.FloatSDKOperationOptionObjectDefinitionType,
+				return &sdkModels.SDKOperationOptionObjectDefinition{
+					Type: sdkModels.FloatSDKOperationOptionObjectDefinitionType,
 				}, nil
 			}
 
@@ -210,14 +210,14 @@ func (p operationsParser) determineObjectDefinitionForOptionRaw(paramType string
 				return nil, fmt.Errorf("unsupported format type for number %q", format)
 			}
 
-			return &models.SDKOperationOptionObjectDefinition{
-				Type: models.IntegerSDKOperationOptionObjectDefinitionType,
+			return &sdkModels.SDKOperationOptionObjectDefinition{
+				Type: sdkModels.IntegerSDKOperationOptionObjectDefinitionType,
 			}, nil
 		}
 
 	case "string":
-		return &models.SDKOperationOptionObjectDefinition{
-			Type: models.StringSDKOperationOptionObjectDefinitionType,
+		return &sdkModels.SDKOperationOptionObjectDefinition{
+			Type: sdkModels.StringSDKOperationOptionObjectDefinitionType,
 		}, nil
 	}
 	return nil, fmt.Errorf("unsupported field type %q", paramType)
@@ -330,10 +330,10 @@ func (p operationsParser) operationIsLongRunning(input parsedOperation) bool {
 	return val
 }
 
-func (p operationsParser) optionsForOperation(input parsedOperation) (*map[string]models.SDKOperationOption, *internal.ParseResult, error) {
-	output := make(map[string]models.SDKOperationOption)
+func (p operationsParser) optionsForOperation(input parsedOperation) (*map[string]sdkModels.SDKOperationOption, *internal.ParseResult, error) {
+	output := make(map[string]sdkModels.SDKOperationOption)
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
+		Constants: map[string]sdkModels.SDKConstant{},
 	}
 
 	for _, param := range input.operation.Parameters {
@@ -352,7 +352,7 @@ func (p operationsParser) optionsForOperation(input parsedOperation) (*map[strin
 			val := param.Name
 			name := cleanup.NormalizeName(val)
 
-			option := models.SDKOperationOption{
+			option := sdkModels.SDKOperationOption{
 				Required: param.Required,
 			}
 
@@ -386,8 +386,8 @@ func (p operationsParser) optionsForOperation(input parsedOperation) (*map[strin
 				}
 				result.Constants[constant.Name] = constant.Details
 
-				option.ObjectDefinition = models.SDKOperationOptionObjectDefinition{
-					Type:          models.ReferenceSDKOperationOptionObjectDefinitionType,
+				option.ObjectDefinition = sdkModels.SDKOperationOptionObjectDefinition{
+					Type:          sdkModels.ReferenceSDKOperationOptionObjectDefinitionType,
 					ReferenceName: &constant.Name,
 				}
 			}
@@ -399,7 +399,7 @@ func (p operationsParser) optionsForOperation(input parsedOperation) (*map[strin
 	return &output, &result, nil
 }
 
-func (p operationsParser) operationShouldBeIgnored(input models.SDKOperation) bool {
+func (p operationsParser) operationShouldBeIgnored(input sdkModels.SDKOperation) bool {
 	// Some HTTP Operations don't make sense for us to expose at this time, for example
 	// a GET request which returns no content. They may at some point in the future but
 	// for now there's not much point
@@ -415,7 +415,7 @@ func (p operationsParser) operationShouldBeIgnored(input models.SDKOperation) bo
 	return false
 }
 
-func (p operationsParser) requestObjectForOperation(input parsedOperation, known internal.ParseResult) (*models.SDKObjectDefinition, *internal.ParseResult, error) {
+func (p operationsParser) requestObjectForOperation(input parsedOperation, known internal.ParseResult) (*sdkModels.SDKObjectDefinition, *internal.ParseResult, error) {
 	// all we should parse out is the top level object - nothing more.
 
 	// find the same operation in the unexpanded swagger spec since we need the reference name
@@ -441,7 +441,7 @@ func (p operationsParser) requestObjectForOperation(input parsedOperation, known
 }
 
 type operationResponseObjectResult struct {
-	objectDefinition    *models.SDKObjectDefinition
+	objectDefinition    *sdkModels.SDKObjectDefinition
 	paginationFieldName *string
 }
 
@@ -460,8 +460,8 @@ func (p operationsParser) operationIsASuccess(statusCode int, resp spec.Response
 func (p operationsParser) responseObjectForOperation(input parsedOperation, known internal.ParseResult) (*operationResponseObjectResult, *internal.ParseResult, error) {
 	output := operationResponseObjectResult{}
 	result := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
-		Models:    map[string]models.SDKModel{},
+		Constants: map[string]sdkModels.SDKConstant{},
+		Models:    map[string]sdkModels.SDKModel{},
 	}
 	result.Append(known)
 
@@ -473,7 +473,7 @@ func (p operationsParser) responseObjectForOperation(input parsedOperation, know
 
 	// since it's possible for operations to have multiple status codes, parse out all the objects and then find the most applicable
 	statusCodes := make([]int, 0)
-	objectDefinitionsByStatusCode := map[int]models.SDKObjectDefinition{}
+	objectDefinitionsByStatusCode := map[int]sdkModels.SDKObjectDefinition{}
 	for statusCode, details := range unexpandedOperation.Responses.StatusCodeResponses {
 		if !p.operationIsASuccess(statusCode, details) {
 			continue

--- a/tools/importer-rest-api-specs/components/parser/operations_test.go
+++ b/tools/importer-rest-api-specs/components/parser/operations_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -22,7 +22,7 @@ func TestParseOperationsEmpty(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources:   map[string]importerModels.AzureApiResource{},
+		Resources:   map[string]sdkModels.APIResource{},
 	}
 	validateParsedSwaggerResultMatches(t, expected, actual)
 }
@@ -35,9 +35,9 @@ func TestParseOperationSingleWithTag(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HeadWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{http.StatusOK},
@@ -61,9 +61,9 @@ func TestParseOperationSingleWithTagAndResourceId(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HeadWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -71,17 +71,17 @@ func TestParseOperationSingleWithTagAndResourceId(t *testing.T) {
 						ResourceIDName:      pointer.To("ThingId"),
 					},
 				},
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ThingId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
-							models.NewStaticValueResourceIDSegment("staticThings", "things"),
-							models.NewUserSpecifiedResourceIDSegment("thing", "thing"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
+							sdkModels.NewStaticValueResourceIDSegment("staticThings", "things"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("thing", "thing"),
 						},
 					},
 				},
@@ -100,9 +100,9 @@ func TestParseOperationSingleWithTagAndResourceIdSuffix(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HeadWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -111,17 +111,17 @@ func TestParseOperationSingleWithTagAndResourceIdSuffix(t *testing.T) {
 						URISuffix:           pointer.To("/restart"),
 					},
 				},
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ThingId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
-							models.NewStaticValueResourceIDSegment("staticThings", "things"),
-							models.NewUserSpecifiedResourceIDSegment("thing", "thing"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
+							sdkModels.NewStaticValueResourceIDSegment("staticThings", "things"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("thing", "thing"),
 						},
 					},
 				},
@@ -140,28 +140,28 @@ func TestParseOperationSingleWithRequestObject(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
-							Type:          models.ReferenceSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 							ReferenceName: pointer.To("Example"),
 						},
 						URISuffix: pointer.To("/things"),
@@ -182,28 +182,28 @@ func TestParseOperationSingleWithRequestObjectInlined(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
-							Type:          models.ReferenceSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 							ReferenceName: pointer.To("Example"),
 						},
 						URISuffix: pointer.To("/things"),
@@ -224,28 +224,28 @@ func TestParseOperationSingleWithResponseObject(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type:          models.ReferenceSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 							ReferenceName: pointer.To("Example"),
 						},
 						URISuffix: pointer.To("/things"),
@@ -266,28 +266,28 @@ func TestParseOperationSingleWithResponseObjectInlined(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type:          models.ReferenceSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 							ReferenceName: pointer.To("Example"),
 						},
 						URISuffix: pointer.To("/things"),
@@ -308,30 +308,30 @@ func TestParseOperationSingleWithResponseObjectInlinedList(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.ListSDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
-								Type:          models.ReferenceSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.ListSDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
+								Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								ReferenceName: pointer.To("Example"),
 							},
 						},
@@ -353,15 +353,15 @@ func TestParseOperationSingleRequestingWithABool(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.BooleanSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.BooleanSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -381,15 +381,15 @@ func TestParseOperationSingleRequestingWithAInteger(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.IntegerSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.IntegerSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -409,17 +409,17 @@ func TestParseOperationSingleRequestingWithADictionaryOfStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.DictionarySDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
-								Type: models.StringSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.DictionarySDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
+								Type: sdkModels.StringSDKObjectDefinitionType,
 							},
 						},
 						URISuffix: pointer.To("/things"),
@@ -440,17 +440,17 @@ func TestParseOperationSingleRequestingWithAListOfStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.ListSDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
-								Type: models.StringSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.ListSDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
+								Type: sdkModels.StringSDKObjectDefinitionType,
 							},
 						},
 						URISuffix: pointer.To("/things"),
@@ -473,15 +473,15 @@ func TestParseOperationSingleRequestingWithAString(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -501,15 +501,15 @@ func TestParseOperationSingleReturningABool(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeABoolean": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.BooleanSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.BooleanSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
 					},
@@ -529,15 +529,15 @@ func TestParseOperationSingleReturningAFloat(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAFloat": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.FloatSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.FloatSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
 					},
@@ -557,15 +557,15 @@ func TestParseOperationSingleReturningAFile(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAFile": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.RawFileSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.RawFileSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
 					},
@@ -585,15 +585,15 @@ func TestParseOperationSingleReturningAnInteger(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAnInteger": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.IntegerSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.IntegerSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
 					},
@@ -613,15 +613,15 @@ func TestParseOperationSingleReturningAString(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAString": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
 					},
@@ -642,15 +642,15 @@ func TestParseOperationSingleReturningAnErrorStatusCode(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAString": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
 					},
@@ -670,18 +670,18 @@ func TestParseOperationSingleReturningATopLevelRawObject(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"RawObjectToMeToYou": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.RawObjectSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.RawObjectSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.RawObjectSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.RawObjectSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/chuckle"),
 					},
@@ -701,31 +701,31 @@ func TestParseOperationSingleReturningADictionaryOfAModel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Person": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeADictionaryOfAModel": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.DictionarySDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.DictionarySDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
 								ReferenceName: pointer.To("Person"),
-								Type:          models.ReferenceSDKObjectDefinitionType,
+								Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 							},
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
@@ -746,17 +746,17 @@ func TestParseOperationSingleReturningADictionaryOfStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeADictionaryOfStrings": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.DictionarySDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
-								Type: models.StringSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.DictionarySDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
+								Type: sdkModels.StringSDKObjectDefinitionType,
 							},
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
@@ -777,17 +777,17 @@ func TestParseOperationSingleReturningAListOfIntegers(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAListOfIntegers": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.ListSDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
-								Type: models.IntegerSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.ListSDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
+								Type: sdkModels.IntegerSDKObjectDefinitionType,
 							},
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
@@ -808,31 +808,31 @@ func TestParseOperationSingleReturningAListOfAModel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Person": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAListOfModels": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.ListSDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.ListSDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
 								ReferenceName: pointer.To("Person"),
-								Type:          models.ReferenceSDKObjectDefinitionType,
+								Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 							},
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
@@ -853,17 +853,17 @@ func TestParseOperationSingleReturningAListOfStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAListOfStrings": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.ListSDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
-								Type: models.StringSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.ListSDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
+								Type: sdkModels.StringSDKObjectDefinitionType,
 							},
 						},
 						URISuffix: pointer.To("/worlds/favourite"),
@@ -884,33 +884,33 @@ func TestParseOperationSingleReturningAListOfListOfAModel(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Person": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAListOfListOfModels": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.ListSDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
-								Type: models.ListSDKObjectDefinitionType,
-								NestedItem: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.ListSDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
+								Type: sdkModels.ListSDKObjectDefinitionType,
+								NestedItem: &sdkModels.SDKObjectDefinition{
 									ReferenceName: pointer.To("Person"),
-									Type:          models.ReferenceSDKObjectDefinitionType,
+									Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 								},
 							},
 						},
@@ -932,19 +932,19 @@ func TestParseOperationSingleReturningAListOfListOfStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GimmeAListOfListOfStrings": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.ListSDKObjectDefinitionType,
-							NestedItem: &models.SDKObjectDefinition{
-								Type: models.ListSDKObjectDefinitionType,
-								NestedItem: &models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.ListSDKObjectDefinitionType,
+							NestedItem: &sdkModels.SDKObjectDefinition{
+								Type: sdkModels.ListSDKObjectDefinitionType,
+								NestedItem: &sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 							},
 						},
@@ -966,30 +966,30 @@ func TestParseOperationSingleWithList(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"World": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"ListWorlds": {
 						ContentType:                      "application/json",
 						ExpectedStatusCodes:              []int{200},
 						FieldContainingPaginationDetails: pointer.To("nextLink"),
 						Method:                           "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("World"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds"),
 					},
@@ -1011,22 +1011,22 @@ func TestParseOperationSingleWithListWhichIsNotAList(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"World": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"ListWorlds": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -1036,9 +1036,9 @@ func TestParseOperationSingleWithListWhichIsNotAList(t *testing.T) {
 						// a list operation, even if there's a `skipToken` present.
 						FieldContainingPaginationDetails: nil,
 						Method:                           "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("World"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds"),
 					},
@@ -1058,16 +1058,16 @@ func TestParseOperationSingleWithListReturningAListOfStrings(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"ListWorlds": {
 						ContentType:                      "application/json",
 						ExpectedStatusCodes:              []int{200},
 						FieldContainingPaginationDetails: pointer.To("nextLink"),
 						Method:                           "GET",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds"),
 					},
@@ -1089,30 +1089,30 @@ func TestParseOperationSingleWithListWithoutPageable(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"World": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"ListWorlds": {
 						ContentType:                      "application/json",
 						ExpectedStatusCodes:              []int{200},
 						FieldContainingPaginationDetails: pointer.To("nextLink"),
 						Method:                           "GET",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("World"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/worlds"),
 					},
@@ -1132,30 +1132,30 @@ func TestParseOperationSingleWithLongRunningOperation(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						LongRunning:         true,
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -1175,33 +1175,33 @@ func TestParseOperationSingleWithRequestAndResponseObject(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"PutWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -1221,9 +1221,9 @@ func TestParseOperationSingleWithMultipleTags(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HeadThings": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -1233,7 +1233,7 @@ func TestParseOperationSingleWithMultipleTags(t *testing.T) {
 				},
 			},
 			"Other": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					// Whilst the operation name should be `HeadThings`, since this is another Tag
 					// it's intentionally prefixed for when things cross boundaries (to avoid conflicts)
 					"HelloHeadThings": {
@@ -1258,10 +1258,10 @@ func TestParseOperationSingleWithInferredTag(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			// since there's no tags, the file name is used to infer the tag (in this case, 'OperationsSingleWithNoTags')
 			"OperationsSingleWithNoTags": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					// since the prefix doesn't match the Tag (since no tag) this gets a combined name
 					"HelloHeadWorld": {
 						ContentType:         "application/json",
@@ -1285,66 +1285,66 @@ func TestParseOperationSingleWithHeaderOptions(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HeadWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "HEAD",
-						Options: map[string]models.SDKOperationOption{
+						Options: map[string]sdkModels.SDKOperationOption{
 							"BoolValue": {
 								HeaderName: pointer.To("boolValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.BooleanSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.BooleanSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"CsvOfDoubleValue": {
 								HeaderName: pointer.To("csvOfDoubleValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.CSVSDKOperationOptionObjectDefinitionType,
-									NestedItem: &models.SDKOperationOptionObjectDefinition{
-										Type: models.FloatSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.CSVSDKOperationOptionObjectDefinitionType,
+									NestedItem: &sdkModels.SDKOperationOptionObjectDefinition{
+										Type: sdkModels.FloatSDKOperationOptionObjectDefinitionType,
 									},
 								},
 								Required: true,
 							},
 							"CsvOfStringValue": {
 								HeaderName: pointer.To("csvOfStringValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.CSVSDKOperationOptionObjectDefinitionType,
-									NestedItem: &models.SDKOperationOptionObjectDefinition{
-										Type: models.StringSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.CSVSDKOperationOptionObjectDefinitionType,
+									NestedItem: &sdkModels.SDKOperationOptionObjectDefinition{
+										Type: sdkModels.StringSDKOperationOptionObjectDefinitionType,
 									},
 								},
 								Required: true,
 							},
 							"DecimalValue": {
 								HeaderName: pointer.To("decimalValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.FloatSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.FloatSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"DoubleValue": {
 								HeaderName: pointer.To("doubleValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.FloatSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.FloatSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IntValue": {
 								HeaderName: pointer.To("intValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.IntegerSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.IntegerSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"StringValue": {
 								HeaderName: pointer.To("stringValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.StringSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.StringSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1367,66 +1367,66 @@ func TestParseOperationSingleWithQueryStringOptions(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HeadWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "HEAD",
-						Options: map[string]models.SDKOperationOption{
+						Options: map[string]sdkModels.SDKOperationOption{
 							"BoolValue": {
 								QueryStringName: pointer.To("boolValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.BooleanSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.BooleanSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"CsvOfDoubleValue": {
 								QueryStringName: pointer.To("csvOfDoubleValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.CSVSDKOperationOptionObjectDefinitionType,
-									NestedItem: &models.SDKOperationOptionObjectDefinition{
-										Type: models.FloatSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.CSVSDKOperationOptionObjectDefinitionType,
+									NestedItem: &sdkModels.SDKOperationOptionObjectDefinition{
+										Type: sdkModels.FloatSDKOperationOptionObjectDefinitionType,
 									},
 								},
 								Required: true,
 							},
 							"CsvOfStringValue": {
 								QueryStringName: pointer.To("csvOfStringValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.CSVSDKOperationOptionObjectDefinitionType,
-									NestedItem: &models.SDKOperationOptionObjectDefinition{
-										Type: models.StringSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.CSVSDKOperationOptionObjectDefinitionType,
+									NestedItem: &sdkModels.SDKOperationOptionObjectDefinition{
+										Type: sdkModels.StringSDKOperationOptionObjectDefinitionType,
 									},
 								},
 								Required: true,
 							},
 							"DecimalValue": {
 								QueryStringName: pointer.To("decimalValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.FloatSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.FloatSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"DoubleValue": {
 								QueryStringName: pointer.To("doubleValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.FloatSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.FloatSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"IntValue": {
 								QueryStringName: pointer.To("intValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.IntegerSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.IntegerSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
 							"StringValue": {
 								QueryStringName: pointer.To("stringValue"),
-								ObjectDefinition: models.SDKOperationOptionObjectDefinition{
-									Type: models.StringSDKOperationOptionObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKOperationOptionObjectDefinition{
+									Type: sdkModels.StringSDKOperationOptionObjectDefinitionType,
 								},
 								Required: true,
 							},
@@ -1449,9 +1449,9 @@ func TestParseOperationMultipleBasedOnTheSameResourceId(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HeadWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -1466,17 +1466,17 @@ func TestParseOperationMultipleBasedOnTheSameResourceId(t *testing.T) {
 						URISuffix:           pointer.To("/restart"),
 					},
 				},
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ThingId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
-							models.NewStaticValueResourceIDSegment("staticThings", "things"),
-							models.NewUserSpecifiedResourceIDSegment("thing", "thing"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
+							sdkModels.NewStaticValueResourceIDSegment("staticThings", "things"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("thing", "thing"),
 						},
 					},
 				},
@@ -1495,9 +1495,9 @@ func TestParseOperationsContainingContentTypes(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Default": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -1508,8 +1508,8 @@ func TestParseOperationsContainingContentTypes(t *testing.T) {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 						// this can become `/json-request` when https://github.com/hashicorp/pandora/issues/3807 is fixed
 						URISuffix: pointer.To("/jsonRequest"),
@@ -1518,8 +1518,8 @@ func TestParseOperationsContainingContentTypes(t *testing.T) {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/jsonResponse"),
 					},
@@ -1527,8 +1527,8 @@ func TestParseOperationsContainingContentTypes(t *testing.T) {
 						ContentType:         "application/xml",
 						ExpectedStatusCodes: []int{200},
 						Method:              "GET",
-						RequestObject: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+						RequestObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/xmlRequest"),
 					},
@@ -1536,8 +1536,8 @@ func TestParseOperationsContainingContentTypes(t *testing.T) {
 						ContentType:         "application/xml",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						ResponseObject: &models.SDKObjectDefinition{
-							Type: models.StringSDKObjectDefinitionType,
+						ResponseObject: &sdkModels.SDKObjectDefinition{
+							Type: sdkModels.StringSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/xmlResponse"),
 					},
@@ -1557,29 +1557,29 @@ func TestParseOperationContainingMultipleReturnObjects(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"FirstModel": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Hello": {
 								JsonName: "hello",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HeadWorld": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200, 202},
 						Method:              "PUT",
-						ResponseObject: &models.SDKObjectDefinition{
+						ResponseObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("FirstModel"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/things"),
 					},
@@ -1599,9 +1599,9 @@ func TestParseOperationsWithStutteringNames(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"ExampleTag": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Mars": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},

--- a/tools/importer-rest-api-specs/components/parser/parse_data.go
+++ b/tools/importer-rest-api-specs/components/parser/parse_data.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func combineResourcesWith(first importerModels.AzureApiDefinition, other map[string]importerModels.AzureApiResource) (*map[string]importerModels.AzureApiResource, error) {
-	resources := make(map[string]importerModels.AzureApiResource)
+func combineResourcesWith(first importerModels.AzureApiDefinition, other map[string]sdkModels.APIResource) (*map[string]sdkModels.APIResource, error) {
+	resources := make(map[string]sdkModels.APIResource)
 	for k, v := range first.Resources {
 		resources[k] = v
 	}
@@ -43,11 +43,11 @@ func combineResourcesWith(first importerModels.AzureApiDefinition, other map[str
 		}
 		existing.Operations = *operations
 
-		resourceIds, err := combineResourceIds(existing.ResourceIds, v.ResourceIds)
+		resourceIds, err := combineResourceIds(existing.ResourceIDs, v.ResourceIDs)
 		if err != nil {
 			return nil, fmt.Errorf("combining resource ids: %+v", err)
 		}
-		existing.ResourceIds = *resourceIds
+		existing.ResourceIDs = *resourceIds
 
 		resources[k] = existing
 	}
@@ -55,8 +55,8 @@ func combineResourcesWith(first importerModels.AzureApiDefinition, other map[str
 	return &resources, nil
 }
 
-func combineConstants(first, second map[string]models.SDKConstant) (*map[string]models.SDKConstant, error) {
-	constants := make(map[string]models.SDKConstant)
+func combineConstants(first, second map[string]sdkModels.SDKConstant) (*map[string]sdkModels.SDKConstant, error) {
+	constants := make(map[string]sdkModels.SDKConstant)
 	for k, v := range first {
 		constants[k] = v
 	}
@@ -83,8 +83,8 @@ func combineConstants(first, second map[string]models.SDKConstant) (*map[string]
 	return &constants, nil
 }
 
-func combineModels(first map[string]models.SDKModel, second map[string]models.SDKModel) (*map[string]models.SDKModel, error) {
-	output := make(map[string]models.SDKModel)
+func combineModels(first map[string]sdkModels.SDKModel, second map[string]sdkModels.SDKModel) (*map[string]sdkModels.SDKModel, error) {
+	output := make(map[string]sdkModels.SDKModel)
 
 	for k, v := range first {
 		output[k] = v
@@ -120,8 +120,8 @@ func combineModels(first map[string]models.SDKModel, second map[string]models.SD
 	return &output, nil
 }
 
-func combineOperations(first map[string]models.SDKOperation, second map[string]models.SDKOperation) (*map[string]models.SDKOperation, error) {
-	output := make(map[string]models.SDKOperation, 0)
+func combineOperations(first map[string]sdkModels.SDKOperation, second map[string]sdkModels.SDKOperation) (*map[string]sdkModels.SDKOperation, error) {
+	output := make(map[string]sdkModels.SDKOperation, 0)
 
 	for k, v := range first {
 		output[k] = v
@@ -140,8 +140,8 @@ func combineOperations(first map[string]models.SDKOperation, second map[string]m
 	return &output, nil
 }
 
-func combineResourceIds(first map[string]models.ResourceID, second map[string]models.ResourceID) (*map[string]models.ResourceID, error) {
-	output := make(map[string]models.ResourceID)
+func combineResourceIds(first map[string]sdkModels.ResourceID, second map[string]sdkModels.ResourceID) (*map[string]sdkModels.ResourceID, error) {
+	output := make(map[string]sdkModels.ResourceID)
 
 	for k, v := range first {
 		output[k] = v

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvider *string, resourceIds resourceids.ParseResult) (*importerModels.AzureApiDefinition, error) {
-	resources := make(map[string]importerModels.AzureApiResource, 0)
+	resources := make(map[string]sdkModels.APIResource, 0)
 
 	tags := d.findTags()
 	// first we assume everything has a tag
@@ -80,7 +80,7 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 	}
 
 	// now that we have a canonical list of resources, can we simplify the Operation names at all?
-	resourcesOut := make(map[string]importerModels.AzureApiResource)
+	resourcesOut := make(map[string]sdkModels.APIResource)
 	for resourceName, resource := range resources {
 		d.logger.Trace(fmt.Sprintf("Simplifying operation names for resource %q", resourceName))
 		updated := d.simplifyOperationNamesForResource(resource, resourceName)
@@ -103,7 +103,7 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 
 		// this is to avoid the creation of empty packages/directories in the api definitions
 		if len(result.Models) > 0 || len(result.Constants) > 0 {
-			resource := importerModels.AzureApiResource{
+			resource := sdkModels.APIResource{
 				Constants: result.Constants,
 				Models:    result.Models,
 			}
@@ -124,7 +124,7 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 	}, nil
 }
 
-func (d *SwaggerDefinition) simplifyOperationNamesForResource(resource importerModels.AzureApiResource, resourceName string) importerModels.AzureApiResource {
+func (d *SwaggerDefinition) simplifyOperationNamesForResource(resource sdkModels.APIResource, resourceName string) sdkModels.APIResource {
 	allOperationsStartWithPrefix := true
 	resourceNameLower := strings.ToLower(resourceName)
 	for operationName := range resource.Operations {
@@ -140,7 +140,7 @@ func (d *SwaggerDefinition) simplifyOperationNamesForResource(resource importerM
 		return resource
 	}
 
-	output := make(map[string]models.SDKOperation)
+	output := make(map[string]sdkModels.SDKOperation)
 	for key, value := range resource.Operations {
 		updatedKey := key[len(resourceNameLower):]
 		// Trim off any spurious `s` at the start. This happens when the Swagger Tag and the Operation ID
@@ -178,7 +178,7 @@ func (d *SwaggerDefinition) ParseResourceIds(resourceProvider *string) (*resourc
 func (d *SwaggerDefinition) filterResourceIdsToResourceProvider(input resourceids.ParseResult, resourceProvider string) (*resourceids.ParseResult, error) {
 	output := resourceids.ParseResult{
 		OperationIdsToParsedResourceIds: input.OperationIdsToParsedResourceIds,
-		NamesToResourceIDs:              map[string]models.ResourceID{},
+		NamesToResourceIDs:              map[string]sdkModels.ResourceID{},
 		Constants:                       input.Constants,
 	}
 
@@ -199,13 +199,13 @@ func (d *SwaggerDefinition) filterResourceIdsToResourceProvider(input resourceid
 	return &output, nil
 }
 
-func resourceIdUsesAResourceProviderOtherThan(input *models.ResourceID, resourceProvider *string) (*bool, error) {
+func resourceIdUsesAResourceProviderOtherThan(input *sdkModels.ResourceID, resourceProvider *string) (*bool, error) {
 	if input == nil || resourceProvider == nil {
 		return pointer.To(false), nil
 	}
 
 	for i, segment := range input.Segments {
-		if segment.Type != models.ResourceProviderResourceIDSegmentType {
+		if segment.Type != sdkModels.ResourceProviderResourceIDSegmentType {
 			continue
 		}
 

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -12,6 +12,7 @@ import (
 	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -31,7 +32,7 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 		}
 
 		if resource != nil {
-			d.logger.Trace(fmt.Sprintf("The Tag %q has %d API Operations", tag, len(resource.Operations)))
+			logging.Tracef("The Tag %q has %d API Operations", tag, len(resource.Operations))
 			normalizedTag := normalizeTag(tag)
 			normalizedTag = cleanup.NormalizeResourceName(normalizedTag)
 			resources[normalizedTag] = *resource
@@ -82,7 +83,7 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 	// now that we have a canonical list of resources, can we simplify the Operation names at all?
 	resourcesOut := make(map[string]sdkModels.APIResource)
 	for resourceName, resource := range resources {
-		d.logger.Trace(fmt.Sprintf("Simplifying operation names for resource %q", resourceName))
+		logging.Tracef("Simplifying operation names for resource %q", resourceName)
 		updated := d.simplifyOperationNamesForResource(resource, resourceName)
 		resourcesOut[resourceName] = updated
 	}
@@ -136,7 +137,7 @@ func (d *SwaggerDefinition) simplifyOperationNamesForResource(resource sdkModels
 	}
 
 	if !allOperationsStartWithPrefix {
-		d.logger.Trace(fmt.Sprintf("Skipping simplifying operation names for resource %q", resourceName))
+		logging.Tracef("Skipping simplifying operation names for resource %q", resourceName)
 		return resource
 	}
 
@@ -156,7 +157,7 @@ func (d *SwaggerDefinition) simplifyOperationNamesForResource(resource sdkModels
 			updatedKey = updatedKey[1:]
 		}
 
-		d.logger.Trace(fmt.Sprintf("Simplifying Operation %q to %q", key, updatedKey))
+		logging.Tracef("Simplifying Operation %q to %q", key, updatedKey)
 		output[updatedKey] = value
 	}
 
@@ -165,7 +166,7 @@ func (d *SwaggerDefinition) simplifyOperationNamesForResource(resource sdkModels
 }
 
 func (d *SwaggerDefinition) ParseResourceIds(resourceProvider *string) (*resourceids.ParseResult, error) {
-	parser := resourceids.NewParser(d.logger.Named("ResourceID Parser"), d.swaggerSpecExpanded)
+	parser := resourceids.NewParser(d.swaggerSpecExpanded)
 
 	resourceIds, err := parser.Parse()
 	if err != nil {
@@ -185,7 +186,7 @@ func (d *SwaggerDefinition) filterResourceIdsToResourceProvider(input resourceid
 	for name := range input.NamesToResourceIDs {
 		value := input.NamesToResourceIDs[name]
 
-		d.logger.Trace(fmt.Sprintf("Processing ID %q (%q)", name, helpers.DisplayValueForResourceID(value)))
+		logging.Tracef("Processing ID %q (%q)", name, helpers.DisplayValueForResourceID(value))
 		usesADifferentResourceProvider, err := resourceIdUsesAResourceProviderOtherThan(pointer.To(value), pointer.To(resourceProvider))
 		if err != nil {
 			return nil, err

--- a/tools/importer-rest-api-specs/components/parser/parser_test.go
+++ b/tools/importer-rest-api-specs/components/parser/parser_test.go
@@ -183,7 +183,7 @@ func validateDirectory(serviceName, apiVersion, versionDirectory string) error {
 		fileNames = append(fileNames, fileName)
 	}
 
-	if _, err := LoadAndParseFiles(versionDirectory, *swaggerFiles, serviceName, apiVersion, nil, hclog.New(hclog.DefaultOptions)); err != nil {
+	if _, err := LoadAndParseFiles(versionDirectory, *swaggerFiles, serviceName, apiVersion, nil); err != nil {
 		return err
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resource_ids_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -20,23 +20,23 @@ func TestParseResourceIdBasic(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ServerId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
-							models.NewStaticValueResourceIDSegment("staticServers", "servers"),
-							models.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							sdkModels.NewStaticValueResourceIDSegment("staticServers", "servers"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -59,11 +59,11 @@ func TestParseResourceIdContainingAConstant(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Constants: map[string]models.SDKConstant{
+				Constants: map[string]sdkModels.SDKConstant{
 					"Planet": {
-						Type: models.StringSDKConstantType,
+						Type: sdkModels.StringSDKConstantType,
 						Values: map[string]string{
 							"Earth":   "Earth",
 							"Jupiter": "Jupiter",
@@ -72,18 +72,18 @@ func TestParseResourceIdContainingAConstant(t *testing.T) {
 						},
 					},
 				},
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"PlanetId": {
 						ConstantNames: []string{
 							"Planet",
 						},
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticPlanets", "planets"),
-							models.NewConstantResourceIDSegment("planetName", "Planet", "Earth"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticPlanets", "planets"),
+							sdkModels.NewConstantResourceIDSegment("planetName", "Planet", "Earth"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"OperationContainingAConstant": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -106,20 +106,20 @@ func TestParseResourceIdContainingAScope(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ScopedVirtualMachineId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewScopeResourceIDSegment("scope"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
-							models.NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
-							models.NewUserSpecifiedResourceIDSegment("virtualMachineName", "virtualMachinesName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewScopeResourceIDSegment("scope"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftFooBar", "Microsoft.FooBar"),
+							sdkModels.NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineName", "virtualMachinesName"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"OperationContainingAScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -151,17 +151,17 @@ func TestParseResourceIdContainingAHiddenScope(t *testing.T) {
 			expected := importerModels.AzureApiDefinition{
 				ServiceName: "Example",
 				ApiVersion:  "2020-01-01",
-				Resources: map[string]importerModels.AzureApiResource{
+				Resources: map[string]sdkModels.APIResource{
 					"Example": {
-						ResourceIds: map[string]models.ResourceID{
+						ResourceIDs: map[string]sdkModels.ResourceID{
 							"ScopeId": {
 								CommonIDAlias: pointer.To("Scope"),
-								Segments: []models.ResourceIDSegment{
-									models.NewScopeResourceIDSegment("scope"),
+								Segments: []sdkModels.ResourceIDSegment{
+									sdkModels.NewScopeResourceIDSegment("scope"),
 								},
 							},
 						},
-						Operations: map[string]models.SDKOperation{
+						Operations: map[string]sdkModels.SDKOperation{
 							"OperationContainingAHiddenScope": {
 								ContentType:         "application/json",
 								ExpectedStatusCodes: []int{200},
@@ -187,17 +187,17 @@ func TestParseResourceIdContainingAHiddenScopeWithExtraSegment(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ScopeId": {
 						CommonIDAlias: pointer.To("Scope"),
-						Segments: []models.ResourceIDSegment{
-							models.NewScopeResourceIDSegment("scope"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewScopeResourceIDSegment("scope"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"OperationContainingAHiddenScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -220,17 +220,17 @@ func TestParseResourceIdContainingAHiddenScopeWithSuffix(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ScopeId": {
 						CommonIDAlias: pointer.To("Scope"),
-						Segments: []models.ResourceIDSegment{
-							models.NewScopeResourceIDSegment("scope"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewScopeResourceIDSegment("scope"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"OperationContainingAHiddenScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -263,17 +263,17 @@ func TestParseResourceIdContainingAHiddenScopeNested(t *testing.T) {
 			expected := importerModels.AzureApiDefinition{
 				ServiceName: "Example",
 				ApiVersion:  "2020-01-01",
-				Resources: map[string]importerModels.AzureApiResource{
+				Resources: map[string]sdkModels.APIResource{
 					"Example": {
-						ResourceIds: map[string]models.ResourceID{
+						ResourceIDs: map[string]sdkModels.ResourceID{
 							"ScopeId": {
 								CommonIDAlias: pointer.To("Scope"),
-								Segments: []models.ResourceIDSegment{
-									models.NewScopeResourceIDSegment("scope"),
+								Segments: []sdkModels.ResourceIDSegment{
+									sdkModels.NewScopeResourceIDSegment("scope"),
 								},
 							},
 						},
-						Operations: map[string]models.SDKOperation{
+						Operations: map[string]sdkModels.SDKOperation{
 							"OperationContainingAHiddenScope": {
 								ContentType:         "application/json",
 								ExpectedStatusCodes: []int{200},
@@ -298,17 +298,17 @@ func TestParseResourceIdContainingAHiddenScopeNestedWithExtraSegment(t *testing.
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ScopeId": {
 						CommonIDAlias: pointer.To("Scope"),
-						Segments: []models.ResourceIDSegment{
-							models.NewScopeResourceIDSegment("scope"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewScopeResourceIDSegment("scope"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"OperationContainingAHiddenScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -331,17 +331,17 @@ func TestParseResourceIdContainingAHiddenScopeNestedWithSuffix(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ScopeId": {
 						CommonIDAlias: pointer.To("Scope"),
-						Segments: []models.ResourceIDSegment{
-							models.NewScopeResourceIDSegment("scope"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewScopeResourceIDSegment("scope"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"OperationContainingAHiddenScope": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -365,9 +365,9 @@ func TestParseResourceIdWithJustUriSuffix(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"JustSuffix": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -390,23 +390,23 @@ func TestParseResourceIdWithResourceIdAndUriSuffix(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ServerId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
-							models.NewStaticValueResourceIDSegment("staticServers", "servers"),
-							models.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							sdkModels.NewStaticValueResourceIDSegment("staticServers", "servers"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -430,23 +430,23 @@ func TestParseResourceIdWithResourceIdAndUriSuffixForMultipleUris(t *testing.T) 
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ServerId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
-							models.NewStaticValueResourceIDSegment("staticServers", "servers"),
-							models.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							sdkModels.NewStaticValueResourceIDSegment("staticServers", "servers"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Restart": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -483,23 +483,23 @@ func TestParseResourceIdContainingResourceProviderShouldGetTitleCased(t *testing
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ServerId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
-							models.NewStaticValueResourceIDSegment("staticServers", "servers"),
-							models.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							sdkModels.NewStaticValueResourceIDSegment("staticServers", "servers"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -522,23 +522,23 @@ func TestParseResourceIdContainingTheSameResourceIdWithDifferentSegments(t *test
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"VirtualMachineId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
-							models.NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
-							models.NewUserSpecifiedResourceIDSegment("machineName", "machineName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftSomeResourceProvider", "Microsoft.SomeResourceProvider"),
+							sdkModels.NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("machineName", "machineName"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Restart": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -568,23 +568,23 @@ func TestParseResourceIdContainingTheSegmentsNamedTheSame(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"BillingPeriodId": {
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftManagement", "Microsoft.Management"),
-							models.NewStaticValueResourceIDSegment("staticManagementGroups", "managementGroups"),
-							models.NewUserSpecifiedResourceIDSegment("managementGroupId", "managementGroupId"),
-							models.NewStaticValueResourceIDSegment("staticProviders2", "providers"),
-							models.NewResourceProviderResourceIDSegment("staticMicrosoftBilling", "Microsoft.Billing"),
-							models.NewStaticValueResourceIDSegment("staticBillingPeriods", "billingPeriods"),
-							models.NewUserSpecifiedResourceIDSegment("billingPeriodName", "billingPeriodName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftManagement", "Microsoft.Management"),
+							sdkModels.NewStaticValueResourceIDSegment("staticManagementGroups", "managementGroups"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("managementGroupId", "managementGroupId"),
+							sdkModels.NewStaticValueResourceIDSegment("staticProviders2", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftBilling", "Microsoft.Billing"),
+							sdkModels.NewStaticValueResourceIDSegment("staticBillingPeriods", "billingPeriods"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("billingPeriodName", "billingPeriodName"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"Test": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
@@ -621,37 +621,37 @@ func TestParseResourceIdsWhereTheSameUriContainsDifferentConstantValuesPerOperat
 		expected := importerModels.AzureApiDefinition{
 			ServiceName: "Example",
 			ApiVersion:  "2020-01-01",
-			Resources: map[string]importerModels.AzureApiResource{
+			Resources: map[string]sdkModels.APIResource{
 				"Hello": {
-					Constants: map[string]models.SDKConstant{
+					Constants: map[string]sdkModels.SDKConstant{
 						"PlanetNames": {
-							Type: models.StringSDKConstantType,
+							Type: sdkModels.StringSDKConstantType,
 							Values: map[string]string{
 								"Earth": "Earth",
 								"Mars":  "Mars",
 							},
 						},
 					},
-					ResourceIds: map[string]models.ResourceID{
+					ResourceIDs: map[string]sdkModels.ResourceID{
 						"GalaxyId": {
-							Segments: []models.ResourceIDSegment{
-								models.NewStaticValueResourceIDSegment("staticGalaxies", "galaxies"),
-								models.NewUserSpecifiedResourceIDSegment("galaxyName", "galaxyName"),
+							Segments: []sdkModels.ResourceIDSegment{
+								sdkModels.NewStaticValueResourceIDSegment("staticGalaxies", "galaxies"),
+								sdkModels.NewUserSpecifiedResourceIDSegment("galaxyName", "galaxyName"),
 							},
 						},
 						"PlanetId": {
 							ConstantNames: []string{
 								"PlanetNames",
 							},
-							Segments: []models.ResourceIDSegment{
-								models.NewStaticValueResourceIDSegment("staticGalaxies", "galaxies"),
-								models.NewUserSpecifiedResourceIDSegment("galaxyName", "galaxyName"),
-								models.NewStaticValueResourceIDSegment("staticHello", "hello"),
-								models.NewConstantResourceIDSegment("planetName", "PlanetNames", "Earth"),
+							Segments: []sdkModels.ResourceIDSegment{
+								sdkModels.NewStaticValueResourceIDSegment("staticGalaxies", "galaxies"),
+								sdkModels.NewUserSpecifiedResourceIDSegment("galaxyName", "galaxyName"),
+								sdkModels.NewStaticValueResourceIDSegment("staticHello", "hello"),
+								sdkModels.NewConstantResourceIDSegment("planetName", "PlanetNames", "Earth"),
 							},
 						},
 					},
-					Operations: map[string]models.SDKOperation{
+					Operations: map[string]sdkModels.SDKOperation{
 						"Delete": {
 							ContentType:         "application/json",
 							ExpectedStatusCodes: []int{200},
@@ -682,55 +682,55 @@ func TestParseResourceIdsCommon(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Example": {
-				ResourceIds: map[string]models.ResourceID{
+				ResourceIDs: map[string]sdkModels.ResourceID{
 					"ManagementGroupId": {
 						CommonIDAlias: pointer.To("ManagementGroup"),
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("providers", "providers"),
-							models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
-							models.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
-							models.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
+							sdkModels.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
 						},
 					},
 					"ResourceGroupId": {
 						CommonIDAlias: pointer.To("ResourceGroup"),
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
 						},
 					},
 					"ScopeId": {
 						CommonIDAlias: pointer.To("Scope"),
-						Segments: []models.ResourceIDSegment{
-							models.NewScopeResourceIDSegment("scope"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewScopeResourceIDSegment("scope"),
 						},
 					},
 					"SubscriptionId": {
 						CommonIDAlias: pointer.To("Subscription"),
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
 						},
 					},
 					"UserAssignedIdentityId": {
 						CommonIDAlias: pointer.To("UserAssignedIdentity"),
-						Segments: []models.ResourceIDSegment{
-							models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-							models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-							models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-							models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-							models.NewStaticValueResourceIDSegment("providers", "providers"),
-							models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-							models.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-							models.NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
+						Segments: []sdkModels.ResourceIDSegment{
+							sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+							sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+							sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+							sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+							sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+							sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+							sdkModels.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+							sdkModels.NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"GetManagementGroup": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdAppService{}
 
 type commonIdAppService struct{}
 
-func (c commonIdAppService) id() models.ResourceID {
+func (c commonIdAppService) id() sdkModels.ResourceID {
 	name := "AppService"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
-			models.NewStaticValueResourceIDSegment("sites", "sites"),
-			models.NewUserSpecifiedResourceIDSegment("siteName", "siteName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			sdkModels.NewStaticValueResourceIDSegment("sites", "sites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("siteName", "siteName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_environment.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_environment.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdAppServiceEnvironment{}
 
 type commonIdAppServiceEnvironment struct{}
 
-func (c commonIdAppServiceEnvironment) id() models.ResourceID {
+func (c commonIdAppServiceEnvironment) id() sdkModels.ResourceID {
 	name := "AppServiceEnvironment"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
-			models.NewStaticValueResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
-			models.NewUserSpecifiedResourceIDSegment("hostingEnvironmentName", "hostingEnvironmentName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			sdkModels.NewStaticValueResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("hostingEnvironmentName", "hostingEnvironmentName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_plan.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_app_service_plan.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdAppServicePlan{}
 
 type commonIdAppServicePlan struct{}
 
-func (c commonIdAppServicePlan) id() models.ResourceID {
+func (c commonIdAppServicePlan) id() sdkModels.ResourceID {
 	name := "AppServicePlan"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
-			models.NewStaticValueResourceIDSegment("serverFarms", "serverFarms"),
-			models.NewUserSpecifiedResourceIDSegment("serverFarmName", "serverFarmName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Web"),
+			sdkModels.NewStaticValueResourceIDSegment("serverFarms", "serverFarms"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("serverFarmName", "serverFarmName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_automation_compilation_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_automation_compilation_job.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdAutomationCompilationJob{}
 
 type commonIdAutomationCompilationJob struct{}
 
-func (c commonIdAutomationCompilationJob) id() models.ResourceID {
+func (c commonIdAutomationCompilationJob) id() sdkModels.ResourceID {
 	name := "AutomationCompilationJob"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Automation"),
-			models.NewStaticValueResourceIDSegment("automationAccounts", "automationAccounts"),
-			models.NewUserSpecifiedResourceIDSegment("automationAccountName", "automationAccountName"),
-			models.NewStaticValueResourceIDSegment("compilationJobs", "compilationJobs"),
-			models.NewUserSpecifiedResourceIDSegment("compilationJobId", "compilationJobId"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Automation"),
+			sdkModels.NewStaticValueResourceIDSegment("automationAccounts", "automationAccounts"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("automationAccountName", "automationAccountName"),
+			sdkModels.NewStaticValueResourceIDSegment("compilationJobs", "compilationJobs"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("compilationJobId", "compilationJobId"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_availability_set.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_availability_set.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdAvailabilitySet{}
 
 type commonIdAvailabilitySet struct{}
 
-func (c commonIdAvailabilitySet) id() models.ResourceID {
+func (c commonIdAvailabilitySet) id() sdkModels.ResourceID {
 	name := "AvailabilitySet"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("availabilitySets", "availabilitySets"),
-			models.NewUserSpecifiedResourceIDSegment("availabilitySetName", "availabilitySetName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("availabilitySets", "availabilitySets"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("availabilitySetName", "availabilitySetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdBotService{}
 
 type commonIdBotService struct{}
 
-func (commonIdBotService) id() models.ResourceID {
+func (commonIdBotService) id() sdkModels.ResourceID {
 	name := "BotService"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftBotService", "Microsoft.BotService"),
-			models.NewStaticValueResourceIDSegment("staticBotServices", "botServices"),
-			models.NewUserSpecifiedResourceIDSegment("botServiceName", "botServiceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftBotService", "Microsoft.BotService"),
+			sdkModels.NewStaticValueResourceIDSegment("staticBotServices", "botServices"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("botServiceName", "botServiceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service_channel.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_bot_service_channel.go
@@ -4,23 +4,23 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdBotServiceChannel{}
 
 type commonIdBotServiceChannel struct{}
 
-func (commonIdBotServiceChannel) id() models.ResourceID {
+func (commonIdBotServiceChannel) id() sdkModels.ResourceID {
 	name := "BotServiceChannel"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{
 			"BotServiceChannelType",
 		},
-		Constants: map[string]models.SDKConstant{
+		Constants: map[string]sdkModels.SDKConstant{
 			"BotServiceChannelType": {
-				Type: models.StringSDKConstantType,
+				Type: sdkModels.StringSDKConstantType,
 				Values: map[string]string{
 					"AcsChatChannel":          "AcsChatChannel",
 					"AlexaChannel":            "AlexaChannel",
@@ -44,17 +44,17 @@ func (commonIdBotServiceChannel) id() models.ResourceID {
 				},
 			},
 		},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftBotService", "Microsoft.BotService"),
-			models.NewStaticValueResourceIDSegment("staticBotServices", "botServices"),
-			models.NewUserSpecifiedResourceIDSegment("botServiceName", "botServiceName"),
-			models.NewStaticValueResourceIDSegment("staticChannels", "channels"),
-			models.NewConstantResourceIDSegment("channelType", "BotServiceChannelType", "AcsChatChannel"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftBotService", "Microsoft.BotService"),
+			sdkModels.NewStaticValueResourceIDSegment("staticBotServices", "botServices"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("botServiceName", "botServiceName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticChannels", "channels"),
+			sdkModels.NewConstantResourceIDSegment("channelType", "BotServiceChannelType", "AcsChatChannel"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_capability.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_capability.go
@@ -4,26 +4,26 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdChaosStudioCapability{}
 
 type commonIdChaosStudioCapability struct{}
 
-func (commonIdChaosStudioCapability) id() models.ResourceID {
+func (commonIdChaosStudioCapability) id() sdkModels.ResourceID {
 	name := "ChaosStudioCapability"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewScopeResourceIDSegment("scope"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
-			models.NewStaticValueResourceIDSegment("staticTargets", "targets"),
-			models.NewUserSpecifiedResourceIDSegment("targetName", "targetName"),
-			models.NewStaticValueResourceIDSegment("staticCapabilities", "capabilities"),
-			models.NewUserSpecifiedResourceIDSegment("capabilityName", "capabilityName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewScopeResourceIDSegment("scope"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
+			sdkModels.NewStaticValueResourceIDSegment("staticTargets", "targets"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("targetName", "targetName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticCapabilities", "capabilities"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("capabilityName", "capabilityName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_target.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_chaos_studio_target.go
@@ -4,24 +4,24 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdChaosStudioTarget{}
 
 type commonIdChaosStudioTarget struct{}
 
-func (commonIdChaosStudioTarget) id() models.ResourceID {
+func (commonIdChaosStudioTarget) id() sdkModels.ResourceID {
 	name := "ChaosStudioTarget"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewScopeResourceIDSegment("scope"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
-			models.NewStaticValueResourceIDSegment("staticTargets", "targets"),
-			models.NewUserSpecifiedResourceIDSegment("targetName", "targetName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewScopeResourceIDSegment("scope"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftChaos", "Microsoft.Chaos"),
+			sdkModels.NewStaticValueResourceIDSegment("staticTargets", "targets"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("targetName", "targetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_ip_configuration.go
@@ -4,33 +4,33 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdCloudServicesIPConfiguration{}
 
 type commonIdCloudServicesIPConfiguration struct{}
 
-func (c commonIdCloudServicesIPConfiguration) id() models.ResourceID {
+func (c commonIdCloudServicesIPConfiguration) id() sdkModels.ResourceID {
 	name := "CloudServicesIPConfiguration"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("cloudServices", "cloudServices"),
-			models.NewUserSpecifiedResourceIDSegment("cloudServiceName", "cloudServiceName"),
-			models.NewStaticValueResourceIDSegment("roleInstances", "roleInstances"),
-			models.NewUserSpecifiedResourceIDSegment("roleInstanceName", "roleInstanceName"),
-			models.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
-			models.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("cloudServices", "cloudServices"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("cloudServiceName", "cloudServiceName"),
+			sdkModels.NewStaticValueResourceIDSegment("roleInstances", "roleInstances"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("roleInstanceName", "roleInstanceName"),
+			sdkModels.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
+			sdkModels.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_cloud_services_public_ip_address.go
@@ -4,35 +4,35 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdCloudServicesPublicIPAddress{}
 
 type commonIdCloudServicesPublicIPAddress struct{}
 
-func (c commonIdCloudServicesPublicIPAddress) id() models.ResourceID {
+func (c commonIdCloudServicesPublicIPAddress) id() sdkModels.ResourceID {
 	name := "CloudServicesPublicIPAddress"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("cloudServices", "cloudServices"),
-			models.NewUserSpecifiedResourceIDSegment("cloudServiceName", "cloudServiceName"),
-			models.NewStaticValueResourceIDSegment("roleInstances", "roleInstances"),
-			models.NewUserSpecifiedResourceIDSegment("roleInstanceName", "roleInstanceName"),
-			models.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
-			models.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
-			models.NewStaticValueResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
-			models.NewUserSpecifiedResourceIDSegment("publicIPAddressName", "publicIPAddressName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("cloudServices", "cloudServices"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("cloudServiceName", "cloudServiceName"),
+			sdkModels.NewStaticValueResourceIDSegment("roleInstances", "roleInstances"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("roleInstanceName", "roleInstanceName"),
+			sdkModels.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
+			sdkModels.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
+			sdkModels.NewStaticValueResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("publicIPAddressName", "publicIPAddressName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdDedicatedHost{}
 
 type commonIdDedicatedHost struct{}
 
-func (c commonIdDedicatedHost) id() models.ResourceID {
+func (c commonIdDedicatedHost) id() sdkModels.ResourceID {
 	name := "DedicatedHost"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("hostGroups", "hostGroups"),
-			models.NewUserSpecifiedResourceIDSegment("hostGroupName", "hostGroupName"),
-			models.NewStaticValueResourceIDSegment("hosts", "hosts"),
-			models.NewUserSpecifiedResourceIDSegment("hostName", "hostName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("hostGroups", "hostGroups"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("hostGroupName", "hostGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("hosts", "hosts"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("hostName", "hostName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_dedicated_host_group.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdDedicatedHostGroup{}
 
 type commonIdDedicatedHostGroup struct{}
 
-func (c commonIdDedicatedHostGroup) id() models.ResourceID {
+func (c commonIdDedicatedHostGroup) id() sdkModels.ResourceID {
 	name := "DedicatedHostGroup"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("hostGroups", "hostGroups"),
-			models.NewUserSpecifiedResourceIDSegment("hostGroupName", "hostGroupName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("hostGroups", "hostGroups"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("hostGroupName", "hostGroupName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_disk_encryption_set.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_disk_encryption_set.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdDiskEncryptionSet{}
 
 type commonIdDiskEncryptionSet struct{}
 
-func (c commonIdDiskEncryptionSet) id() models.ResourceID {
+func (c commonIdDiskEncryptionSet) id() sdkModels.ResourceID {
 	name := "DiskEncryptionSet"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("diskEncryptionSets", "diskEncryptionSets"),
-			models.NewUserSpecifiedResourceIDSegment("diskEncryptionSetName", "diskEncryptionSetName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("diskEncryptionSets", "diskEncryptionSets"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("diskEncryptionSetName", "diskEncryptionSetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_expressroute_circuit_peering.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_expressroute_circuit_peering.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdExpressRouteCircuitPeering{}
 
 type commonIdExpressRouteCircuitPeering struct{}
 
-func (c commonIdExpressRouteCircuitPeering) id() models.ResourceID {
+func (c commonIdExpressRouteCircuitPeering) id() sdkModels.ResourceID {
 	name := "ExpressRouteCircuitPeering"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("expressRouteCircuits", "expressRouteCircuits"),
-			models.NewUserSpecifiedResourceIDSegment("circuitName", "circuitName"),
-			models.NewStaticValueResourceIDSegment("peerings", "peerings"),
-			models.NewUserSpecifiedResourceIDSegment("peeringName", "peeringName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("expressRouteCircuits", "expressRouteCircuits"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("circuitName", "circuitName"),
+			sdkModels.NewStaticValueResourceIDSegment("peerings", "peerings"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("peeringName", "peeringName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hdinsight_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hdinsight_cluster.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdHDInsightCluster{}
 
 type commonIdHDInsightCluster struct{}
 
-func (c commonIdHDInsightCluster) id() models.ResourceID {
+func (c commonIdHDInsightCluster) id() sdkModels.ResourceID {
 	name := "HDInsightCluster"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.HDInsight"),
-			models.NewStaticValueResourceIDSegment("clusters", "clusters"),
-			models.NewUserSpecifiedResourceIDSegment("clusterName", "clusterName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.HDInsight"),
+			sdkModels.NewStaticValueResourceIDSegment("clusters", "clusters"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("clusterName", "clusterName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_job.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdHyperVSiteJob{}
 
 type commonIdHyperVSiteJob struct{}
 
-func (c commonIdHyperVSiteJob) id() models.ResourceID {
+func (c commonIdHyperVSiteJob) id() sdkModels.ResourceID {
 	name := "HyperVSiteJob"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.NewStaticValueResourceIDSegment("hyperVSites", "hyperVSites"),
-			models.NewUserSpecifiedResourceIDSegment("hyperVSiteName", "hyperVSiteName"),
-			models.NewStaticValueResourceIDSegment("jobs", "jobs"),
-			models.NewUserSpecifiedResourceIDSegment("jobName", "jobName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			sdkModels.NewStaticValueResourceIDSegment("hyperVSites", "hyperVSites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("hyperVSiteName", "hyperVSiteName"),
+			sdkModels.NewStaticValueResourceIDSegment("jobs", "jobs"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("jobName", "jobName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_machine.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_machine.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdHyperVSiteMachine{}
 
 type commonIdHyperVSiteMachine struct{}
 
-func (c commonIdHyperVSiteMachine) id() models.ResourceID {
+func (c commonIdHyperVSiteMachine) id() sdkModels.ResourceID {
 	name := "HyperVSiteMachine"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.NewStaticValueResourceIDSegment("hyperVSites", "hyperVSites"),
-			models.NewUserSpecifiedResourceIDSegment("hyperVSiteName", "hyperVSiteName"),
-			models.NewStaticValueResourceIDSegment("machines", "machines"),
-			models.NewUserSpecifiedResourceIDSegment("machineName", "machineName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			sdkModels.NewStaticValueResourceIDSegment("hyperVSites", "hyperVSites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("hyperVSiteName", "hyperVSiteName"),
+			sdkModels.NewStaticValueResourceIDSegment("machines", "machines"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("machineName", "machineName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_runasaccount.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_hyperv_site_runasaccount.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdHyperVSiteRunAsAccount{}
 
 type commonIdHyperVSiteRunAsAccount struct{}
 
-func (c commonIdHyperVSiteRunAsAccount) id() models.ResourceID {
+func (c commonIdHyperVSiteRunAsAccount) id() sdkModels.ResourceID {
 	name := "HyperVSiteRunAsAccount"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.NewStaticValueResourceIDSegment("hyperVSites", "hyperVSites"),
-			models.NewUserSpecifiedResourceIDSegment("hyperVSiteName", "hyperVSiteName"),
-			models.NewStaticValueResourceIDSegment("runAsAccounts", "runAsAccounts"),
-			models.NewUserSpecifiedResourceIDSegment("runAsAccountName", "runAsAccountName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			sdkModels.NewStaticValueResourceIDSegment("hyperVSites", "hyperVSites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("hyperVSiteName", "hyperVSiteName"),
+			sdkModels.NewStaticValueResourceIDSegment("runAsAccounts", "runAsAccounts"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("runAsAccountName", "runAsAccountName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdKeyVault{}
 
 type commonIdKeyVault struct{}
 
-func (c commonIdKeyVault) id() models.ResourceID {
+func (c commonIdKeyVault) id() sdkModels.ResourceID {
 	name := "KeyVault"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
-			models.NewStaticValueResourceIDSegment("vaults", "vaults"),
-			models.NewUserSpecifiedResourceIDSegment("vaultName", "vaultName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			sdkModels.NewStaticValueResourceIDSegment("vaults", "vaults"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("vaultName", "vaultName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdKeyVaultKey{}
 
 type commonIdKeyVaultKey struct{}
 
-func (c commonIdKeyVaultKey) id() models.ResourceID {
+func (c commonIdKeyVaultKey) id() sdkModels.ResourceID {
 	name := "KeyVaultKey"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
-			models.NewStaticValueResourceIDSegment("vaults", "vaults"),
-			models.NewUserSpecifiedResourceIDSegment("vaultName", "vaultName"),
-			models.NewStaticValueResourceIDSegment("keys", "keys"),
-			models.NewUserSpecifiedResourceIDSegment("keyName", "keyName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			sdkModels.NewStaticValueResourceIDSegment("vaults", "vaults"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("vaultName", "vaultName"),
+			sdkModels.NewStaticValueResourceIDSegment("keys", "keys"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("keyName", "keyName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key_version.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_key_version.go
@@ -4,31 +4,31 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdKeyVaultKeyVersion{}
 
 type commonIdKeyVaultKeyVersion struct{}
 
-func (c commonIdKeyVaultKeyVersion) id() models.ResourceID {
+func (c commonIdKeyVaultKeyVersion) id() sdkModels.ResourceID {
 	name := "KeyVaultKeyVersion"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
-			models.NewStaticValueResourceIDSegment("vaults", "vaults"),
-			models.NewUserSpecifiedResourceIDSegment("vaultName", "vaultName"),
-			models.NewStaticValueResourceIDSegment("keys", "keys"),
-			models.NewUserSpecifiedResourceIDSegment("keyName", "keyName"),
-			models.NewStaticValueResourceIDSegment("versions", "versions"),
-			models.NewUserSpecifiedResourceIDSegment("versionName", "versionName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			sdkModels.NewStaticValueResourceIDSegment("vaults", "vaults"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("vaultName", "vaultName"),
+			sdkModels.NewStaticValueResourceIDSegment("keys", "keys"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("keyName", "keyName"),
+			sdkModels.NewStaticValueResourceIDSegment("versions", "versions"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("versionName", "versionName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_private_endpoint_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_key_vault_private_endpoint_connection.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdKeyVaultPrivateEndpointConnection{}
 
 type commonIdKeyVaultPrivateEndpointConnection struct{}
 
-func (c commonIdKeyVaultPrivateEndpointConnection) id() models.ResourceID {
+func (c commonIdKeyVaultPrivateEndpointConnection) id() sdkModels.ResourceID {
 	name := "KeyVaultPrivateEndpointConnection"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
-			models.NewStaticValueResourceIDSegment("vaults", "vaults"),
-			models.NewUserSpecifiedResourceIDSegment("vaultName", "vaultName"),
-			models.NewStaticValueResourceIDSegment("privateEndpointConnections", "privateEndpointConnections"),
-			models.NewUserSpecifiedResourceIDSegment("privateEndpointConnectionName", "privateEndpointConnectionName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.KeyVault"),
+			sdkModels.NewStaticValueResourceIDSegment("vaults", "vaults"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("vaultName", "vaultName"),
+			sdkModels.NewStaticValueResourceIDSegment("privateEndpointConnections", "privateEndpointConnections"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("privateEndpointConnectionName", "privateEndpointConnectionName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kubernetes_cluster.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdKubernetesCluster{}
 
 type commonIdKubernetesCluster struct{}
 
-func (c commonIdKubernetesCluster) id() models.ResourceID {
+func (c commonIdKubernetesCluster) id() sdkModels.ResourceID {
 	name := "KubernetesCluster"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ContainerService"),
-			models.NewStaticValueResourceIDSegment("managedClusters", "managedClusters"),
-			models.NewUserSpecifiedResourceIDSegment("managedClusterName", "managedClusterName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ContainerService"),
+			sdkModels.NewStaticValueResourceIDSegment("managedClusters", "managedClusters"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("managedClusterName", "managedClusterName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_cluster.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_cluster.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdKustoCluster{}
 
 type commonIdKustoCluster struct{}
 
-func (c commonIdKustoCluster) id() models.ResourceID {
+func (c commonIdKustoCluster) id() sdkModels.ResourceID {
 	name := "KustoCluster"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
-			models.NewStaticValueResourceIDSegment("staticClusters", "clusters"),
-			models.NewUserSpecifiedResourceIDSegment("kustoClusterName", "kustoClusterName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
+			sdkModels.NewStaticValueResourceIDSegment("staticClusters", "clusters"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("kustoClusterName", "kustoClusterName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_kusto_database.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdKustoDatabase{}
 
 type commonIdKustoDatabase struct{}
 
-func (c commonIdKustoDatabase) id() models.ResourceID {
+func (c commonIdKustoDatabase) id() sdkModels.ResourceID {
 	name := "KustoDatabase"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
-			models.NewStaticValueResourceIDSegment("staticClusters", "clusters"),
-			models.NewUserSpecifiedResourceIDSegment("kustoClusterName", "kustoClusterName"),
-			models.NewStaticValueResourceIDSegment("staticDatabases", "databases"),
-			models.NewUserSpecifiedResourceIDSegment("kustoDatabaseName", "kustoDatabaseName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftKusto", "Microsoft.Kusto"),
+			sdkModels.NewStaticValueResourceIDSegment("staticClusters", "clusters"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("kustoClusterName", "kustoClusterName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticDatabases", "databases"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("kustoDatabaseName", "kustoDatabaseName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_managed_disk.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_managed_disk.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdManagedDisk{}
 
 type commonIdManagedDisk struct{}
 
-func (c commonIdManagedDisk) id() models.ResourceID {
+func (c commonIdManagedDisk) id() sdkModels.ResourceID {
 	name := "ManagedDisk"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("disks", "disks"),
-			models.NewUserSpecifiedResourceIDSegment("diskName", "diskName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("disks", "disks"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("diskName", "diskName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group.go
@@ -4,23 +4,23 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdManagementGroupMatcher{}
 
 type commonIdManagementGroupMatcher struct{}
 
-func (commonIdManagementGroupMatcher) id() models.ResourceID {
+func (commonIdManagementGroupMatcher) id() sdkModels.ResourceID {
 	name := "ManagementGroup"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
-			models.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
-			models.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
+			sdkModels.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_management_group_test.go
@@ -6,31 +6,31 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 func TestCommonResourceID_ManagementGroup(t *testing.T) {
-	valid := models.ResourceID{
+	valid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
-			models.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
-			models.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
+			sdkModels.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
 		},
 	}
-	invalid := models.ResourceID{
+	invalid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
-			models.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
-			models.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
-			models.NewStaticValueResourceIDSegment("someResource", "someResource"),
-			models.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Management"),
+			sdkModels.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
+			sdkModels.NewStaticValueResourceIDSegment("someResource", "someResource"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
 		},
 	}
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		valid,
 		invalid,
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdNetworkInterface{}
 
 type commonIdNetworkInterface struct{}
 
-func (c commonIdNetworkInterface) id() models.ResourceID {
+func (c commonIdNetworkInterface) id() sdkModels.ResourceID {
 	name := "NetworkInterface"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_network_interface_ip_configuration.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdNetworkInterfaceIPConfiguration{}
 
 type commonIdNetworkInterfaceIPConfiguration struct{}
 
-func (c commonIdNetworkInterfaceIPConfiguration) id() models.ResourceID {
+func (c commonIdNetworkInterfaceIPConfiguration) id() sdkModels.ResourceID {
 	name := "NetworkInterfaceIPConfiguration"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
-			models.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
+			sdkModels.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_p2s_vpn_gateway.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_p2s_vpn_gateway.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdP2sVPNGateway{}
 
 type commonIdP2sVPNGateway struct{}
 
-func (c commonIdP2sVPNGateway) id() models.ResourceID {
+func (c commonIdP2sVPNGateway) id() sdkModels.ResourceID {
 	name := "P2sVPNGateway"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("p2sVpnGateways", "p2sVpnGateways"),
-			models.NewUserSpecifiedResourceIDSegment("gatewayName", "gatewayName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("p2sVpnGateways", "p2sVpnGateways"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("gatewayName", "gatewayName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_provisioning_service_id.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_provisioning_service_id.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdProvisioningService{}
 
 type commonIdProvisioningService struct{}
 
-func (c commonIdProvisioningService) id() models.ResourceID {
+func (c commonIdProvisioningService) id() sdkModels.ResourceID {
 	name := "ProvisioningService"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Devices"),
-			models.NewStaticValueResourceIDSegment("provisioningServices", "provisioningServices"),
-			models.NewUserSpecifiedResourceIDSegment("provisioningServiceName", "provisioningServiceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Devices"),
+			sdkModels.NewStaticValueResourceIDSegment("provisioningServices", "provisioningServices"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("provisioningServiceName", "provisioningServiceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_public_ip_address.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdPublicIPAddress{}
 
 type commonIdPublicIPAddress struct{}
 
-func (c commonIdPublicIPAddress) id() models.ResourceID {
+func (c commonIdPublicIPAddress) id() sdkModels.ResourceID {
 	name := "PublicIPAddress"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
-			models.NewUserSpecifiedResourceIDSegment("publicIPAddressesName", "publicIPAddressesName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("publicIPAddressesName", "publicIPAddressesName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group.go
@@ -4,23 +4,23 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdResourceGroupMatcher{}
 
 type commonIdResourceGroupMatcher struct{}
 
-func (commonIdResourceGroupMatcher) id() models.ResourceID {
+func (commonIdResourceGroupMatcher) id() sdkModels.ResourceID {
 	name := "ResourceGroup"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_resource_group_test.go
@@ -6,31 +6,31 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 func TestCommonResourceID_ResourceGroup(t *testing.T) {
-	valid := models.ResourceID{
+	valid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
 		},
 	}
-	invalid := models.ResourceID{
+	invalid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("someResource", "someResource"),
-			models.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("someResource", "someResource"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
 		},
 	}
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		valid,
 		invalid,
 	}
@@ -59,23 +59,23 @@ func TestCommonResourceID_ResourceGroup(t *testing.T) {
 }
 
 func TestCommonResourceID_ResourceGroupIncorrectSegment(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		{
 			ConstantNames: []string{},
-			Segments: []models.ResourceIDSegment{
-				models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-				models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-				models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-				models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			Segments: []sdkModels.ResourceIDSegment{
+				sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+				sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+				sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+				sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
 			},
 		},
 		{
 			ConstantNames: []string{},
-			Segments: []models.ResourceIDSegment{
-				models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-				models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-				models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-				models.NewResourceGroupNameResourceIDSegment("sourceResourceGroupName"),
+			Segments: []sdkModels.ResourceIDSegment{
+				sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+				sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+				sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+				sdkModels.NewResourceGroupNameResourceIDSegment("sourceResourceGroupName"),
 			},
 		},
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope.go
@@ -4,20 +4,20 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdScopeMatcher{}
 
 type commonIdScopeMatcher struct{}
 
-func (commonIdScopeMatcher) id() models.ResourceID {
+func (commonIdScopeMatcher) id() sdkModels.ResourceID {
 	name := "Scope"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewScopeResourceIDSegment("scope"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewScopeResourceIDSegment("scope"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_scope_test.go
@@ -6,25 +6,25 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 func TestCommonResourceID_Scope(t *testing.T) {
-	valid := models.ResourceID{
+	valid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewScopeResourceIDSegment("resourcePath"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewScopeResourceIDSegment("resourcePath"),
 		},
 	}
-	invalid := models.ResourceID{
+	invalid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewScopeResourceIDSegment("scope"),
-			models.NewStaticValueResourceIDSegment("someResource", "someResource"),
-			models.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewScopeResourceIDSegment("scope"),
+			sdkModels.NewStaticValueResourceIDSegment("someResource", "someResource"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
 		},
 	}
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		valid,
 		invalid,
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_shared_image_gallery.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_shared_image_gallery.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSharedImageGallery{}
 
 type commonIdSharedImageGallery struct{}
 
-func (c commonIdSharedImageGallery) id() models.ResourceID {
+func (c commonIdSharedImageGallery) id() sdkModels.ResourceID {
 	name := "SharedImageGallery"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("galleries", "galleries"),
-			models.NewUserSpecifiedResourceIDSegment("galleryName", "galleryName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("galleries", "galleries"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("galleryName", "galleryName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_spring_cloud_service.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_spring_cloud_service.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSpringCloudService{}
 
 type commonIdSpringCloudService struct{}
 
-func (c commonIdSpringCloudService) id() models.ResourceID {
+func (c commonIdSpringCloudService) id() sdkModels.ResourceID {
 	name := "SpringCloudService"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftAppPlatform", "Microsoft.AppPlatform"),
-			models.NewStaticValueResourceIDSegment("staticSpring", "spring"),
-			models.NewUserSpecifiedResourceIDSegment("serviceName", "serviceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftAppPlatform", "Microsoft.AppPlatform"),
+			sdkModels.NewStaticValueResourceIDSegment("staticSpring", "spring"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("serviceName", "serviceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_database.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSqlDatabase{}
 
 type commonIdSqlDatabase struct{}
 
-func (c commonIdSqlDatabase) id() models.ResourceID {
+func (c commonIdSqlDatabase) id() sdkModels.ResourceID {
 	name := "SqlDatabase"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.NewStaticValueResourceIDSegment("servers", "servers"),
-			models.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
-			models.NewStaticValueResourceIDSegment("databases", "databases"),
-			models.NewUserSpecifiedResourceIDSegment("databaseName", "databaseName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			sdkModels.NewStaticValueResourceIDSegment("servers", "servers"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+			sdkModels.NewStaticValueResourceIDSegment("databases", "databases"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("databaseName", "databaseName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_elastic_pool.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_elastic_pool.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSqlElasticPool{}
 
 type commonIdSqlElasticPool struct{}
 
-func (c commonIdSqlElasticPool) id() models.ResourceID {
+func (c commonIdSqlElasticPool) id() sdkModels.ResourceID {
 	name := "SqlElasticPool"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.NewStaticValueResourceIDSegment("servers", "servers"),
-			models.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
-			models.NewStaticValueResourceIDSegment("elasticPools", "elasticPools"),
-			models.NewUserSpecifiedResourceIDSegment("elasticPoolName", "elasticPoolName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			sdkModels.NewStaticValueResourceIDSegment("servers", "servers"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+			sdkModels.NewStaticValueResourceIDSegment("elasticPools", "elasticPools"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("elasticPoolName", "elasticPoolName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSqlManagedInstance{}
 
 type commonIdSqlManagedInstance struct{}
 
-func (c commonIdSqlManagedInstance) id() models.ResourceID {
+func (c commonIdSqlManagedInstance) id() sdkModels.ResourceID {
 	name := "SqlManagedInstance"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.NewStaticValueResourceIDSegment("managedInstances", "managedInstances"),
-			models.NewUserSpecifiedResourceIDSegment("managedInstanceName", "managedInstanceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			sdkModels.NewStaticValueResourceIDSegment("managedInstances", "managedInstances"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("managedInstanceName", "managedInstanceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance_database.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_managed_instance_database.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSqlManagedInstanceDatabase{}
 
 type commonIdSqlManagedInstanceDatabase struct{}
 
-func (c commonIdSqlManagedInstanceDatabase) id() models.ResourceID {
+func (c commonIdSqlManagedInstanceDatabase) id() sdkModels.ResourceID {
 	name := "SqlManagedInstanceDatabase"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.NewStaticValueResourceIDSegment("managedInstances", "managedInstances"),
-			models.NewUserSpecifiedResourceIDSegment("managedInstanceName", "managedInstanceName"),
-			models.NewStaticValueResourceIDSegment("databases", "databases"),
-			models.NewUserSpecifiedResourceIDSegment("databaseName", "databaseName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			sdkModels.NewStaticValueResourceIDSegment("managedInstances", "managedInstances"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("managedInstanceName", "managedInstanceName"),
+			sdkModels.NewStaticValueResourceIDSegment("databases", "databases"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("databaseName", "databaseName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_server.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_sql_server.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSqlServer{}
 
 type commonIdSqlServer struct{}
 
-func (c commonIdSqlServer) id() models.ResourceID {
+func (c commonIdSqlServer) id() sdkModels.ResourceID {
 	name := "SqlServer"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
-			models.NewStaticValueResourceIDSegment("servers", "servers"),
-			models.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Sql"),
+			sdkModels.NewStaticValueResourceIDSegment("servers", "servers"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("serverName", "serverName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_account.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_account.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdStorageAccount{}
 
 type commonIdStorageAccount struct{}
 
-func (c commonIdStorageAccount) id() models.ResourceID {
+func (c commonIdStorageAccount) id() sdkModels.ResourceID {
 	name := "StorageAccount"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
-			models.NewStaticValueResourceIDSegment("storageAccounts", "storageAccounts"),
-			models.NewUserSpecifiedResourceIDSegment("storageAccountName", "storageAccountName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
+			sdkModels.NewStaticValueResourceIDSegment("storageAccounts", "storageAccounts"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("storageAccountName", "storageAccountName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_container.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_storage_container.go
@@ -4,31 +4,31 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdStorageContainer{}
 
 type commonIdStorageContainer struct{}
 
-func (c commonIdStorageContainer) id() models.ResourceID {
+func (c commonIdStorageContainer) id() sdkModels.ResourceID {
 	name := "StorageContainer"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
-			models.NewStaticValueResourceIDSegment("storageAccounts", "storageAccounts"),
-			models.NewUserSpecifiedResourceIDSegment("storageAccountName", "storageAccountName"),
-			models.NewStaticValueResourceIDSegment("blobServices", "blobServices"),
-			models.NewStaticValueResourceIDSegment("default", "default"),
-			models.NewStaticValueResourceIDSegment("containers", "containers"),
-			models.NewUserSpecifiedResourceIDSegment("containerName", "containerName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Storage"),
+			sdkModels.NewStaticValueResourceIDSegment("storageAccounts", "storageAccounts"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("storageAccountName", "storageAccountName"),
+			sdkModels.NewStaticValueResourceIDSegment("blobServices", "blobServices"),
+			sdkModels.NewStaticValueResourceIDSegment("default", "default"),
+			sdkModels.NewStaticValueResourceIDSegment("containers", "containers"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("containerName", "containerName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subnet.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subnet.go
@@ -4,29 +4,29 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSubnet{}
 
 type commonIdSubnet struct{}
 
-func (c commonIdSubnet) id() models.ResourceID {
+func (c commonIdSubnet) id() sdkModels.ResourceID {
 	name := "Subnet"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("virtualNetworks", "virtualNetworks"),
-			models.NewUserSpecifiedResourceIDSegment("virtualNetworkName", "virtualNetworkName"),
-			models.NewStaticValueResourceIDSegment("subnets", "subnets"),
-			models.NewUserSpecifiedResourceIDSegment("subnetName", "subnetName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualNetworks", "virtualNetworks"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualNetworkName", "virtualNetworkName"),
+			sdkModels.NewStaticValueResourceIDSegment("subnets", "subnets"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("subnetName", "subnetName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription.go
@@ -4,21 +4,21 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdSubscriptionMatcher{}
 
 type commonIdSubscriptionMatcher struct{}
 
-func (commonIdSubscriptionMatcher) id() models.ResourceID {
+func (commonIdSubscriptionMatcher) id() sdkModels.ResourceID {
 	name := "Subscription"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_subscription_test.go
@@ -6,27 +6,27 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 func TestCommonResourceID_Subscription(t *testing.T) {
-	valid := models.ResourceID{
+	valid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
 		},
 	}
-	invalid := models.ResourceID{
+	invalid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("someResource", "someResource"),
-			models.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("someResource", "someResource"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
 		},
 	}
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		valid,
 		invalid,
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity.go
@@ -4,27 +4,27 @@
 package resourceids
 
 import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 var _ commonIdMatcher = commonIdUserAssignedIdentity{}
 
 type commonIdUserAssignedIdentity struct{}
 
-func (commonIdUserAssignedIdentity) id() models.ResourceID {
+func (commonIdUserAssignedIdentity) id() sdkModels.ResourceID {
 	name := "UserAssignedIdentity"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-			models.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+			sdkModels.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_user_assigned_identity_test.go
@@ -6,39 +6,39 @@ package resourceids
 import (
 	"testing"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 func TestCommonResourceID_UserAssignedIdentity(t *testing.T) {
-	valid := models.ResourceID{
+	valid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-			models.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+			sdkModels.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
 		},
 	}
-	invalid := models.ResourceID{
+	invalid := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-			models.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-			models.NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
-			models.NewStaticValueResourceIDSegment("someResource", "someResource"),
-			models.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+			sdkModels.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("userAssignedIdentityName", "userAssignedIdentityName"),
+			sdkModels.NewStaticValueResourceIDSegment("someResource", "someResource"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
 		},
 	}
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		valid,
 		invalid,
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_hub_bgp_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_hub_bgp_connection.go
@@ -3,30 +3,28 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVirtualHubBGPConnection{}
 
 type commonIdVirtualHubBGPConnection struct{}
 
-func (c commonIdVirtualHubBGPConnection) id() models.ResourceID {
+func (c commonIdVirtualHubBGPConnection) id() sdkModels.ResourceID {
 	name := "VirtualHubBGPConnection"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("virtualHubs", "virtualHubs"),
-			models.NewUserSpecifiedResourceIDSegment("hubName", "hubName"),
-			models.NewStaticValueResourceIDSegment("bgpConnections", "bgpConnections"),
-			models.NewUserSpecifiedResourceIDSegment("connectionName", "connectionName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualHubs", "virtualHubs"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("hubName", "hubName"),
+			sdkModels.NewStaticValueResourceIDSegment("bgpConnections", "bgpConnections"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("connectionName", "connectionName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_ip_configuration.go
@@ -3,34 +3,32 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVirtualMachineScaleSetIPConfiguration{}
 
 type commonIdVirtualMachineScaleSetIPConfiguration struct{}
 
-func (c commonIdVirtualMachineScaleSetIPConfiguration) id() models.ResourceID {
+func (c commonIdVirtualMachineScaleSetIPConfiguration) id() sdkModels.ResourceID {
 	name := "VirtualMachineScaleSetIPConfiguration"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
-			models.NewUserSpecifiedResourceIDSegment("virtualMachineScaleSetName", "virtualMachineScaleSetName"),
-			models.NewStaticValueResourceIDSegment("virtualMachines", "virtualMachines"),
-			models.NewUserSpecifiedResourceIDSegment("virtualMachineIndex", "virtualMachineIndex"),
-			models.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
-			models.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineScaleSetName", "virtualMachineScaleSetName"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualMachines", "virtualMachines"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineIndex", "virtualMachineIndex"),
+			sdkModels.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
+			sdkModels.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_network_interface.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_network_interface.go
@@ -3,32 +3,30 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVirtualMachineScaleSetNetworkInterface{}
 
 type commonIdVirtualMachineScaleSetNetworkInterface struct{}
 
-func (c commonIdVirtualMachineScaleSetNetworkInterface) id() models.ResourceID {
+func (c commonIdVirtualMachineScaleSetNetworkInterface) id() sdkModels.ResourceID {
 	name := "VirtualMachineScaleSetNetworkInterface"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
-			models.NewUserSpecifiedResourceIDSegment("virtualMachineScaleSetName", "virtualMachineScaleSetName"),
-			models.NewStaticValueResourceIDSegment("virtualMachines", "virtualMachines"),
-			models.NewUserSpecifiedResourceIDSegment("virtualMachineIndex", "virtualMachineIndex"),
-			models.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineScaleSetName", "virtualMachineScaleSetName"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualMachines", "virtualMachines"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineIndex", "virtualMachineIndex"),
+			sdkModels.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_public_ip_address.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_machine_scale_set_public_ip_address.go
@@ -3,36 +3,34 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVirtualMachineScaleSetPublicIPAddress{}
 
 type commonIdVirtualMachineScaleSetPublicIPAddress struct{}
 
-func (c commonIdVirtualMachineScaleSetPublicIPAddress) id() models.ResourceID {
+func (c commonIdVirtualMachineScaleSetPublicIPAddress) id() sdkModels.ResourceID {
 	name := "VirtualMachineScaleSetPublicIPAddress"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
-			models.NewStaticValueResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
-			models.NewUserSpecifiedResourceIDSegment("virtualMachineScaleSetName", "virtualMachineScaleSetName"),
-			models.NewStaticValueResourceIDSegment("virtualMachines", "virtualMachines"),
-			models.NewUserSpecifiedResourceIDSegment("virtualMachineIndex", "virtualMachineIndex"),
-			models.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
-			models.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
-			models.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
-			models.NewStaticValueResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
-			models.NewUserSpecifiedResourceIDSegment("publicIpAddressName", "publicIpAddressName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Compute"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualMachineScaleSets", "virtualMachineScaleSets"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineScaleSetName", "virtualMachineScaleSetName"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualMachines", "virtualMachines"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineIndex", "virtualMachineIndex"),
+			sdkModels.NewStaticValueResourceIDSegment("networkInterfaces", "networkInterfaces"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("networkInterfaceName", "networkInterfaceName"),
+			sdkModels.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("ipConfigurationName", "ipConfigurationName"),
+			sdkModels.NewStaticValueResourceIDSegment("publicIPAddresses", "publicIPAddresses"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("publicIpAddressName", "publicIpAddressName"),
 		},
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_network.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_network.go
@@ -3,28 +3,26 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVirtualNetwork{}
 
 type commonIdVirtualNetwork struct{}
 
-func (c commonIdVirtualNetwork) id() models.ResourceID {
+func (c commonIdVirtualNetwork) id() sdkModels.ResourceID {
 	name := "VirtualNetwork"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("virtualNetworks", "virtualNetworks"),
-			models.NewUserSpecifiedResourceIDSegment("virtualNetworkName", "virtualNetworkName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualNetworks", "virtualNetworks"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualNetworkName", "virtualNetworkName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_router_peering.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_router_peering.go
@@ -3,30 +3,28 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVirtualRouterPeering{}
 
 type commonIdVirtualRouterPeering struct{}
 
-func (c commonIdVirtualRouterPeering) id() models.ResourceID {
+func (c commonIdVirtualRouterPeering) id() sdkModels.ResourceID {
 	name := "VirtualRouterPeering"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("virtualRouters", "virtualRouters"),
-			models.NewUserSpecifiedResourceIDSegment("virtualRouterName", "virtualRouterName"),
-			models.NewStaticValueResourceIDSegment("peerings", "peerings"),
-			models.NewUserSpecifiedResourceIDSegment("peeringName", "peeringName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualRouters", "virtualRouters"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualRouterName", "virtualRouterName"),
+			sdkModels.NewStaticValueResourceIDSegment("peerings", "peerings"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("peeringName", "peeringName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_wan_p2s_vpn_gateway.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtual_wan_p2s_vpn_gateway.go
@@ -3,28 +3,26 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVirtualWANP2SVPNGateway{}
 
 type commonIdVirtualWANP2SVPNGateway struct{}
 
-func (c commonIdVirtualWANP2SVPNGateway) id() models.ResourceID {
+func (c commonIdVirtualWANP2SVPNGateway) id() sdkModels.ResourceID {
 	name := "VirtualWANP2SVPNGateway"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("p2sVpnGateways", "p2sVpnGateways"),
-			models.NewUserSpecifiedResourceIDSegment("gatewayName", "gatewayName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("p2sVpnGateways", "p2sVpnGateways"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("gatewayName", "gatewayName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtualhub_ip_configuration.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_virtualhub_ip_configuration.go
@@ -3,30 +3,28 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVirtualHubIPConfiguration{}
 
 type commonIdVirtualHubIPConfiguration struct{}
 
-func (c commonIdVirtualHubIPConfiguration) id() models.ResourceID {
+func (c commonIdVirtualHubIPConfiguration) id() sdkModels.ResourceID {
 	name := "VirtualHubIPConfiguration"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("virtualHubs", "virtualHubs"),
-			models.NewUserSpecifiedResourceIDSegment("virtualHubName", "virtualHubName"),
-			models.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
-			models.NewUserSpecifiedResourceIDSegment("ipConfigName", "ipConfigName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("virtualHubs", "virtualHubs"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("virtualHubName", "virtualHubName"),
+			sdkModels.NewStaticValueResourceIDSegment("ipConfigurations", "ipConfigurations"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("ipConfigName", "ipConfigName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_job.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_job.go
@@ -3,31 +3,29 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVMwareSiteJob{}
 
 type commonIdVMwareSiteJob struct {
 }
 
-func (c commonIdVMwareSiteJob) id() models.ResourceID {
+func (c commonIdVMwareSiteJob) id() sdkModels.ResourceID {
 	name := "VMwareSiteJob"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.NewStaticValueResourceIDSegment("vmwareSites", "vmwareSites"),
-			models.NewUserSpecifiedResourceIDSegment("vmwareSiteName", "vmwareSiteName"),
-			models.NewStaticValueResourceIDSegment("jobs", "jobs"),
-			models.NewUserSpecifiedResourceIDSegment("jobName", "jobName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			sdkModels.NewStaticValueResourceIDSegment("vmwareSites", "vmwareSites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("vmwareSiteName", "vmwareSiteName"),
+			sdkModels.NewStaticValueResourceIDSegment("jobs", "jobs"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("jobName", "jobName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_machine.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_machine.go
@@ -3,31 +3,29 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVMwareSiteMachine{}
 
 type commonIdVMwareSiteMachine struct {
 }
 
-func (c commonIdVMwareSiteMachine) id() models.ResourceID {
+func (c commonIdVMwareSiteMachine) id() sdkModels.ResourceID {
 	name := "VMwareSiteMachine"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.NewStaticValueResourceIDSegment("vmwareSites", "vmwareSites"),
-			models.NewUserSpecifiedResourceIDSegment("vmwareSiteName", "vmwareSiteName"),
-			models.NewStaticValueResourceIDSegment("machines", "machines"),
-			models.NewUserSpecifiedResourceIDSegment("machineName", "machineName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			sdkModels.NewStaticValueResourceIDSegment("vmwareSites", "vmwareSites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("vmwareSiteName", "vmwareSiteName"),
+			sdkModels.NewStaticValueResourceIDSegment("machines", "machines"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("machineName", "machineName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_runasaccount.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vmware_site_runasaccount.go
@@ -3,31 +3,29 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVMwareSiteRunAsAccount{}
 
 type commonIdVMwareSiteRunAsAccount struct {
 }
 
-func (c commonIdVMwareSiteRunAsAccount) id() models.ResourceID {
+func (c commonIdVMwareSiteRunAsAccount) id() sdkModels.ResourceID {
 	name := "VMwareSiteRunAsAccount"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
-			models.NewStaticValueResourceIDSegment("vmwareSites", "vmwareSites"),
-			models.NewUserSpecifiedResourceIDSegment("vmwareSiteName", "vmwareSiteName"),
-			models.NewStaticValueResourceIDSegment("runAsAccounts", "runAsAccounts"),
-			models.NewUserSpecifiedResourceIDSegment("runAsAccountName", "runAsAccountName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.OffAzure"),
+			sdkModels.NewStaticValueResourceIDSegment("vmwareSites", "vmwareSites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("vmwareSiteName", "vmwareSiteName"),
+			sdkModels.NewStaticValueResourceIDSegment("runAsAccounts", "runAsAccounts"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("runAsAccountName", "runAsAccountName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vpn_gateway_vpn_connection.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_id_vpn_gateway_vpn_connection.go
@@ -3,30 +3,28 @@
 
 package resourceids
 
-import (
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
-)
+import sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 
 var _ commonIdMatcher = commonIdVPNConnection{}
 
 type commonIdVPNConnection struct{}
 
-func (c commonIdVPNConnection) id() models.ResourceID {
+func (c commonIdVPNConnection) id() sdkModels.ResourceID {
 	name := "VPNConnection"
-	return models.ResourceID{
+	return sdkModels.ResourceID{
 		CommonIDAlias: &name,
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("providers", "providers"),
-			models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
-			models.NewStaticValueResourceIDSegment("vpnGateways", "vpnGateways"),
-			models.NewUserSpecifiedResourceIDSegment("gatewayName", "gatewayName"),
-			models.NewStaticValueResourceIDSegment("vpnConnections", "vpnConnections"),
-			models.NewUserSpecifiedResourceIDSegment("connectionName", "connectionName"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.Network"),
+			sdkModels.NewStaticValueResourceIDSegment("vpnGateways", "vpnGateways"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("gatewayName", "gatewayName"),
+			sdkModels.NewStaticValueResourceIDSegment("vpnConnections", "vpnConnections"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("connectionName", "connectionName"),
 		},
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/common_ids.go
@@ -5,12 +5,12 @@ package resourceids
 
 import (
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 type commonIdMatcher interface {
 	// id returns the Resource ID for this Common ID
-	id() models.ResourceID
+	id() sdkModels.ResourceID
 }
 
 var commonIdTypes = []commonIdMatcher{
@@ -107,8 +107,8 @@ var commonIdTypes = []commonIdMatcher{
 	commonIdAppServicePlan{},
 }
 
-func switchOutCommonResourceIDsAsNeeded(input []models.ResourceID) []models.ResourceID {
-	output := make([]models.ResourceID, 0)
+func switchOutCommonResourceIDsAsNeeded(input []sdkModels.ResourceID) []sdkModels.ResourceID {
+	output := make([]sdkModels.ResourceID, 0)
 
 	for _, value := range input {
 		// TODO: we should expose a `[]CommonIDs` function from `hashicorp/go-azure-helpers` so that we can reuse these

--- a/tools/importer-rest-api-specs/components/parser/resourceids/distinct_resource_ids.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/distinct_resource_ids.go
@@ -7,13 +7,13 @@ import (
 	"sort"
 
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
-func (p *Parser) distinctResourceIds(input map[string]processedResourceId) ([]models.ResourceID, map[string]models.SDKConstant) {
-	out := make([]models.ResourceID, 0)
+func (p *Parser) distinctResourceIds(input map[string]processedResourceId) ([]sdkModels.ResourceID, map[string]sdkModels.SDKConstant) {
+	out := make([]sdkModels.ResourceID, 0)
 
-	allConstants := make(map[string]models.SDKConstant)
+	allConstants := make(map[string]sdkModels.SDKConstant)
 	for _, operation := range input {
 		if operation.segments == nil {
 			continue
@@ -31,7 +31,7 @@ func (p *Parser) distinctResourceIds(input map[string]processedResourceId) ([]mo
 		}
 		sort.Strings(constantNames)
 
-		item := models.ResourceID{
+		item := sdkModels.ResourceID{
 			CommonIDAlias: nil,
 			ConstantNames: constantNames,
 			Segments:      *operation.segments,

--- a/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/generate_names_test.go
@@ -9,149 +9,149 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
-var subscriptionResourceId = models.ResourceID{
+var subscriptionResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
 	},
 }
-var resourceGroupResourceId = models.ResourceID{
+var resourceGroupResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
 	},
 }
-var managementGroupResourceId = models.ResourceID{
+var managementGroupResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftManagement", "Microsoft.Management"),
-		models.NewStaticValueResourceIDSegment("staticManagementGroups", "managementGroups"),
-		models.NewUserSpecifiedResourceIDSegment("name", "name"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftManagement", "Microsoft.Management"),
+		sdkModels.NewStaticValueResourceIDSegment("staticManagementGroups", "managementGroups"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("name", "name"),
 	},
 }
-var virtualMachineResourceId = models.ResourceID{
+var virtualMachineResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftCompute", "Microsoft.Compute"),
-		models.NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
-		models.NewUserSpecifiedResourceIDSegment("virtualMachineName", "virtualMachineValue"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftCompute", "Microsoft.Compute"),
+		sdkModels.NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineName", "virtualMachineValue"),
 	},
 }
-var virtualMachineExtensionResourceId = models.ResourceID{
+var virtualMachineExtensionResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftCompute", "Microsoft.Compute"),
-		models.NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
-		models.NewUserSpecifiedResourceIDSegment("virtualMachineName", "virtualMachineValue"),
-		models.NewStaticValueResourceIDSegment("staticExtensions", "extensions"),
-		models.NewUserSpecifiedResourceIDSegment("extensionName", "extensionValue"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftCompute", "Microsoft.Compute"),
+		sdkModels.NewStaticValueResourceIDSegment("staticVirtualMachines", "virtualMachines"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("virtualMachineName", "virtualMachineValue"),
+		sdkModels.NewStaticValueResourceIDSegment("staticExtensions", "extensions"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("extensionName", "extensionValue"),
 	},
 }
-var virtualNetworkExtensionResourceId = models.ResourceID{
+var virtualNetworkExtensionResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftNetwork", "Microsoft.Network"),
-		models.NewStaticValueResourceIDSegment("staticExtensions", "extensions"),
-		models.NewUserSpecifiedResourceIDSegment("extensionName", "extensionValue"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftNetwork", "Microsoft.Network"),
+		sdkModels.NewStaticValueResourceIDSegment("staticExtensions", "extensions"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("extensionName", "extensionValue"),
 	},
 }
-var scopedMonitorResourceId = models.ResourceID{
+var scopedMonitorResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewScopeResourceIDSegment("scope"),
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftMonitor", "Microsoft.Monitor"),
-		models.NewStaticValueResourceIDSegment("staticExtensions", "extensions"),
-		models.NewUserSpecifiedResourceIDSegment("extensionName", "extensionValue"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewScopeResourceIDSegment("scope"),
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftMonitor", "Microsoft.Monitor"),
+		sdkModels.NewStaticValueResourceIDSegment("staticExtensions", "extensions"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("extensionName", "extensionValue"),
 	},
 }
-var signalRResourceId = models.ResourceID{
+var signalRResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftSignalRService", "Microsoft.SignalRService"),
-		models.NewStaticValueResourceIDSegment("staticSignalR", "SignalR"),
-		models.NewUserSpecifiedResourceIDSegment("resourceName", "resourceValue"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftSignalRService", "Microsoft.SignalRService"),
+		sdkModels.NewStaticValueResourceIDSegment("staticSignalR", "SignalR"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("resourceName", "resourceValue"),
 	},
 }
-var eventHubSkuResourceId = models.ResourceID{
+var eventHubSkuResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftEventHub", "Microsoft.EventHub"),
-		models.NewStaticValueResourceIDSegment("staticSku", "sku"),
-		models.NewUserSpecifiedResourceIDSegment("sku", "sku"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftEventHub", "Microsoft.EventHub"),
+		sdkModels.NewStaticValueResourceIDSegment("staticSku", "sku"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("sku", "sku"),
 	},
 }
-var trafficManagerProfileResourceId = models.ResourceID{
+var trafficManagerProfileResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{
 		"EndpointType",
 	},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftNetwork", "Microsoft.Network"),
-		models.NewStaticValueResourceIDSegment("staticTrafficManagerProfiles", "trafficManagerProfiles"),
-		models.NewUserSpecifiedResourceIDSegment("profileName", "profileValue"),
-		models.NewConstantResourceIDSegment("endpointType", "EndpointType", "nestedEndpoints"),
-		models.NewUserSpecifiedResourceIDSegment("endpointName", "endpointValue"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftNetwork", "Microsoft.Network"),
+		sdkModels.NewStaticValueResourceIDSegment("staticTrafficManagerProfiles", "trafficManagerProfiles"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("profileName", "profileValue"),
+		sdkModels.NewConstantResourceIDSegment("endpointType", "EndpointType", "nestedEndpoints"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("endpointName", "endpointValue"),
 	},
 }
-var redisPatchSchedulesResourceId = models.ResourceID{
+var redisPatchSchedulesResourceId = sdkModels.ResourceID{
 	ConstantNames: []string{
 		"Default",
 	},
-	Segments: []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-		models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-		models.NewResourceProviderResourceIDSegment("staticMicrosoftCache", "Microsoft.Cache"),
-		models.NewStaticValueResourceIDSegment("staticRedis", "redis"),
-		models.NewUserSpecifiedResourceIDSegment("name", "name"),
-		models.NewStaticValueResourceIDSegment("staticPatchSchedules", "patchSchedules"),
-		models.NewConstantResourceIDSegment("default", "Default", "first"),
+	Segments: []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftCache", "Microsoft.Cache"),
+		sdkModels.NewStaticValueResourceIDSegment("staticRedis", "redis"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("name", "name"),
+		sdkModels.NewStaticValueResourceIDSegment("staticPatchSchedules", "patchSchedules"),
+		sdkModels.NewConstantResourceIDSegment("default", "Default", "first"),
 	},
 }
 
 func TestResourceIDNamingEmpty(t *testing.T) {
 	uriToParsedOperation := map[string]ParsedOperation{}
-	actualNamesToIds, err := generateNamesForResourceIds([]models.ResourceID{}, uriToParsedOperation)
+	actualNamesToIds, err := generateNamesForResourceIds([]sdkModels.ResourceID{}, uriToParsedOperation)
 	if err != nil {
 		t.Fatalf("error: %+v", err)
 		return
@@ -163,10 +163,10 @@ func TestResourceIDNamingEmpty(t *testing.T) {
 }
 
 func TestResourceIDNamingSubscriptionId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		subscriptionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"SubscriptionId": subscriptionResourceId,
 	}
 
@@ -183,12 +183,12 @@ func TestResourceIDNamingSubscriptionId(t *testing.T) {
 }
 
 func TestResourceIDNamingSubscriptionIdAndSuffix(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		// intentionally here twice
 		subscriptionResourceId,
 		subscriptionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"SubscriptionId": subscriptionResourceId,
 	}
 
@@ -205,10 +205,10 @@ func TestResourceIDNamingSubscriptionIdAndSuffix(t *testing.T) {
 }
 
 func TestResourceIDNamingResourceGroupId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		resourceGroupResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"ResourceGroupId": resourceGroupResourceId,
 	}
 
@@ -225,12 +225,12 @@ func TestResourceIDNamingResourceGroupId(t *testing.T) {
 }
 
 func TestResourceIDNamingResourceGroupIdAndSuffix(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		// intentionally in here twice
 		resourceGroupResourceId,
 		resourceGroupResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"ResourceGroupId": resourceGroupResourceId,
 	}
 
@@ -247,10 +247,10 @@ func TestResourceIDNamingResourceGroupIdAndSuffix(t *testing.T) {
 }
 
 func TestResourceIDNamingManagementGroupId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		managementGroupResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"ManagementGroupId": managementGroupResourceId,
 	}
 
@@ -267,12 +267,12 @@ func TestResourceIDNamingManagementGroupId(t *testing.T) {
 }
 
 func TestResourceIDNamingManagementGroupIdAndSuffix(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		// intentionally here twice
 		managementGroupResourceId,
 		managementGroupResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"ManagementGroupId": managementGroupResourceId,
 	}
 
@@ -289,10 +289,10 @@ func TestResourceIDNamingManagementGroupIdAndSuffix(t *testing.T) {
 }
 
 func TestResourceIDNamingEventHubSkuId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		eventHubSkuResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"SkuId": eventHubSkuResourceId,
 	}
 
@@ -309,17 +309,17 @@ func TestResourceIDNamingEventHubSkuId(t *testing.T) {
 }
 
 func TestResourceIDNamingTopLevelScope(t *testing.T) {
-	scopeResourceId := models.ResourceID{
+	scopeResourceId := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewScopeResourceIDSegment("scope"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewScopeResourceIDSegment("scope"),
 		},
 	}
 
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		scopeResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"ScopeId": scopeResourceId,
 	}
 
@@ -336,26 +336,26 @@ func TestResourceIDNamingTopLevelScope(t *testing.T) {
 }
 
 func TestResourceIDNamingContainingAConstant(t *testing.T) {
-	dnsResourceId := models.ResourceID{
+	dnsResourceId := sdkModels.ResourceID{
 		ConstantNames: []string{
 			"DnsRecordType",
 		},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftNetwork", "Microsoft.Network"),
-			models.NewConstantResourceIDSegment("recordType", "DnsRecordType", "A"),
-			models.NewUserSpecifiedResourceIDSegment("recordName", "recordValue"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftNetwork", "Microsoft.Network"),
+			sdkModels.NewConstantResourceIDSegment("recordType", "DnsRecordType", "A"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("recordName", "recordValue"),
 		},
 	}
 
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		dnsResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"RecordTypeId": dnsResourceId,
 	}
 
@@ -372,28 +372,28 @@ func TestResourceIDNamingContainingAConstant(t *testing.T) {
 }
 
 func TestResourceIDNamingContainingAConstantAndSuffix(t *testing.T) {
-	dnsResourceId := models.ResourceID{
+	dnsResourceId := sdkModels.ResourceID{
 		ConstantNames: []string{
 			"DnsRecordType",
 		},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftNetwork", "Microsoft.Network"),
-			models.NewConstantResourceIDSegment("recordType", "DnsRecordType", "AAAA"),
-			models.NewUserSpecifiedResourceIDSegment("recordName", "recordValue"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftNetwork", "Microsoft.Network"),
+			sdkModels.NewConstantResourceIDSegment("recordType", "DnsRecordType", "AAAA"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("recordName", "recordValue"),
 		},
 	}
 
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		// intentionally in here twice
 		dnsResourceId,
 		dnsResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"RecordTypeId": dnsResourceId,
 	}
 
@@ -410,10 +410,10 @@ func TestResourceIDNamingContainingAConstantAndSuffix(t *testing.T) {
 }
 
 func TestResourceIdNamingTopLevelResourceId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		virtualMachineResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"VirtualMachineId": virtualMachineResourceId,
 	}
 
@@ -430,11 +430,11 @@ func TestResourceIdNamingTopLevelResourceId(t *testing.T) {
 }
 
 func TestResourceIdNamingTopLevelAndNestedResourceId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		virtualMachineResourceId,
 		virtualMachineExtensionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"VirtualMachineId": virtualMachineResourceId,
 		"ExtensionId":      virtualMachineExtensionResourceId,
 	}
@@ -452,10 +452,10 @@ func TestResourceIdNamingTopLevelAndNestedResourceId(t *testing.T) {
 }
 
 func TestResourceIdNamingNestedResourceId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		virtualMachineExtensionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"ExtensionId": virtualMachineExtensionResourceId,
 	}
 
@@ -472,10 +472,10 @@ func TestResourceIdNamingNestedResourceId(t *testing.T) {
 }
 
 func TestResourceIdNamingResourceUnderScope(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		scopedMonitorResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"ScopedExtensionId": scopedMonitorResourceId,
 	}
 
@@ -492,11 +492,11 @@ func TestResourceIdNamingResourceUnderScope(t *testing.T) {
 }
 
 func TestResourceIdNamingConflictingTwoLevels(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		virtualNetworkExtensionResourceId,
 		virtualMachineExtensionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"VirtualMachineExtensionId": virtualMachineExtensionResourceId,
 		"ExtensionId":               virtualNetworkExtensionResourceId,
 	}
@@ -514,11 +514,11 @@ func TestResourceIdNamingConflictingTwoLevels(t *testing.T) {
 }
 
 func TestResourceIdNamingConflictingWithUpdatingOperation(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		virtualNetworkExtensionResourceId,
 		virtualMachineExtensionResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"VirtualMachineExtensionId": virtualMachineExtensionResourceId,
 		"ExtensionId":               virtualNetworkExtensionResourceId,
 	}
@@ -553,88 +553,88 @@ func TestResourceIdNamingConflictingWithUpdatingOperation(t *testing.T) {
 }
 
 func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
-	workerPoolInstanceResourceId := models.ResourceID{
+	workerPoolInstanceResourceId := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftWeb", "Microsoft.Web"),
-			models.NewStaticValueResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
-			models.NewUserSpecifiedResourceIDSegment("name", "name"),
-			models.NewStaticValueResourceIDSegment("staticWorkerPools", "workerPools"),
-			models.NewUserSpecifiedResourceIDSegment("workerPoolName", "workerPoolValue"),
-			models.NewStaticValueResourceIDSegment("instances", "instances"),
-			models.NewUserSpecifiedResourceIDSegment("instance", "instanceValue"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftWeb", "Microsoft.Web"),
+			sdkModels.NewStaticValueResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("name", "name"),
+			sdkModels.NewStaticValueResourceIDSegment("staticWorkerPools", "workerPools"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("workerPoolName", "workerPoolValue"),
+			sdkModels.NewStaticValueResourceIDSegment("instances", "instances"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("instance", "instanceValue"),
 		},
 	}
-	multiRolePoolInstanceResourceId := models.ResourceID{
+	multiRolePoolInstanceResourceId := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftWeb", "Microsoft.Web"),
-			models.NewStaticValueResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
-			models.NewUserSpecifiedResourceIDSegment("name", "name"),
-			models.NewStaticValueResourceIDSegment("multiRolePools", "multiRolePools"),
-			models.NewStaticValueResourceIDSegment("default", "default"),
-			models.NewStaticValueResourceIDSegment("instances", "instances"),
-			models.NewUserSpecifiedResourceIDSegment("instance", "instance"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftWeb", "Microsoft.Web"),
+			sdkModels.NewStaticValueResourceIDSegment("hostingEnvironments", "hostingEnvironments"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("name", "name"),
+			sdkModels.NewStaticValueResourceIDSegment("multiRolePools", "multiRolePools"),
+			sdkModels.NewStaticValueResourceIDSegment("default", "default"),
+			sdkModels.NewStaticValueResourceIDSegment("instances", "instances"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("instance", "instance"),
 		},
 	}
-	slotInstanceProcessModuleResourceId := models.ResourceID{
+	slotInstanceProcessModuleResourceId := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftWeb", "Microsoft.Web"),
-			models.NewStaticValueResourceIDSegment("sites", "sites"),
-			models.NewUserSpecifiedResourceIDSegment("name", "name"),
-			models.NewStaticValueResourceIDSegment("slots", "slots"),
-			models.NewUserSpecifiedResourceIDSegment("slot", "slot"),
-			models.NewStaticValueResourceIDSegment("instances", "instances"),
-			models.NewUserSpecifiedResourceIDSegment("instanceId", "instanceId"),
-			models.NewStaticValueResourceIDSegment("processes", "processes"),
-			models.NewUserSpecifiedResourceIDSegment("processId", "processId"),
-			models.NewStaticValueResourceIDSegment("modules", "modules"),
-			models.NewUserSpecifiedResourceIDSegment("baseAddress", "baseAddress"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftWeb", "Microsoft.Web"),
+			sdkModels.NewStaticValueResourceIDSegment("sites", "sites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("name", "name"),
+			sdkModels.NewStaticValueResourceIDSegment("slots", "slots"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("slot", "slot"),
+			sdkModels.NewStaticValueResourceIDSegment("instances", "instances"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("instanceId", "instanceId"),
+			sdkModels.NewStaticValueResourceIDSegment("processes", "processes"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("processId", "processId"),
+			sdkModels.NewStaticValueResourceIDSegment("modules", "modules"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("baseAddress", "baseAddress"),
 		},
 	}
-	instanceProcessModuleResourceId := models.ResourceID{
+	instanceProcessModuleResourceId := sdkModels.ResourceID{
 		ConstantNames: []string{},
-		Segments: []models.ResourceIDSegment{
-			models.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
-			models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-			models.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
-			models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-			models.NewStaticValueResourceIDSegment("staticProviders", "providers"),
-			models.NewResourceProviderResourceIDSegment("staticMicrosoftWeb", "Microsoft.Web"),
-			models.NewStaticValueResourceIDSegment("sites", "sites"),
-			models.NewUserSpecifiedResourceIDSegment("name", "name"),
-			models.NewStaticValueResourceIDSegment("instances", "instances"),
-			models.NewUserSpecifiedResourceIDSegment("instanceId", "instanceId"),
-			models.NewStaticValueResourceIDSegment("processes", "processes"),
-			models.NewUserSpecifiedResourceIDSegment("processId", "processId"),
-			models.NewStaticValueResourceIDSegment("modules", "modules"),
-			models.NewUserSpecifiedResourceIDSegment("baseAddress", "baseAddress"),
+		Segments: []sdkModels.ResourceIDSegment{
+			sdkModels.NewStaticValueResourceIDSegment("staticSubscriptions", "subscriptions"),
+			sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+			sdkModels.NewStaticValueResourceIDSegment("staticResourceGroups", "resourceGroups"),
+			sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+			sdkModels.NewStaticValueResourceIDSegment("staticProviders", "providers"),
+			sdkModels.NewResourceProviderResourceIDSegment("staticMicrosoftWeb", "Microsoft.Web"),
+			sdkModels.NewStaticValueResourceIDSegment("sites", "sites"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("name", "name"),
+			sdkModels.NewStaticValueResourceIDSegment("instances", "instances"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("instanceId", "instanceId"),
+			sdkModels.NewStaticValueResourceIDSegment("processes", "processes"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("processId", "processId"),
+			sdkModels.NewStaticValueResourceIDSegment("modules", "modules"),
+			sdkModels.NewUserSpecifiedResourceIDSegment("baseAddress", "baseAddress"),
 		},
 	}
 
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		workerPoolInstanceResourceId,
 		multiRolePoolInstanceResourceId,
 		slotInstanceProcessModuleResourceId,
 		instanceProcessModuleResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"WorkerPoolInstanceId": workerPoolInstanceResourceId,
 		"InstanceId":           multiRolePoolInstanceResourceId,
 		"ProcessModuleId":      slotInstanceProcessModuleResourceId,
@@ -654,10 +654,10 @@ func TestResourceIdNamingConflictingMultipleLevels(t *testing.T) {
 }
 
 func TestResourceIdNamingSignalRId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		signalRResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"SignalRId": signalRResourceId,
 	}
 
@@ -674,10 +674,10 @@ func TestResourceIdNamingSignalRId(t *testing.T) {
 }
 
 func TestResourceIdNamingTrafficManagerEndpoint(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		trafficManagerProfileResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"EndpointTypeId": trafficManagerProfileResourceId,
 	}
 
@@ -694,10 +694,10 @@ func TestResourceIdNamingTrafficManagerEndpoint(t *testing.T) {
 }
 
 func TestResourceIDNamingRedisDefaultId(t *testing.T) {
-	input := []models.ResourceID{
+	input := []sdkModels.ResourceID{
 		redisPatchSchedulesResourceId,
 	}
-	expectedNamesToIds := map[string]models.ResourceID{
+	expectedNamesToIds := map[string]sdkModels.ResourceID{
 		"DefaultId": redisPatchSchedulesResourceId,
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/resourceids/helpers.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/helpers.go
@@ -7,21 +7,21 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/cleanup"
 )
 
-func normalizedResourceManagerResourceId(pri models.ResourceID) string {
+func normalizedResourceManagerResourceId(pri sdkModels.ResourceID) string {
 	segments := segmentsWithoutUriSuffix(pri)
 	return normalizedResourceId(segments)
 }
 
-func segmentsWithoutUriSuffix(pri models.ResourceID) []models.ResourceIDSegment {
+func segmentsWithoutUriSuffix(pri sdkModels.ResourceID) []sdkModels.ResourceIDSegment {
 	segments := pri.Segments
 	lastUserValueSegment := -1
 	for i, segment := range segments {
 		// everything else technically is a user configurable component
-		if segment.Type != models.StaticResourceIDSegmentType && segment.Type != models.ResourceProviderResourceIDSegmentType {
+		if segment.Type != sdkModels.StaticResourceIDSegmentType && segment.Type != sdkModels.ResourceProviderResourceIDSegmentType {
 			lastUserValueSegment = i
 		}
 	}
@@ -32,25 +32,25 @@ func segmentsWithoutUriSuffix(pri models.ResourceID) []models.ResourceIDSegment 
 	return segments
 }
 
-func normalizedResourceId(segments []models.ResourceIDSegment) string {
+func normalizedResourceId(segments []sdkModels.ResourceIDSegment) string {
 	components := make([]string, 0)
 	for _, segment := range segments {
 		switch segment.Type {
-		case models.ResourceProviderResourceIDSegmentType:
+		case sdkModels.ResourceProviderResourceIDSegmentType:
 			{
 				normalizedSegment := cleanup.NormalizeResourceProviderName(*segment.FixedValue)
 				components = append(components, normalizedSegment)
 				continue
 			}
 
-		case models.StaticResourceIDSegmentType:
+		case sdkModels.StaticResourceIDSegmentType:
 			{
 				normalizedSegment := cleanup.NormalizeSegment(*segment.FixedValue, true)
 				components = append(components, normalizedSegment)
 				continue
 			}
 
-		case models.ConstantResourceIDSegmentType, models.ResourceGroupResourceIDSegmentType, models.ScopeResourceIDSegmentType, models.SubscriptionIDResourceIDSegmentType, models.UserSpecifiedResourceIDSegmentType:
+		case sdkModels.ConstantResourceIDSegmentType, sdkModels.ResourceGroupResourceIDSegmentType, sdkModels.ScopeResourceIDSegmentType, sdkModels.SubscriptionIDResourceIDSegmentType, sdkModels.UserSpecifiedResourceIDSegmentType:
 			// e.g. {example}
 			normalizedSegment := segment.Name
 			normalizedSegment = cleanup.NormalizeReservedKeywords(segment.Name)
@@ -65,7 +65,7 @@ func normalizedResourceId(segments []models.ResourceIDSegment) string {
 	return fmt.Sprintf("/%s", strings.Join(components, "/"))
 }
 
-func ResourceIdsMatch(first, second models.ResourceID) bool {
+func ResourceIdsMatch(first, second sdkModels.ResourceID) bool {
 	if len(first.Segments) != len(second.Segments) {
 		return false
 	}
@@ -80,16 +80,16 @@ func ResourceIdsMatch(first, second models.ResourceID) bool {
 		// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}
 		// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}
 		// as such providing they're both user specified segments (and the rest is the same) then they're the same
-		if first.Type == models.ResourceGroupResourceIDSegmentType || first.Type == models.SubscriptionIDResourceIDSegmentType || first.Type == models.UserSpecifiedResourceIDSegmentType {
+		if first.Type == sdkModels.ResourceGroupResourceIDSegmentType || first.Type == sdkModels.SubscriptionIDResourceIDSegmentType || first.Type == sdkModels.UserSpecifiedResourceIDSegmentType {
 			continue
 		}
 
 		// With a Scope the key doesn't matter as much as that it's a Scope, so presuming the types match (above) we're good.
-		if first.Type == models.ScopeResourceIDSegmentType {
+		if first.Type == sdkModels.ScopeResourceIDSegmentType {
 			continue
 		}
 
-		if first.Type == models.ConstantResourceIDSegmentType {
+		if first.Type == sdkModels.ConstantResourceIDSegmentType {
 			if first.ConstantReference != nil && second.ConstantReference == nil {
 				return false
 			}
@@ -104,7 +104,7 @@ func ResourceIdsMatch(first, second models.ResourceID) bool {
 			continue
 		}
 
-		if first.Type == models.ResourceProviderResourceIDSegmentType || first.Type == models.StaticResourceIDSegmentType {
+		if first.Type == sdkModels.ResourceProviderResourceIDSegmentType || first.Type == sdkModels.StaticResourceIDSegmentType {
 			if first.FixedValue != nil && second.FixedValue == nil {
 				return false
 			}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/interface.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/interface.go
@@ -5,19 +5,15 @@ package resourceids
 
 import (
 	"github.com/go-openapi/analysis"
-	"github.com/hashicorp/go-hclog"
 )
 
 type Parser struct {
-	logger hclog.Logger
-
 	swaggerSpecExpanded *analysis.Spec
 }
 
 // NewParser returns a Parser instance which can be used to parse Resource IDs
-func NewParser(logger hclog.Logger, swaggerSpecExpanded *analysis.Spec) *Parser {
+func NewParser(swaggerSpecExpanded *analysis.Spec) *Parser {
 	return &Parser{
-		logger:              logger,
 		swaggerSpecExpanded: swaggerSpecExpanded,
 	}
 }

--- a/tools/importer-rest-api-specs/components/parser/resourceids/models.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/models.go
@@ -6,7 +6,6 @@ package resourceids
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
@@ -36,7 +35,7 @@ type ParseResult struct {
 	Constants map[string]models.SDKConstant
 }
 
-func (r *ParseResult) Append(other ParseResult, logger hclog.Logger) error {
+func (r *ParseResult) Append(other ParseResult) error {
 	intermediate := internal.ParseResult{
 		Constants: map[string]models.SDKConstant{},
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/models.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/models.go
@@ -6,13 +6,13 @@ package resourceids
 import (
 	"fmt"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 )
 
 type ParsedOperation struct {
 	// ResourceId is the ParsedResourceId object for this Resource Id
-	ResourceId *models.ResourceID
+	ResourceId *sdkModels.ResourceID
 
 	// ResourceIdName is the name of the ResourceID
 	ResourceIdName *string
@@ -29,15 +29,15 @@ type ParseResult struct {
 	OperationIdsToParsedResourceIds map[string]ParsedOperation
 
 	// NamesToResourceIDs is a mapping of the ResourceID Names to the parsed Resource ID objects
-	NamesToResourceIDs map[string]models.ResourceID
+	NamesToResourceIDs map[string]sdkModels.ResourceID
 
 	// Constants is a map of Name - ConstantDetails found within the Resource IDs
-	Constants map[string]models.SDKConstant
+	Constants map[string]sdkModels.SDKConstant
 }
 
 func (r *ParseResult) Append(other ParseResult) error {
 	intermediate := internal.ParseResult{
-		Constants: map[string]models.SDKConstant{},
+		Constants: map[string]sdkModels.SDKConstant{},
 	}
 	intermediate.AppendConstants(r.Constants)
 	intermediate.AppendConstants(other.Constants)
@@ -74,7 +74,7 @@ func (r *ParseResult) Append(other ParseResult) error {
 
 		// since we have a new list of Resource IDs we also need to go through and regenerate the names
 		// as we may have conflicts etc
-		combinedResourceIds := make([]models.ResourceID, 0)
+		combinedResourceIds := make([]sdkModels.ResourceID, 0)
 		for _, v := range r.NamesToResourceIDs {
 			combinedResourceIds = append(combinedResourceIds, v)
 		}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/spec"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 func TestParseResourceIDFromOperation_ConstantSingle(t *testing.T) {
@@ -65,9 +65,9 @@ func TestParseResourceIDFromOperation_ConstantMultiple(t *testing.T) {
 	if resourceId.segments == nil {
 		t.Fatalf("expected 2 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("planets", "planets"),
-		models.NewConstantResourceIDSegment("planetName", "NameOfPlanet", "Earth"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("planets", "planets"),
+		sdkModels.NewConstantResourceIDSegment("planetName", "NameOfPlanet", "Earth"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 
@@ -108,9 +108,9 @@ func TestParseResourceIDFromOperation_InvalidSegmentDefaultGetsTransformed(t *te
 	if resourceId.segments == nil {
 		t.Fatalf("expected 2 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("defaults", "defaults"),
-		models.NewUserSpecifiedResourceIDSegment("defaultName", "defaultName"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("defaults", "defaults"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("defaultName", "defaultName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 
@@ -170,9 +170,9 @@ func TestParseResourceIDFromOperation_InvalidSegmentTypeGetsTransformed(t *testi
 	if resourceId.segments == nil {
 		t.Fatalf("expected 2 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("things", "things"),
-		models.NewUserSpecifiedResourceIDSegment("typeName", "typeName"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("things", "things"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("typeName", "typeName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 
@@ -203,11 +203,11 @@ func TestParseResourceIDFromOperation_ManagementGroupId(t *testing.T) {
 	if resourceId.segments == nil {
 		t.Fatalf("expected 4 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("providers", "providers"),
-		models.NewResourceProviderResourceIDSegment("resourceProviders", "Microsoft.Management"),
-		models.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
-		models.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("resourceProviders", "Microsoft.Management"),
+		sdkModels.NewStaticValueResourceIDSegment("managementGroups", "managementGroups"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("groupId", "groupId"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -231,11 +231,11 @@ func TestParseResourceIDFromOperation_ResourceGroupId(t *testing.T) {
 	if resourceId.segments == nil {
 		t.Fatalf("expected 4 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("providers", "providers"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -259,11 +259,11 @@ func TestParseResourceIDFromOperation_ResourceGroupId_IncorrectSegment(t *testin
 	if resourceId.segments == nil {
 		t.Fatalf("expected 4 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("providers", "providers"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -287,8 +287,8 @@ func TestParseResourceIDFromOperation_Scope(t *testing.T) {
 	if resourceId.segments == nil {
 		t.Fatalf("expected 1 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewScopeResourceIDSegment("resourceId"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewScopeResourceIDSegment("resourceId"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -312,9 +312,9 @@ func TestParseResourceIDFromOperation_SubscriptionId(t *testing.T) {
 	if resourceId.segments == nil {
 		t.Fatalf("expected 2 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("providers", "providers"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
@@ -356,20 +356,20 @@ func TestParseResourceIDFromOperation_UserAssignedIdentityId(t *testing.T) {
 	if resourceId.segments == nil {
 		t.Fatalf("expected 8 segments but got 0")
 	}
-	expectedSegments := []models.ResourceIDSegment{
-		models.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
-		models.NewSubscriptionIDResourceIDSegment("subscriptionId"),
-		models.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
-		models.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
-		models.NewStaticValueResourceIDSegment("providers", "providers"),
-		models.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
-		models.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
-		models.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.ManagedIdentity"),
+		sdkModels.NewStaticValueResourceIDSegment("userAssignedIdentities", "userAssignedIdentities"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("resourceName", "resourceName"),
 	}
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
 
-func validateSegmentsMatch(t *testing.T, actual []models.ResourceIDSegment, expected []models.ResourceIDSegment) {
+func validateSegmentsMatch(t *testing.T, actual []sdkModels.ResourceIDSegment, expected []sdkModels.ResourceIDSegment) {
 	if len(actual) != len(expected) {
 		t.Fatalf("expected there to be %d segments but got %d", len(expected), len(actual))
 	}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments_test.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parse_segments_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/go-openapi/spec"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
@@ -23,7 +22,7 @@ func TestParseResourceIDFromOperation_ConstantSingle(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation").AddParam(param)
 	uri := "/planets/{planetName}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -51,7 +50,7 @@ func TestParseResourceIDFromOperation_ConstantMultiple(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation").AddParam(param)
 	uri := "/planets/{planetName}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -94,7 +93,7 @@ func TestParseResourceIDFromOperation_InvalidSegmentDefaultGetsTransformed(t *te
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/defaults/{default}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -129,7 +128,7 @@ func TestParseResourceIDFromOperation_InvalidSegmentDefaultAsStaticValueGetsLeft
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/default"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -156,7 +155,7 @@ func TestParseResourceIDFromOperation_InvalidSegmentTypeGetsTransformed(t *testi
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/things/{type}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -189,7 +188,7 @@ func TestParseResourceIDFromOperation_ManagementGroupId(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/providers/Microsoft.Management/managementGroups/{groupId}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -217,7 +216,7 @@ func TestParseResourceIDFromOperation_ResourceGroupId(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -245,7 +244,7 @@ func TestParseResourceIDFromOperation_ResourceGroupId_IncorrectSegment(t *testin
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -273,7 +272,7 @@ func TestParseResourceIDFromOperation_Scope(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/{resourceId}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -298,7 +297,7 @@ func TestParseResourceIDFromOperation_SubscriptionId(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/subscriptions/{subscriptionId}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -324,7 +323,7 @@ func TestParseResourceIDFromOperation_UriSuffixOnly(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/someUri"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
@@ -342,7 +341,7 @@ func TestParseResourceIDFromOperation_UserAssignedIdentityId(t *testing.T) {
 	swagger := spec.NewOperation("Example_Operation")
 	uri := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{resourceName}"
 
-	parser := NewParser(hclog.NewNullLogger(), nil)
+	parser := NewParser(nil)
 	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
 	if err != nil {
 		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parser.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 )
 
@@ -51,7 +51,7 @@ func (p *Parser) Parse() (*ParseResult, error) {
 	}, nil
 }
 
-func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSegments map[string]processedResourceId, namesToResourceIds map[string]models.ResourceID) (*map[string]ParsedOperation, error) {
+func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSegments map[string]processedResourceId, namesToResourceIds map[string]sdkModels.ResourceID) (*map[string]ParsedOperation, error) {
 	output := make(map[string]ParsedOperation)
 
 	for operationId, operation := range operationIdsToSegments {
@@ -73,7 +73,7 @@ func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSe
 		}
 		sort.Strings(constantNames)
 
-		placeholder := models.ResourceID{
+		placeholder := sdkModels.ResourceID{
 			ConstantNames: constantNames,
 			Segments:      *operation.segments,
 		}
@@ -81,7 +81,7 @@ func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSe
 		found := false
 		for name, resourceId := range namesToResourceIds {
 			// NOTE: we intentionally use an empty `id` here to avoid comparing on the Alias
-			other := models.ResourceID{
+			other := sdkModels.ResourceID{
 				ConstantNames: resourceId.ConstantNames,
 				Segments:      resourceId.Segments,
 			}

--- a/tools/importer-rest-api-specs/components/parser/resourceids/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/resourceids/parser.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 )
 
 // Parse takes a list of Swagger Resources and returns a ParseResult, containing
@@ -15,29 +16,29 @@ import (
 func (p *Parser) Parse() (*ParseResult, error) {
 	// 1. Go through and map the Operation IDs to the parsed Resource ID
 	// (which includes the Resource ID and any URISuffix as needed)
-	p.logger.Trace("Parsing the segments for each operation..")
+	logging.Tracef("Parsing the segments for each operation..")
 	operationIdsToSegments, err := p.parseSegmentsForEachOperation()
 	if err != nil {
 		return nil, fmt.Errorf("parsing the segments for each operation: %+v", err)
 	}
 
 	// 2. Process the list of parsed segments to obtain a unique list of Resource IDs
-	p.logger.Trace("Determining the list of unique Resource IDs from the parsed input")
+	logging.Tracef("Determining the list of unique Resource IDs from the parsed input")
 	uniqueResourceIds, distinctConstants := p.distinctResourceIds(*operationIdsToSegments)
 
 	// 3. Then we need to find any Common Resource IDs and switch those references out
-	p.logger.Trace("Generating Names for Resource IDs..")
+	logging.Tracef("Generating Names for Resource IDs..")
 	resourceIds := switchOutCommonResourceIDsAsNeeded(uniqueResourceIds)
 
 	// 4. We then need to generate a unique Resource ID name for each of the Resource IDs
-	p.logger.Trace("Generating Names for Resource IDs..")
+	logging.Tracef("Generating Names for Resource IDs..")
 	namesToResourceIds, err := p.generateNamesForResourceIds(resourceIds, nil)
 	if err != nil {
 		return nil, fmt.Errorf("generating Names for Resource IDs: %+v", err)
 	}
 
 	// 5. Then we need to work through the list of Resource IDs and Operation IDs to map the data across
-	p.logger.Trace("Updating the Parsed Operations with the Processed ResourceIds..")
+	logging.Tracef("Updating the Parsed Operations with the Processed ResourceIds..")
 	operationIdsToResourceIds, err := p.updateParsedOperationsWithProcessedResourceIds(*operationIdsToSegments, *namesToResourceIds)
 	if err != nil {
 		return nil, fmt.Errorf("updating the parsed Operations with the Processed Resource ID information: %+v", err)
@@ -54,7 +55,7 @@ func (p *Parser) updateParsedOperationsWithProcessedResourceIds(operationIdsToSe
 	output := make(map[string]ParsedOperation)
 
 	for operationId, operation := range operationIdsToSegments {
-		p.logger.Trace(fmt.Sprintf("Processing Operation ID %q", operationId))
+		logging.Tracef("Processing Operation ID %q", operationId)
 		if operation.segments == nil {
 			if operation.uriSuffix == nil {
 				return nil, fmt.Errorf("the Operation ID %q had no Segments and no URISuffix", operationId)

--- a/tools/importer-rest-api-specs/components/parser/swagger_resources.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_resources.go
@@ -8,15 +8,15 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-
 	"github.com/go-openapi/spec"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/helpers"
 	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/commonschema"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/constants"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/internal"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser/resourceids"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 )
 
 func (d *SwaggerDefinition) parseResourcesWithinSwaggerTag(tag *string, resourceProvider *string, resourceIds resourceids.ParseResult) (*sdkModels.APIResource, error) {
@@ -194,7 +194,7 @@ func (d *SwaggerDefinition) findNestedItemsYetToBeParsed(operations map[string]s
 				return nil, fmt.Errorf("finding top level object named %q: %+v", referenceName, err)
 			}
 
-			parsedAsAConstant, constErr := constants.MapConstant(topLevelObject.Type, referenceName, nil, topLevelObject.Enum, topLevelObject.Extensions, d.logger.Named("Constant Parser"))
+			parsedAsAConstant, constErr := constants.MapConstant(topLevelObject.Type, referenceName, nil, topLevelObject.Enum, topLevelObject.Extensions)
 			parsedAsAModel, modelErr := d.parseModel(referenceName, *topLevelObject)
 			if (constErr != nil && modelErr != nil) || (parsedAsAConstant == nil && parsedAsAModel == nil) {
 				return nil, fmt.Errorf("reference %q didn't parse as a Model or a Constant.\n\nConstant Error: %+v\n\nModel Error: %+v", referenceName, constErr, modelErr)
@@ -399,7 +399,7 @@ func (d *SwaggerDefinition) findModelNamesWhichImplement(parentName string) (*[]
 			continue
 		}
 
-		d.logger.Trace(fmt.Sprintf("Found %q implements %q", childName, parentName))
+		logging.Tracef("Found %q implements %q", childName, parentName)
 		modelNames = append(modelNames, childName)
 	}
 

--- a/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
+++ b/tools/importer-rest-api-specs/components/parser/swagger_tags_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
@@ -20,30 +20,30 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 
 					"First": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						// https://github.com/hashicorp/pandora/issues/3807
 						URISuffix: pointer.To("/someotheruri"),
@@ -52,9 +52,9 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/bar"),
 					},
@@ -62,9 +62,9 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/foo"),
 					},
@@ -72,9 +72,9 @@ func TestParsingOperationsUsingTheSameSwaggerTagInDifferentCasings(t *testing.T)
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PATCH",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						// https://github.com/hashicorp/pandora/issues/3807
 						URISuffix: pointer.To("/someotheruri"),
@@ -95,29 +95,29 @@ func TestParsingOperationsOnResources(t *testing.T) {
 	expected := importerModels.AzureApiDefinition{
 		ServiceName: "Example",
 		ApiVersion:  "2020-01-01",
-		Resources: map[string]importerModels.AzureApiResource{
+		Resources: map[string]sdkModels.APIResource{
 			"Hello": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"First": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						// https://github.com/hashicorp/pandora/issues/3807
 						URISuffix: pointer.To("/someotheruri"),
@@ -126,9 +126,9 @@ func TestParsingOperationsOnResources(t *testing.T) {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PUT",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/bar"),
 					},
@@ -136,9 +136,9 @@ func TestParsingOperationsOnResources(t *testing.T) {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "PATCH",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						// https://github.com/hashicorp/pandora/issues/3807
 						URISuffix: pointer.To("/someotheruri"),
@@ -146,27 +146,27 @@ func TestParsingOperationsOnResources(t *testing.T) {
 				},
 			},
 			"HelloOperations": {
-				Models: map[string]models.SDKModel{
+				Models: map[string]sdkModels.SDKModel{
 					"Example": {
-						Fields: map[string]models.SDKField{
+						Fields: map[string]sdkModels.SDKField{
 							"Name": {
 								JsonName: "name",
-								ObjectDefinition: models.SDKObjectDefinition{
-									Type: models.StringSDKObjectDefinitionType,
+								ObjectDefinition: sdkModels.SDKObjectDefinition{
+									Type: sdkModels.StringSDKObjectDefinitionType,
 								},
 								Required: false,
 							},
 						},
 					},
 				},
-				Operations: map[string]models.SDKOperation{
+				Operations: map[string]sdkModels.SDKOperation{
 					"HelloRestart": {
 						ContentType:         "application/json",
 						ExpectedStatusCodes: []int{200},
 						Method:              "POST",
-						RequestObject: &models.SDKObjectDefinition{
+						RequestObject: &sdkModels.SDKObjectDefinition{
 							ReferenceName: pointer.To("Example"),
-							Type:          models.ReferenceSDKObjectDefinitionType,
+							Type:          sdkModels.ReferenceSDKObjectDefinitionType,
 						},
 						URISuffix: pointer.To("/foo"),
 					},

--- a/tools/importer-rest-api-specs/components/transformer/internal_to_dataapisdk.go
+++ b/tools/importer-rest-api-specs/components/transformer/internal_to_dataapisdk.go
@@ -6,19 +6,19 @@ package transformer
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-hclog"
 	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 // NOTE: this file contains temporary glue code to enable refactoring this tool gradually, component-by-component.
 
-func MapInternalTypesToDataAPISDKTypes(serviceName string, inputApiVersions []importerModels.AzureApiDefinition, resourceProvider *string, logger hclog.Logger) (*sdkModels.Service, error) {
+func MapInternalTypesToDataAPISDKTypes(serviceName string, inputApiVersions []importerModels.AzureApiDefinition, resourceProvider *string) (*sdkModels.Service, error) {
 	apiVersions := make(map[string]sdkModels.APIVersion)
 
-	logger.Debug("Mapping API Versions..")
+	logging.Debugf("Mapping API Versions..")
 	for _, item := range inputApiVersions {
-		logger.Trace(fmt.Sprintf("Mapping Service %q / API Version %q", item.ServiceName, item.ApiVersion))
+		logging.Tracef("Mapping Service %q / API Version %q", item.ServiceName, item.ApiVersion)
 		mapped, err := mapInternalAPIVersionTypeToDataAPISDKType(item.ApiVersion, item)
 		if err != nil {
 			return nil, fmt.Errorf("mapping API Version %q: %+v", item.ApiVersion, err)

--- a/tools/importer-rest-api-specs/components/transformer/internal_to_dataapisdk.go
+++ b/tools/importer-rest-api-specs/components/transformer/internal_to_dataapisdk.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
 // NOTE: this file contains temporary glue code to enable refactoring this tool gradually, component-by-component.
 
-func MapInternalTypesToDataAPISDKTypes(serviceName string, inputApiVersions []importerModels.AzureApiDefinition, resourceProvider *string, logger hclog.Logger) (*models.Service, error) {
-	apiVersions := make(map[string]models.APIVersion)
+func MapInternalTypesToDataAPISDKTypes(serviceName string, inputApiVersions []importerModels.AzureApiDefinition, resourceProvider *string, logger hclog.Logger) (*sdkModels.Service, error) {
+	apiVersions := make(map[string]sdkModels.APIVersion)
 
 	logger.Debug("Mapping API Versions..")
 	for _, item := range inputApiVersions {
@@ -32,7 +32,7 @@ func MapInternalTypesToDataAPISDKTypes(serviceName string, inputApiVersions []im
 		apiVersions[item.ApiVersion] = *mapped
 	}
 
-	output := models.Service{
+	output := sdkModels.Service{
 		APIVersions:      apiVersions,
 		Generate:         true,
 		Name:             serviceName,
@@ -42,8 +42,8 @@ func MapInternalTypesToDataAPISDKTypes(serviceName string, inputApiVersions []im
 	return &output, nil
 }
 
-func mapInternalAPIVersionTypeToDataAPISDKType(apiVersion string, input importerModels.AzureApiDefinition) (*models.APIVersion, error) {
-	resources := make(map[string]models.APIResource)
+func mapInternalAPIVersionTypeToDataAPISDKType(apiVersion string, input importerModels.AzureApiDefinition) (*sdkModels.APIVersion, error) {
+	resources := make(map[string]sdkModels.APIResource)
 
 	for apiResource, apiResourceDetails := range input.Resources {
 		// Skip outputting APIResources containing only Constants/Models
@@ -52,11 +52,11 @@ func mapInternalAPIVersionTypeToDataAPISDKType(apiVersion string, input importer
 			continue
 		}
 
-		resources[apiResource] = models.APIResource{
+		resources[apiResource] = sdkModels.APIResource{
 			Constants:   apiResourceDetails.Constants,
 			Models:      apiResourceDetails.Models,
 			Operations:  apiResourceDetails.Operations,
-			ResourceIDs: apiResourceDetails.ResourceIds,
+			ResourceIDs: apiResourceDetails.ResourceIDs,
 		}
 	}
 
@@ -65,11 +65,11 @@ func mapInternalAPIVersionTypeToDataAPISDKType(apiVersion string, input importer
 		return nil, nil
 	}
 
-	return &models.APIVersion{
+	return &sdkModels.APIVersion{
 		APIVersion: apiVersion,
 		Generate:   true,
 		Preview:    input.IsPreviewVersion(),
 		Resources:  resources,
-		Source:     models.AzureRestAPISpecsSourceDataOrigin,
+		Source:     sdkModels.AzureRestAPISpecsSourceDataOrigin,
 	}, nil
 }

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser.go
@@ -1,0 +1,1 @@
+package apidefinitions

--- a/tools/importer-rest-api-specs/internal/logging/log.go
+++ b/tools/importer-rest-api-specs/internal/logging/log.go
@@ -19,6 +19,10 @@ func Debugf(msg string, args ...interface{}) {
 	Log.Debug(fmt.Sprintf(msg, args...))
 }
 
+func Errorf(msg string, args ...interface{}) {
+	Log.Error(fmt.Sprintf(msg, args...))
+}
+
 func Infof(msg string, args ...interface{}) {
 	Log.Info(fmt.Sprintf(msg, args...))
 }

--- a/tools/importer-rest-api-specs/internal/pipeline/stage_parse_data_for_service.go
+++ b/tools/importer-rest-api-specs/internal/pipeline/stage_parse_data_for_service.go
@@ -19,6 +19,7 @@ func (p *Pipeline) parseDataForService(service services.Service) (*sdkModels.Ser
 		return nil, fmt.Errorf("discovering for Service %q: %+v", service.Name, err)
 	}
 	logging.Tracef("Resource Provider is %q", *data.ResourceProvider)
+
 	for version, versionData := range data.DataSetsForAPIVersions {
 		logging.Debugf("API Version %q had %d and %d", version, len(versionData.FilePathsContainingAPIDefinitions), len(versionData.FilePathsContainingSupplementaryData))
 	}

--- a/tools/importer-rest-api-specs/models/models.go
+++ b/tools/importer-rest-api-specs/models/models.go
@@ -6,13 +6,13 @@ package models
 import (
 	"strings"
 
-	"github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 )
 
 type AzureApiDefinition struct {
 	ServiceName string
 	ApiVersion  string
-	Resources   map[string]AzureApiResource
+	Resources   map[string]sdkModels.APIResource
 }
 
 func (d AzureApiDefinition) IsPreviewVersion() bool {
@@ -31,14 +31,7 @@ func (d AzureApiDefinition) IsPreviewVersion() bool {
 	return false
 }
 
-type AzureApiResource struct {
-	Constants   map[string]models.SDKConstant
-	Models      map[string]models.SDKModel
-	Operations  map[string]models.SDKOperation
-	ResourceIds map[string]models.ResourceID
-}
-
-func MergeResourcesForTag(base AzureApiResource, merge AzureApiResource) AzureApiResource {
+func MergeResourcesForTag(base, merge sdkModels.APIResource) sdkModels.APIResource {
 	for k, v := range merge.Constants {
 		if _, ok := base.Constants[k]; !ok {
 			base.Constants[k] = v
@@ -56,9 +49,9 @@ func MergeResourcesForTag(base AzureApiResource, merge AzureApiResource) AzureAp
 			base.Operations[k] = v
 		}
 	}
-	for k, v := range merge.ResourceIds {
-		if _, ok := base.ResourceIds[k]; !ok {
-			base.ResourceIds[k] = v
+	for k, v := range merge.ResourceIDs {
+		if _, ok := base.ResourceIDs[k]; !ok {
+			base.ResourceIDs[k] = v
 		}
 	}
 

--- a/tools/importer-rest-api-specs/pipeline/git.go
+++ b/tools/importer-rest-api-specs/pipeline/git.go
@@ -4,13 +4,11 @@
 package pipeline
 
 import (
-	"fmt"
-
 	"github.com/go-git/go-git/v5"
-	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 )
 
-func determineGitSha(repositoryPath string, logger hclog.Logger) (*string, error) {
+func determineGitSha(repositoryPath string) (*string, error) {
 	repo, err := git.PlainOpen(repositoryPath)
 	if err != nil {
 		return nil, err
@@ -22,6 +20,6 @@ func determineGitSha(repositoryPath string, logger hclog.Logger) (*string, error
 	}
 
 	commit := ref.Hash().String()
-	logger.Debug(fmt.Sprintf("Swagger Repository Commit SHA is %q", commit))
+	logging.Debugf("Swagger Repository Commit SHA is %q", commit)
 	return &commit, nil
 }

--- a/tools/importer-rest-api-specs/pipeline/interface.go
+++ b/tools/importer-rest-api-specs/pipeline/interface.go
@@ -51,13 +51,13 @@ func Run(input RunInput) error {
 		return fmt.Errorf("loading data: %+v", err)
 	}
 
-	swaggerGitSha, err := determineGitSha(input.SwaggerDirectory, input.Logger)
+	swaggerGitSha, err := determineGitSha(input.SwaggerDirectory)
 	if err != nil {
 		return fmt.Errorf("determining Git SHA at %q: %+v", input.SwaggerDirectory, err)
 	}
 
 	if input.JustParseData {
-		return validateCanParseData(input, *generationData)
+		return validateCanParseData(*generationData)
 	}
 
 	return runImporter(input, *generationData, *swaggerGitSha)

--- a/tools/importer-rest-api-specs/pipeline/run_importer.go
+++ b/tools/importer-rest-api-specs/pipeline/run_importer.go
@@ -142,7 +142,7 @@ func runImportForService(input RunInput, serviceName string, apiVersionsForServi
 		dataForApiVersion := &importerModels.AzureApiDefinition{
 			ServiceName: serviceName,
 			ApiVersion:  apiVersion,
-			Resources:   map[string]importerModels.AzureApiResource{},
+			Resources:   map[string]sdkModels.APIResource{},
 		}
 		for _, v := range api {
 			tempDataForApiVersion, err := task.parseDataForApiVersion(v, versionLogger)

--- a/tools/importer-rest-api-specs/pipeline/run_importer.go
+++ b/tools/importer-rest-api-specs/pipeline/run_importer.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/data-api-repository/repository"
 	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/discovery"
@@ -29,14 +28,14 @@ func runImporter(input RunInput, generationData []discovery.ServiceInput, swagge
 
 	// Clear any existing data
 	if len(input.Services) == 0 {
-		input.Logger.Info(fmt.Sprintf("Purging all existing Source Data for Source Data Type %q / Source Data Origin %q..", sourceDataType, sourceDataOrigin))
+		logging.Infof("Purging all existing Source Data for Source Data Type %q / Source Data Origin %q..", sourceDataType, sourceDataOrigin)
 		if err := repo.PurgeExistingData(sourceDataOrigin); err != nil {
 			return fmt.Errorf("purging the existing Source Data for the Source Data Type %q / Source Data Origin %q: %+v", sourceDataType, sourceDataOrigin, err)
 		}
 	} else {
-		input.Logger.Info(fmt.Sprintf("Purging the existing Source Data for the Services [%+v] for  for Source Data Type %q / Source Data Origin %q..", input.Services, sourceDataType, sourceDataOrigin))
+		logging.Infof("Purging the existing Source Data for the Services [%+v] for  for Source Data Type %q / Source Data Origin %q..", input.Services, sourceDataType, sourceDataOrigin)
 		for _, serviceName := range input.Services {
-			input.Logger.Debug(fmt.Sprintf("Removing the existing Data for Service %q..", serviceName))
+			logging.Debugf("Removing the existing Data for Service %q..", serviceName)
 			opts := repository.RemoveServiceOptions{
 				ServiceName:      serviceName,
 				SourceDataOrigin: sourceDataOrigin,
@@ -82,8 +81,8 @@ func runImporter(input RunInput, generationData []discovery.ServiceInput, swagge
 			return fmt.Errorf("removing existing API Definitions for Service %q: %+v", serviceName, err)
 		}
 
-		logger := input.Logger.Named(fmt.Sprintf("Importer for Service %q", serviceName))
-		if err := runImportForService(input, serviceName, serviceDetails, sourceDataOrigin, logger, swaggerGitSha, repo); err != nil {
+		logging.Infof("Importer for Service %q", serviceName)
+		if err := runImportForService(input, serviceName, serviceDetails, sourceDataOrigin, swaggerGitSha, repo); err != nil {
 			return fmt.Errorf("parsing data for Service %q: %+v", serviceName, err)
 		}
 	}
@@ -91,7 +90,7 @@ func runImporter(input RunInput, generationData []discovery.ServiceInput, swagge
 	return nil
 }
 
-func runImportForService(input RunInput, serviceName string, apiVersionsForService []discovery.ServiceInput, sourceDataOrigin sdkModels.SourceDataOrigin, logger hclog.Logger, swaggerGitSha string, repo repository.Repository) error {
+func runImportForService(input RunInput, serviceName string, apiVersionsForService []discovery.ServiceInput, sourceDataOrigin sdkModels.SourceDataOrigin, swaggerGitSha string, repo repository.Repository) error {
 	task := pipelineTask{}
 	var resourceProvider *string
 	var terraformPackageName *string
@@ -136,16 +135,14 @@ func runImportForService(input RunInput, serviceName string, apiVersionsForServi
 	// Populate all of the data for this API Version..
 	dataForApiVersions := make([]importerModels.AzureApiDefinition, 0)
 	for apiVersion, api := range consolidatedApiVersions {
-		versionLogger := logger.Named(fmt.Sprintf("Importer for API Version %q", apiVersion))
-
-		versionLogger.Trace("Task: Parsing Data..")
+		logging.Tracef("Task: Parsing Data for API Version %q..", apiVersion)
 		dataForApiVersion := &importerModels.AzureApiDefinition{
 			ServiceName: serviceName,
 			ApiVersion:  apiVersion,
 			Resources:   map[string]sdkModels.APIResource{},
 		}
 		for _, v := range api {
-			tempDataForApiVersion, err := task.parseDataForApiVersion(v, versionLogger)
+			tempDataForApiVersion, err := task.parseDataForApiVersion(v)
 			if err != nil {
 				return fmt.Errorf("parsing data for Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err)
 			}
@@ -161,8 +158,8 @@ func runImportForService(input RunInput, serviceName string, apiVersionsForServi
 	}
 
 	// temporary glue to enable refactoring this tool piece-by-piece
-	logger.Info("Transforming to the Data API SDK types..")
-	service, err := transformer.MapInternalTypesToDataAPISDKTypes(serviceName, dataForApiVersions, resourceProvider, logger)
+	logging.Infof("Transforming to the Data API SDK types..")
+	service, err := transformer.MapInternalTypesToDataAPISDKTypes(serviceName, dataForApiVersions, resourceProvider)
 	if err != nil {
 		return fmt.Errorf("transforming the internal types to the Data API SDK types: %+v", err)
 	}
@@ -175,7 +172,7 @@ func runImportForService(input RunInput, serviceName string, apiVersionsForServi
 	}
 
 	// Now that we have the populated data, let's go ahead and output that..
-	logger.Info(fmt.Sprintf("Persisting API Definitions for Service %s..", serviceName))
+	logging.Infof("Persisting API Definitions for Service %s..", serviceName)
 	opts := repository.SaveServiceOptions{
 		SourceCommitSHA:  pointer.To(swaggerGitSha),
 		ResourceProvider: resourceProvider,

--- a/tools/importer-rest-api-specs/pipeline/run_validate_can_parse_data.go
+++ b/tools/importer-rest-api-specs/pipeline/run_validate_can_parse_data.go
@@ -4,22 +4,22 @@
 package pipeline
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"sync"
 
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/discovery"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 )
 
-func validateCanParseData(input RunInput, generationData []discovery.ServiceInput) error {
+func validateCanParseData(generationData []discovery.ServiceInput) error {
 	var wg sync.WaitGroup
 	for _, v := range generationData {
 		wg.Add(1)
 		go func(v discovery.ServiceInput) {
-			logger := input.Logger.Named(fmt.Sprintf("Importer Service %q / API Version %q", v.ServiceName, v.ApiVersion))
+			logging.Infof("Importer Service %q / API Version %q", v.ServiceName, v.ApiVersion)
 			task := pipelineTask{}
-			if _, err := task.parseDataForApiVersion(v, logger); err != nil {
+			if _, err := task.parseDataForApiVersion(v); err != nil {
 				log.Printf("validating that data can be processed for Service %q / Version %q: %+v", v.ServiceName, v.ApiVersion, err)
 				wg.Done()
 				os.Exit(1)

--- a/tools/importer-rest-api-specs/pipeline/run_validate_can_parse_data_test.go
+++ b/tools/importer-rest-api-specs/pipeline/run_validate_can_parse_data_test.go
@@ -74,7 +74,7 @@ func TestExistingDataCanBeGenerated(t *testing.T) {
 			generationData := data
 
 			task := pipelineTask{}
-			if _, err := task.parseDataForApiVersion(generationData, hclog.New(hclog.DefaultOptions)); err != nil {
+			if _, err := task.parseDataForApiVersion(generationData); err != nil {
 				t.Fatalf("error: %+v", err)
 			}
 		})

--- a/tools/importer-rest-api-specs/pipeline/task_parse_data.go
+++ b/tools/importer-rest-api-specs/pipeline/task_parse_data.go
@@ -6,31 +6,31 @@ package pipeline
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/discovery"
 	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/components/parser"
+	"github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
 	importerModels "github.com/hashicorp/pandora/tools/importer-rest-api-specs/models"
 )
 
-func (pipelineTask) parseDataForApiVersion(input discovery.ServiceInput, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
-	logger.Trace("Parsing Swagger Files..")
-	data, err := parseSwaggerFiles(input, logger.Named("Swagger"))
+func (pipelineTask) parseDataForApiVersion(input discovery.ServiceInput) (*importerModels.AzureApiDefinition, error) {
+	logging.Tracef("Parsing Swagger Files..")
+	data, err := parseSwaggerFiles(input)
 	if err != nil {
 		err = fmt.Errorf("parsing Swagger files: %+v", err)
-		logger.Info(fmt.Sprintf("❌ Service %q - Api Version %q", input.ServiceName, input.ApiVersion))
-		logger.Error(fmt.Sprintf("     💥 Error: %+v", err))
+		logging.Infof(fmt.Sprintf("❌ Service %q - Api Version %q", input.ServiceName, input.ApiVersion))
+		logging.Errorf(fmt.Sprintf("     💥 Error: %+v", err))
 		return nil, err
 	}
 	if data == nil {
-		logger.Info(fmt.Sprintf("😵 Service %q / Api Version %q contains no resources, skipping.", input.ServiceName, input.ApiVersion))
+		logging.Infof("😵 Service %q / Api Version %q contains no resources, skipping.", input.ServiceName, input.ApiVersion)
 		return nil, nil
 	}
 
 	return data, nil
 }
 
-func parseSwaggerFiles(input discovery.ServiceInput, logger hclog.Logger) (*importerModels.AzureApiDefinition, error) {
-	parseResult, err := parser.LoadAndParseFiles(input.SwaggerDirectory, input.SwaggerFiles, input.ServiceName, input.ApiVersion, input.ResourceProviderToFilterTo, logger)
+func parseSwaggerFiles(input discovery.ServiceInput) (*importerModels.AzureApiDefinition, error) {
+	parseResult, err := parser.LoadAndParseFiles(input.SwaggerDirectory, input.SwaggerFiles, input.ServiceName, input.ApiVersion, input.ResourceProviderToFilterTo)
 	if err != nil {
 		return nil, fmt.Errorf("parsing files in %q: %+v", input.SwaggerDirectory, err)
 	}


### PR DESCRIPTION
This PR does some minor refactoring to the `parser` package, namely to:

1. Standardise the import alias for the SDK Models as `sdkModels`
2. Removes the `models.AzureApiResource` type in favour of `sdkModels.APIResource` (since these are _essentially_ the same at this point)
3. Switches the `parser` package to use the regular logging setup, rather than passing an instance around

There's larger changes needed, but I think this is the most sensible breaking point prior to refactoring this package apart - so I'm opting to send this now, else I suspect that the next PR is going to be hard to review