### PR TITLE
Config: add HybridCompute@2024-05-20-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -275,7 +275,7 @@ service "hybridaks" {
 }
 service "hybridcompute" {
   name      = "HybridCompute"
-  available = ["2022-11-10", "2022-12-27"]
+  available = ["2022-11-10", "2022-12-27", "2024-05-20-preview"]
 }
 service "hybridkubernetes" {
   name      = "HybridKubernetes"


### PR DESCRIPTION
I am working on the new resource [System Center Virtual Machine Manager Virtual Machine Instance](https://github.com/Azure/azure-rest-api-specs/blob/ab064e0047ec560a700d6b501097d99471ad817b/specification/scvmm/resource-manager/Microsoft.ScVmm/stable/2023-10-07/scvmm.json#L157) but I found that it depends on the new resource [Hybrid Compute Machine resource](https://github.com/Azure/azure-rest-api-specs/blob/ab064e0047ec560a700d6b501097d99471ad817b/specification/hybridcompute/resource-manager/Microsoft.HybridCompute/preview/2024-05-20-preview/HybridCompute.json#L352). So I think we need to support Hybrid Compute Machine resource first. Given SCVMM RP team said that only latest preview API version of Hybrid Compute supports System Center Virtual Machine Manager Virtual Machine Instance and they mentioned that they have conformation from the Hybrid Compute RP team, that the upcoming stable version will have no breaking change from their latest API version [2024-05-20-preview](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/hybridcompute/resource-manager/Microsoft.HybridCompute/preview/2024-05-20-preview). So I add support for Hybrid Compute with preview version.