### PR TITLE
`tools/importer-rest-api-specs` - correctly find all referenced models to mixin

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/flattener.go
+++ b/tools/importer-rest-api-specs/components/parser/flattener.go
@@ -27,16 +27,18 @@ func load(directory string, fileName string) (*SwaggerDefinition, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading swagger file %q: %+v", filePath, err)
 	}
-	swaggerDocWithReferences, err = findAndMergeLocalMixins(swaggerDocWithReferences, directory, fileName)
+
+	localMixins, err := findLocalMixins(swaggerDocWithReferences, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not mixin remote swagger files referenced by %q: %+v", filePath, err)
 	}
+
 	flattenedWithReferencesOpts := &analysis.FlattenOpts{
 		Minimal:      true,
 		Verbose:      true,
 		Expand:       false,
 		RemoveUnused: false,
-		//ContinueOnError: true,
+		// ContinueOnError: true,
 
 		BasePath: swaggerDocWithReferences.SpecFilePath(),
 		Spec:     analysis.New(swaggerDocWithReferences.Spec()),
@@ -52,17 +54,15 @@ func load(directory string, fileName string) (*SwaggerDefinition, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading swagger file %q: %+v", filePath, err)
 	}
-	expandedSwaggerDoc, err = findAndMergeLocalMixins(expandedSwaggerDoc, directory, fileName)
-	if err != nil {
-		return nil, fmt.Errorf("could not mixin remote swagger files referenced by %q: %+v", filePath, err)
-	}
+
+	_ = analysis.Mixin(expandedSwaggerDoc.Spec(), localMixins)
 
 	flattenedExpandedOpts := &analysis.FlattenOpts{
 		Minimal:      false,
 		Verbose:      true,
 		Expand:       false,
 		RemoveUnused: false,
-		//ContinueOnError: true,
+		// ContinueOnError: true,
 
 		BasePath: expandedSwaggerDoc.SpecFilePath(),
 		Spec:     analysis.New(expandedSwaggerDoc.Spec()),
@@ -85,38 +85,108 @@ func load(directory string, fileName string) (*SwaggerDefinition, error) {
 	}, nil
 }
 
-func findAndMergeLocalMixins(input *loads.Document, basePath string, baseFile string) (*loads.Document, error) {
-	if len(strings.Split(baseFile, "/")) != 2 { // We only care about local files, not sub-folders
-		return input, nil
+func findLocalMixins(input *loads.Document, filePath string) (*spec.Swagger, error) {
+	mixins := &spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Definitions: make(map[string]spec.Schema),
+		},
 	}
-	pathsToMixin := make([]string, 0)
+
 	if input.Analyzer != nil {
-		allRefs := input.Analyzer.AllRefs()
-		for _, v := range allRefs {
-			if path := v.Ref.GetURL(); path != nil && path.Path != "" && len(strings.Split(path.Path, "/")) == 2 { // Check if we have a reference in the CWD.
-				pathsToMixin = append(pathsToMixin, path.Path)
+		for _, ref := range input.Analyzer.AllRefs() {
+			if err := findMixinForRef(ref, filePath, input, mixins); err != nil {
+				return nil, fmt.Errorf("find mixin for ref %q in %q: %+v", ref.String(), filePath, err)
 			}
 		}
 	}
 
-	if len(pathsToMixin) > 0 {
-		uniqueFilter := make(map[string]bool)
-		uniquePaths := make([]string, 0)
-		for _, path := range pathsToMixin {
-			if _, ok := uniqueFilter[path]; !ok {
-				uniqueFilter[path] = true
-				uniquePaths = append(uniquePaths, path)
-			}
-		}
-		mixins := make([]*spec.Swagger, 0)
-		for _, v := range uniquePaths {
-			doc, err := loads.Spec(fmt.Sprintf("%s/%s", basePath, v))
-			if err != nil {
-				return nil, fmt.Errorf("could not load remote ref %q for mixin in %q: %+v", v, baseFile, err)
-			}
-			mixins = append(mixins, doc.Spec())
-		}
-		_ = analysis.Mixin(input.Spec(), mixins...)
+	return mixins, nil
+}
+
+func findMixinForRef(ref spec.Ref, filePath string, doc *loads.Document, mixins *spec.Swagger) error {
+	if path := ref.GetURL(); path == nil || (path.Path != "" && len(strings.Split(path.Path, "/")) != 2) {
+		// Check if we have a reference in the CWD. if path.Path is empty string, it refers to the same file
+		return nil
 	}
-	return input, nil
+
+	modelName, refFilePath := modelNamePathFromRef(ref, filePath)
+	if _, ok := mixins.Definitions[modelName]; ok {
+		return nil
+	}
+
+	if strings.HasPrefix(ref.GetURL().Fragment, "/parameters/") {
+		return nil
+	}
+
+	refDoc := doc
+	if refFilePath != filePath {
+		newDoc, err := loads.Spec(refFilePath)
+		if err != nil {
+			return fmt.Errorf("load swagger %s: %+v", refFilePath, err)
+		}
+
+		refDoc = newDoc
+	}
+	resolvedModel, ok := refDoc.Spec().Definitions[modelName]
+	if !ok {
+		return fmt.Errorf("resolve ref %s from %s: model not found", ref.String(), filePath)
+	}
+	mixins.Definitions[modelName] = resolvedModel
+
+	temp := &spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Definitions: map[string]spec.Schema{
+				modelName: resolvedModel,
+			},
+		},
+	}
+
+	_, isVariant := resolvedModel.Extensions.GetString("x-ms-discriminator-value")
+	if resolvedModel.Discriminator != "" || isVariant {
+		for defName, def := range refDoc.Spec().Definitions {
+			if defName == modelName {
+				continue
+			}
+			for _, allOf := range def.AllOf {
+				if allOf.Ref.String() != "" {
+					allOfRefModelName, _ := modelNamePathFromRef(allOf.Ref, refFilePath)
+					if modelName == allOfRefModelName {
+						mixins.Definitions[defName] = def
+						temp.Definitions[defName] = def
+
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if len(temp.Definitions) > 0 {
+		analyzer := analysis.New(temp)
+		for _, r := range analyzer.AllRefs() {
+			if err := findMixinForRef(r, refFilePath, refDoc, mixins); err != nil {
+				return fmt.Errorf("find mixin for ref %q in %q: %+v", r.String(), refFilePath, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func modelNamePathFromRef(ref spec.Ref, filePath string) (modelName string, modelFilePath string) {
+	refUrl := ref.GetURL()
+	if refUrl == nil {
+		return "", ""
+	}
+
+	modelFilePath = refUrl.Path
+	if modelFilePath == "" {
+		modelFilePath = filePath
+	} else {
+		filePath, _ := filepath.Split(filePath)
+		modelFilePath = filepath.Join(filePath, modelFilePath)
+	}
+
+	fragments := strings.Split(refUrl.Fragment, "/")
+	return fragments[len(fragments)-1], modelFilePath
 }


### PR DESCRIPTION
resolve issue in PR https://github.com/hashicorp/pandora/pull/4374
supersede https://github.com/hashicorp/pandora/pull/4386

This PR optimize the `findAndMergeLocalMixins` to find all specific models being referenced.

Current status: `findAndMergeLocalMixins` will mixin the whole swagger doc that being referenced in current file. Mixin the whole swagger file and then perform the `analysis.Flatten` will sometimes introduce un-relative models, as mentioned in https://github.com/hashicorp/pandora/pull/4374#issuecomment-2320619349. 

More detail: [networkManagerSecurityAdminConfiguration.json](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/network/resource-manager/Microsoft.Network/preview/2024-01-01-preview/networkManagerSecurityAdminConfiguration.json#L51) refer to the [neworkManager.json](https://github.com/Azure/azure-rest-api-specs/blob/ba268c5654f002bc17914e0bc157f19529f1fec1/specification/network/resource-manager/Microsoft.Network/preview/2024-01-01-preview/networkManager.json#L512),
`findAndMergeLocalMixins` will mixin the whole neworkManager.json. And later the `analysis.Flatten` will introduce [network.json#ProvisioingState](https://github.com/Azure/azure-rest-api-specs/blob/b72e0199fa3242d64b0b49f38e71586066a8c048/specification/network/resource-manager/Microsoft.Network/preview/2024-01-01-preview/networkManager.json#L510-L514)

The conflict will happen for [networkManagerSecurityAdminConfiguration.json#ProvisioingState](https://github.com/Azure/azure-rest-api-specs/blob/b72e0199fa3242d64b0b49f38e71586066a8c048/specification/network/resource-manager/Microsoft.Network/preview/2024-01-01-preview/networkManagerSecurityAdminConfiguration.json#L1007-L1023) and [network.json#ProvisioingState](https://github.com/Azure/azure-rest-api-specs/blob/ba268c5654f002bc17914e0bc157f19529f1fec1/specification/network/resource-manager/Microsoft.Network/preview/2024-01-01-preview/network.json#L464-L478). But actually networkManagerSecurityAdminConfiguration.json only use the ProvisioingState in its own file, but another ProvisioningState is introduced while parsing networkManagerSecurityAdminConfiguration.json, through the route  
`networkManagerSecurityAdminConfiguration.json` [->](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/network/resource-manager/Microsoft.Network/preview/2024-01-01-preview/networkManagerSecurityAdminConfiguration.json#L51) whole `networkManager.json` [->](https://github.com/Azure/azure-rest-api-specs/blob/ba268c5654f002bc17914e0bc157f19529f1fec1/specification/network/resource-manager/Microsoft.Network/preview/2024-01-01-preview/networkManager.json#L512) network.json#ProvisioningState

Note although `networkManagerSecurityAdminConfiguration.json` [->](https://github.com/Azure/azure-rest-api-specs/blob/34f5146bc945549d087d38a8a593c0a5f475ad7f/specification/network/resource-manager/Microsoft.Network/preview/2024-01-01-preview/networkManagerSecurityAdminConfiguration.json#L45) `network.json`, the whole `network.json` file will be added by `findAndMergeLocalMixins`, the `ProvisioningState` will not be overwritten. So the conflict is happend by the effect of both `findAndMergeLocalMixins` and `analysis.Flatten`
https://github.com/hashicorp/pandora/blob/49c3c7a9da36b3fea35e96c4112e0071bf2b41b3/tools/importer-rest-api-specs/components/parser/flattener.go#L55-L72


