### PR TITLE
`importer`: try to merge resources of tags which share the same normalize name

### DIFF
--- a/tools/data-api-sdk/v1/models/api_resource.go
+++ b/tools/data-api-sdk/v1/models/api_resource.go
@@ -3,6 +3,8 @@
 
 package models
 
+import "fmt"
+
 // APIResource defines a grouping of related information within an APIVersion.
 type APIResource struct {
 	// Constants specifies a map of Constant Name (key) to SDKConstant (value)
@@ -27,4 +29,34 @@ type APIResource struct {
 	// which contains information about the ResourceIDs used within this APIResource.
 	// NOTE: the Resource ID Name is a valid Identifier.
 	ResourceIDs map[string]ResourceID
+}
+
+func (a APIResource) Merge(b *APIResource) (*APIResource, error) {
+	for k, v := range b.Constants {
+		if _, ok := a.Constants[k]; !ok {
+			a.Constants[k] = v
+		}
+	}
+
+	for k, v := range b.Models {
+		if _, ok := a.Models[k]; !ok {
+			a.Models[k] = v
+		}
+	}
+
+	for k, v := range b.Operations {
+		if _, ok := a.Operations[k]; ok {
+			return nil, fmt.Errorf("operation %s already exits", k)
+		} else {
+			a.Operations[k] = v
+		}
+	}
+
+	for k, v := range b.ResourceIDs {
+		if _, ok := a.ResourceIDs[k]; !ok {
+			a.ResourceIDs[k] = v
+		}
+	}
+
+	return &a, nil
 }

--- a/tools/data-api-sdk/v1/models/api_resource.go
+++ b/tools/data-api-sdk/v1/models/api_resource.go
@@ -3,8 +3,6 @@
 
 package models
 
-import "fmt"
-
 // APIResource defines a grouping of related information within an APIVersion.
 type APIResource struct {
 	// Constants specifies a map of Constant Name (key) to SDKConstant (value)
@@ -31,7 +29,7 @@ type APIResource struct {
 	ResourceIDs map[string]ResourceID
 }
 
-func (a APIResource) Merge(b *APIResource) (*APIResource, error) {
+func (a APIResource) Merge(b *APIResource) APIResource {
 	for k, v := range b.Constants {
 		if _, ok := a.Constants[k]; !ok {
 			a.Constants[k] = v
@@ -45,9 +43,7 @@ func (a APIResource) Merge(b *APIResource) (*APIResource, error) {
 	}
 
 	for k, v := range b.Operations {
-		if _, ok := a.Operations[k]; ok {
-			return nil, fmt.Errorf("operation %s already exits", k)
-		} else {
+		if _, ok := a.Operations[k]; !ok {
 			a.Operations[k] = v
 		}
 	}
@@ -58,5 +54,5 @@ func (a APIResource) Merge(b *APIResource) (*APIResource, error) {
 		}
 	}
 
-	return &a, nil
+	return a
 }

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -36,11 +36,8 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 			normalizedTag := normalizeTag(tag)
 			normalizedTag = cleanup.NormalizeResourceName(normalizedTag)
 			if existed, ok := resources[normalizedTag]; ok {
-				if merged, err := existed.Merge(resource); err != nil {
-					return nil, fmt.Errorf("merging resource %s to %s: %v", tag, normalizedTag, err)
-				} else {
-					resources[normalizedTag] = *merged
-				}
+				merged := existed.Merge(resource)
+				resources[normalizedTag] = merged
 			} else {
 				resources[normalizedTag] = *resource
 			}

--- a/tools/importer-rest-api-specs/components/parser/parser.go
+++ b/tools/importer-rest-api-specs/components/parser/parser.go
@@ -35,7 +35,15 @@ func (d *SwaggerDefinition) parse(serviceName, apiVersion string, resourceProvid
 			logging.Tracef("The Tag %q has %d API Operations", tag, len(resource.Operations))
 			normalizedTag := normalizeTag(tag)
 			normalizedTag = cleanup.NormalizeResourceName(normalizedTag)
-			resources[normalizedTag] = *resource
+			if existed, ok := resources[normalizedTag]; ok {
+				if merged, err := existed.Merge(resource); err != nil {
+					return nil, fmt.Errorf("merging resource %s to %s: %v", tag, normalizedTag, err)
+				} else {
+					resources[normalizedTag] = *merged
+				}
+			} else {
+				resources[normalizedTag] = *resource
+			}
 		}
 	}
 


### PR DESCRIPTION
fixes #4323

there are two similar tags share the same `normalizedName` (note one tag ends with a dot(.) ) in devcenter.json, we can merge these two tags' operation into the same resource. This may seem like a swagger issue, but we can address it here since fixing swagger could take longer.

Attached NetworkConnections: https://github.com/Azure/azure-rest-api-specs/blob/09741dc7c9e43a8f9401d782186cac723dc4af71/specification/devcenter/resource-manager/Microsoft.DevCenter/stable/2023-04-01/devcenter.json#L1260C1-L1261C1
Attached NetworkConnections. :  https://github.com/Azure/azure-rest-api-specs/blob/09741dc7c9e43a8f9401d782186cac723dc4af71/specification/devcenter/resource-manager/Microsoft.DevCenter/stable/2023-04-01/devcenter.json#L628