### PR TITLE
Added `DevOpsInfrastructure` `2024-04-04-preview`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -196,6 +196,10 @@ service "devtestlabs" {
   name      = "DevTestLab"
   available = ["2018-09-15"]
 }
+service "devopsinfrastructure" {
+  name = "DevOpsInfrastructure"
+  available = ["2024-04-04-preview"]
+}
 service "digitaltwins" {
   name      = "DigitalTwins"
   available = ["2023-01-31"]


### PR DESCRIPTION
This PR adds `DevOpsInfrastructure` `2024-04-04-preview` to support a new preview called `Managed DevOps Pool`

API Reference: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/preview/2024-04-04-preview