### PR TITLE
`importer`: fix generated terraform schema file names

### DIFF
--- a/tools/data-api-repository/repository/internal/stages/terraform_schema_models.go
+++ b/tools/data-api-repository/repository/internal/stages/terraform_schema_models.go
@@ -30,7 +30,7 @@ func (g TerraformSchemaModelsStage) Generate(input *helpers.FileSystem, logger h
 			return fmt.Errorf("mapping Terraform Schema Model %q: %+v", schemaModelName, err)
 		}
 
-		fileName := fmt.Sprintf("%s-Resource-Schema-%s.json", g.ResourceDetails.ResourceName, strings.TrimPrefix(schemaModelName, g.ResourceDetails.SchemaModelName))
+		fileName := fmt.Sprintf("%s-Resource-%s-Schema.json", g.ResourceDetails.ResourceName, strings.TrimPrefix(schemaModelName, g.ResourceDetails.SchemaModelName))
 		if schemaModelName == g.ResourceDetails.SchemaModelName {
 			// Special-case the Resources Model so that it's easier to find the Resource's Schema quickly
 			fileName = fmt.Sprintf("%s-Resource-Schema.json", g.ResourceDetails.ResourceName)


### PR DESCRIPTION
Fixes: #4358

The Data-api tool searches for schema files in the Terraform directory with filenames like `xxx-Resource-xxx-Schema.json`, but the filenames generated by the `importer` tool is `xxx-Resource-Schema-xxx.json`, which does not match. This PR renames the generated schema files to align with Data-api logic:

https://github.com/hashicorp/pandora/blob/6edf0c89df2b675f0acc2b9ad9e8b5bfd7fe0d03/tools/data-api-repository/repository/helpers_parse.go#L409-L414

This PR successfully generates resources for the AKS Fleet Manager:

![image](https://github.com/user-attachments/assets/71d67865-8d51-4037-ba6d-865ca0a20aef)

![image](https://github.com/user-attachments/assets/322d0bb4-b994-4e4b-916d-75f643f43697)
