### PR TITLE
`tools/importer-rest-api-specs`: fixing a nil crash

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/constants/interface.go
+++ b/tools/importer-rest-api-specs/components/parser/constants/interface.go
@@ -115,7 +115,7 @@ func MapConstant(typeVal spec.StringOrArray, fieldName string, modelName *string
 
 			key := keyValueForInteger(int64(value))
 			// if an override name is defined for this Constant then we should use it
-			if constExtension.valuesToDisplayNames != nil {
+			if constExtension != nil && constExtension.valuesToDisplayNames != nil {
 				overrideName, hasOverride := (*constExtension.valuesToDisplayNames)[value]
 				if hasOverride {
 					key = overrideName


### PR DESCRIPTION
This occurred when importing `CDN` but is a legit bug/should be nil-check'd on our side too