### PR TITLE
add `CDN@2024-02-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -86,6 +86,10 @@ service "botservice" {
   name      = "BotService"
   available = ["2022-09-15"]
 }
+service "cdn" {
+  name      = "CDN"
+  available = ["2024-02-01"]
+}
 service "chaos" {
   name      = "ChaosStudio"
   available = ["2023-11-01", "2024-01-01"]


### PR DESCRIPTION
The latest CDN API version 2024-02-01 can be successfully imported when the rest-api submodule is updated with PR #4335.


![image](https://github.com/user-attachments/assets/7fb527d8-bc5a-41e5-9792-ffabf0b16c6e)
