### PR TITLE
config - Adding support for AppPlatform 2024-05-01-preview to support Java_21

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -36,7 +36,7 @@ service "applicationinsights" {
 }
 service "appplatform" {
   name      = "AppPlatform"
-  available = ["2023-09-01-preview", "2023-11-01-preview", "2023-12-01", "2024-01-01-preview"]
+  available = ["2023-09-01-preview", "2023-11-01-preview", "2023-12-01", "2024-01-01-preview", "2024-05-01-preview"]
 }
 service "attestation" {
   name      = "Attestation"


### PR DESCRIPTION
In order to support https://github.com/Azure/azure-rest-api-specs/blob/main/specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2024-05-01-preview/appplatform.json#L14130

The current implementation is using github.com/tombuildsstuff/kermit/sdk/appplatform/2023-05-01-preview/appplatform
and would like to start the work to migrate out of kermit and use hashicorp/go-azure-sdk instaed. 