### PR TITLE
`tools/importer-rest-api-specs` - fix possible const conflict

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/flattener.go
+++ b/tools/importer-rest-api-specs/components/parser/flattener.go
@@ -27,16 +27,13 @@ func load(directory string, fileName string) (*SwaggerDefinition, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading swagger file %q: %+v", filePath, err)
 	}
-	swaggerDocWithReferences, err = findAndMergeLocalMixins(swaggerDocWithReferences, directory, fileName)
-	if err != nil {
-		return nil, fmt.Errorf("could not mixin remote swagger files referenced by %q: %+v", filePath, err)
-	}
+
 	flattenedWithReferencesOpts := &analysis.FlattenOpts{
 		Minimal:      true,
 		Verbose:      true,
 		Expand:       false,
 		RemoveUnused: false,
-		//ContinueOnError: true,
+		// ContinueOnError: true,
 
 		BasePath: swaggerDocWithReferences.SpecFilePath(),
 		Spec:     analysis.New(swaggerDocWithReferences.Spec()),
@@ -62,7 +59,7 @@ func load(directory string, fileName string) (*SwaggerDefinition, error) {
 		Verbose:      true,
 		Expand:       false,
 		RemoveUnused: false,
-		//ContinueOnError: true,
+		// ContinueOnError: true,
 
 		BasePath: expandedSwaggerDoc.SpecFilePath(),
 		Spec:     analysis.New(expandedSwaggerDoc.Spec()),

--- a/tools/importer-rest-api-specs/components/parser/models.go
+++ b/tools/importer-rest-api-specs/components/parser/models.go
@@ -144,7 +144,7 @@ func (d *SwaggerDefinition) detailsForField(modelName string, propertyName strin
 
 	field := sdkModels.SDKField{
 		Required:    isRequired,
-		Optional:    !isRequired, //TODO: re-enable readonly && !value.ReadOnly,
+		Optional:    !isRequired, // TODO: re-enable readonly && !value.ReadOnly,
 		ReadOnly:    false,       // TODO: re-enable readonly value.ReadOnly,
 		Sensitive:   false,       // todo: this probably needs to be a predefined list, unless there's something we can parse
 		JsonName:    propertyName,
@@ -362,13 +362,13 @@ func (d *SwaggerDefinition) fieldsForModel(modelName string, input spec.Schema, 
 
 func (d *SwaggerDefinition) findTopLevelObject(name string) (*spec.Schema, error) {
 	for modelName, model := range d.swaggerSpecRaw.Definitions {
-		if strings.EqualFold(modelName, name) {
+		if modelName == name {
 			return &model, nil
 		}
 	}
 
 	for modelName, model := range d.swaggerSpecExtendedRaw.Definitions {
-		if strings.EqualFold(modelName, name) {
+		if modelName == name {
 			return &model, nil
 		}
 	}


### PR DESCRIPTION
resolve issue in PR https://github.com/hashicorp/pandora/pull/4374
fix the issue that `strings.EquelFold` will randomly choose from capitalized or lowercased models, thus leads to conflicts in Enums, the details are in https://github.com/hashicorp/pandora/pull/4374#issuecomment-2320619349
By my local test, we can use exact match here without breaking existing generated data.