### PR TITLE
importer-msgraph-metadata: improvements to reduce duplicate resource/operation names and prevent clobbering

### DIFF
--- a/tools/importer-msgraph-metadata/components/normalize/duplicates_test.go
+++ b/tools/importer-msgraph-metadata/components/normalize/duplicates_test.go
@@ -21,6 +21,9 @@ func TestDeDuplicate(t *testing.T) {
 		// non-duplicate - not preceding and not from beginning
 		"UserAccountPasswordAccountPolicy": "UserAccountPasswordAccountPolicy",
 
+		// single duplicate word at end of name, so must be retained
+		"UserCountCount": "UserCountCount",
+
 		// duplicate from beginning, but at end of name, so must be retained
 		"SynchronizationSecretKeyStringValuePairSynchronizationSecret": "SynchronizationSecretKeyStringValuePairSynchronizationSecret",
 

--- a/tools/importer-msgraph-metadata/components/normalize/verbs.go
+++ b/tools/importer-msgraph-metadata/components/normalize/verbs.go
@@ -34,7 +34,8 @@ var Verbs = operationVerbs{
 	"Enable",
 	"End",
 	"Erase",
-	"Export",
+	//"Export", // clashes with `/deviceManagement/reports/exportJobs`
+	"Evaluate",
 	"Extract",
 	"Forward",
 	"Find",

--- a/tools/importer-msgraph-metadata/components/parser/resourceids.go
+++ b/tools/importer-msgraph-metadata/components/parser/resourceids.go
@@ -192,7 +192,7 @@ func (r ResourceId) FullyQualifiedResourceName(suffixQualification *string) (*st
 				}
 			}
 
-			if i == len(r.Segments)+1 {
+			if i == len(r.Segments)-1 {
 				// Explicitly pluralize a $ref segment when the previous segment was a label and plural
 				if segment.Type == SegmentODataReference && segment.Value == "$ref" && r.Segments[i-1].plural {
 					segmentName = normalize.Pluralize(segmentName)

--- a/tools/importer-msgraph-metadata/components/parser/resourceids.go
+++ b/tools/importer-msgraph-metadata/components/parser/resourceids.go
@@ -63,7 +63,7 @@ func (ri ResourceIds) MatchIdOrAncestor(resourceId ResourceId) (*ResourceIdMatch
 }
 
 // ResourceId represents a unique path in Microsoft Graph that represents a resource. Resource IDs comprise a non-zero
-// number of segments, the last of which must always of type SegmentUserValue (i.e. specified by the user).
+// number of segments, the last of which must always be of type SegmentUserValue (i.e. specified by the user).
 // Whilst paths in Microsoft Graph can comprise different types of object identifiers, we currently only support simple
 // SegmentUserValue segments where the entire slug is provided. For example, these two paths are functionally equivalent:
 //

--- a/tools/importer-msgraph-metadata/components/parser/resources.go
+++ b/tools/importer-msgraph-metadata/components/parser/resources.go
@@ -55,21 +55,24 @@ type Operation struct {
 	// The content-type of the request body
 	RequestContentType *string
 
-	// The model that describes the request body
-	RequestModel *string
+	// The name of the model that describes the request body, can reference either a common model or describe the ad-hoc request model
+	RequestModelName *string
+
+	// The optional ad-hoc request model, if present
+	RequestModel *Model
 
 	// Any user-specified HTTP headers supported for the request
-	RequestHeaders *Headers
+	RequestHeaders *[]Header
 
 	// Any user-specified query string parameters support for the request
-	RequestParams *Params
+	RequestParams *[]Param
 
 	// The internal data type for the request, used when the content type is JSON or XML,
 	// and the request is not described by a model
 	RequestType *DataType
 
 	// The expected *success* responses for this operation
-	Responses Responses
+	Responses []Response
 
 	// When the content type is JSON or XML, and this is a List operation, the name of the field
 	// that specifies a URL to retrieve the next page of results
@@ -78,8 +81,6 @@ type Operation struct {
 	// OpenAPI3 tags for this operation, used to reconcile operations to services
 	Tags []string
 }
-
-type Responses []Response
 
 type Response struct {
 	// The HTTP status code associated with this expected response
@@ -101,8 +102,6 @@ type Response struct {
 	Constant *Constant
 }
 
-type Headers []Header
-
 type Header struct {
 	Name string
 	Type *DataType
@@ -119,8 +118,6 @@ func (h Header) DataApiSdkObjectDefinition() (*sdkModels.SDKOperationOptionObjec
 		Type:          h.Type.DataApiSdkOperationOptionObjectDefinitionType(),
 	}, nil
 }
-
-type Params []Param
 
 type Param struct {
 	Name     string

--- a/tools/importer-msgraph-metadata/components/workarounds/workaround_blacklist.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workaround_blacklist.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package workarounds
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/importer-msgraph-metadata/components/parser"
+)
+
+var _ serviceWorkaround = workaroundBlacklist{}
+
+// workaroundBlacklist drops resources that we do not support. It is not necessary to drop any corresponding
+// resource IDs, since unused resource IDs are automatically excluded from being imported.
+type workaroundBlacklist struct{}
+
+func (workaroundBlacklist) Name() string {
+	return "Blacklist / drop unsupported resources"
+}
+
+func (workaroundBlacklist) Process(apiVersion, serviceName string, resources parser.Resources, resourceIds parser.ResourceIds) error {
+	resourceNamesToDrop := make([]string, 0)
+
+	switch serviceName {
+	case "groups":
+		for resourceName, resource := range resources {
+			// Has conflicting paths that cannot be sensibly distinguished from each other, this causes
+			// resources to clobber each other. For example:
+			//   /groups/{groupId}/sites/{siteId}/termStores/{storeId}/sets/{setId}/terms/{termId}/children/{termId1}/relations/{relationId}
+			//   /groups/{groupId}/sites/{siteId}/termStore/sets/{setId}/terms/{termId}/children/{termId1}/relations/{relationId}
+			if strings.Contains(resource.Category, "TermStore") {
+				resourceNamesToDrop = append(resourceNamesToDrop, resourceName)
+			}
+		}
+
+	case "me":
+		for resourceName, resource := range resources {
+			// Has conflicting paths that cannot be sensibly distinguished from each other, this causes
+			// resources to clobber each other. For example:
+			//   /me/calendar/events/{eventId}/instances/{eventId1}/extensions/{extensionId}
+			//   /me/calendars/{calendarId}/events/{eventId}/instances/{eventId1}/extensions/{extensionId}
+			if strings.HasPrefix(resource.Category, "Calendar") {
+				resourceNamesToDrop = append(resourceNamesToDrop, resourceName)
+			}
+		}
+
+	case "users":
+		for resourceName, resource := range resources {
+			// Has conflicting paths that cannot be sensibly distinguished from each other, this causes
+			// resources to clobber each other. For example:
+			//   /users/{userId}/calendar/events/{eventId}/instances/{eventId1}/extensions/{extensionId}
+			//   /users/{userId}/calendars/{calendarId}/events/{eventId}/instances/{eventId1}/extensions/{extensionId}
+			if strings.HasPrefix(resource.Category, "Calendar") {
+				resourceNamesToDrop = append(resourceNamesToDrop, resourceName)
+			}
+		}
+
+	}
+
+	// Ensure unique resource names, else we will fail to remove a resource that matches multiple criteria above
+	resourceNamesToDrop = slices.Compact(resourceNamesToDrop)
+
+	// Drop unsupported resources
+	for _, resourceName := range resourceNamesToDrop {
+		delete(resources, resourceName)
+	}
+
+	return nil
+}

--- a/tools/importer-msgraph-metadata/components/workarounds/workaround_synchronizationsecrets.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workaround_synchronizationsecrets.go
@@ -64,7 +64,7 @@ func (workaroundSynchronizationSecrets) Process(apiVersion, serviceName string, 
 			PaginationField: pointer.To("@odata.nextLink"),
 			ResourceId:      resourceId,
 			UriSuffix:       uriSuffix,
-			Responses: parser.Responses{
+			Responses: []parser.Response{
 				{
 					Status:        http.StatusOK,
 					ContentType:   pointer.To("application/json"),

--- a/tools/importer-msgraph-metadata/components/workarounds/workarounds.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workarounds.go
@@ -26,6 +26,10 @@ var workarounds = []dataWorkaround{
 // within that service and/or to resource IDs (which are shared across all services). Note that each of these are passed
 // in as maps, so changes propagate to the underlying object.
 var serviceWorkarounds = []serviceWorkaround{
+	// Broad blacklist for incompatible resources
+	workaroundBlacklist{},
+
+	// Service-specific workarounds
 	workaroundSynchronizationSecrets{},
 }
 

--- a/tools/importer-msgraph-metadata/internal/pipeline/importer.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/importer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/getkin/kin-openapi/openapi3"
 	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
 	"github.com/hashicorp/pandora/tools/importer-msgraph-metadata/components/parser"
@@ -51,7 +50,7 @@ func runImportForVersion(input RunInput, apiVersion, openApiFile, metadataGitSha
 		repo:            input.Repo,
 	}
 
-	logging.Infof("Loading OpenAPI3 definitions for API version %q", apiVersion)
+	logging.Infof("Loading OpenAPI3 definitions for API version %q...", apiVersion)
 	p.spec, err = openapi3.NewLoader().LoadFromFile(filepath.Join(input.MetadataDirectory, openApiFile))
 	if err != nil {
 		return err
@@ -69,7 +68,7 @@ func runImportForVersion(input RunInput, apiVersion, openApiFile, metadataGitSha
 		return err
 	}
 
-	logging.Infof("Applying workarounds for invalid type definitions..")
+	logging.Infof("Applying data workarounds...")
 	if err = workarounds.ApplyWorkarounds(p.apiVersion, p.models, p.constants, p.resourceIds); err != nil {
 		return err
 	}
@@ -157,7 +156,7 @@ func runImportForVersion(input RunInput, apiVersion, openApiFile, metadataGitSha
 }
 
 func (p pipelineForService) RunImport() error {
-	logging.Infof("Parsing resources for %q", p.service)
+	logging.Infof("Parsing resources for %q...", p.service)
 	resources, err := p.parseResources(p.resourceIds, p.models, p.constants)
 	if err != nil {
 		return err
@@ -181,7 +180,7 @@ func (p pipelineForService) RunImport() error {
 			if len(resource.Paths) > 0 {
 				path = resource.Paths[0].ID()
 			}
-			logging.Warnf(spew.Sprintf("Resource with no category was encountered for %q at %q: %#v", p.service, path, *resource))
+			logging.Warnf("Resource %q with no category was encountered for %q Service (API Version %q) at path: %s", resource.Name, p.service, p.apiVersion, path)
 		}
 	}
 

--- a/tools/importer-msgraph-metadata/internal/pipeline/importer.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/importer.go
@@ -180,7 +180,7 @@ func (p pipelineForService) RunImport() error {
 			if len(resource.Paths) > 0 {
 				path = resource.Paths[0].ID()
 			}
-			logging.Warnf("Resource %q with no category was encountered for %q Service (API Version %q) at path: %s", resource.Name, p.service, p.apiVersion, path)
+			logging.Warnf("Resource %q (service %s, version %q) with no category was encountered at path: %s", resource.Name, p.service, p.apiVersion, path)
 		}
 	}
 

--- a/tools/importer-msgraph-metadata/internal/pipeline/importer.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/importer.go
@@ -63,7 +63,7 @@ func runImportForVersion(input RunInput, apiVersion, openApiFile, metadataGitSha
 	}
 
 	logging.Infof("Parsing resource IDs...")
-	p.resourceIds, err = parser.ParseResourceIDs(p.spec.Paths, nil)
+	p.resourceIds, err = parser.ResourceIDs(p.spec.Paths, nil)
 	if err != nil {
 		return err
 	}

--- a/tools/importer-msgraph-metadata/internal/pipeline/task_parse_resources.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/task_parse_resources.go
@@ -303,9 +303,11 @@ func (p pipelineForService) parseResources(resourceIds parser.ResourceIds, model
 				continue
 			}
 
-			// Determine prefixes to trim from the operation name
+			// Determine prefixes to trim from the operation name. At this time we are only trimming the singularized
+			// service name from the resource name. There are instances of the pluralized service name being present at
+			// the beginning of resource names, but trimming this universally causes some naming conflicts, so we'll
+			// live with that.
 			prefixesToTrim := []string{
-				//normalize.CleanName(p.service),
 				normalize.Singularize(normalize.CleanName(p.service)),
 			}
 			if resourceId != nil && uriSuffix == nil {

--- a/tools/importer-msgraph-metadata/internal/pipeline/task_parse_resources.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/task_parse_resources.go
@@ -511,8 +511,7 @@ func (p pipelineForService) parseResources(resourceIds parser.ResourceIds, model
 
 			// Trim a trailing colon/semicolon from descriptions because they are confusing
 			operationDescription := strings.Join(descriptionChunks, ". ")
-			operationDescription = strings.TrimSuffix(operationDescription, ":")
-			operationDescription = strings.TrimSuffix(operationDescription, ";")
+			operationDescription = strings.TrimRight(operationDescription, ":;")
 
 			resources[resourceName].Operations = append(resources[resourceName].Operations, parser.Operation{
 				Name:               operationName,

--- a/tools/importer-msgraph-metadata/internal/pipeline/task_translate_service.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/task_translate_service.go
@@ -59,15 +59,20 @@ func (p pipelineForService) translateServiceToDataApiSdkTypes() (*sdkModels.Serv
 
 			var requestObject *sdkModels.SDKObjectDefinition
 
-			if operation.RequestModel != nil {
-				schemaName := *operation.RequestModel
+			if operation.RequestModelName != nil {
+				schemaName := *operation.RequestModelName
 				requestObjectIsCommonType := true
 
-				if !p.models.Found(schemaName) {
-					return nil, fmt.Errorf("request model %q was not found for operation: %s", schemaName, operation.Name)
+				var model *parser.Model
+				if operation.RequestModel != nil {
+					model = operation.RequestModel
+				} else if p.models.Found(schemaName) {
+					model = p.models[schemaName]
 				}
 
-				model := p.models[schemaName]
+				if model == nil {
+					return nil, fmt.Errorf("request model %q was not found for operation: %s", schemaName, operation.Name)
+				}
 
 				if !model.Common {
 					requestObjectIsCommonType = false
@@ -75,7 +80,7 @@ func (p pipelineForService) translateServiceToDataApiSdkTypes() (*sdkModels.Serv
 				}
 
 				requestObject = &sdkModels.SDKObjectDefinition{
-					ReferenceName:             pointer.To(normalize.CleanName(*operation.RequestModel)),
+					ReferenceName:             pointer.To(normalize.CleanName(*operation.RequestModelName)),
 					ReferenceNameIsCommonType: &requestObjectIsCommonType,
 					Type:                      sdkModels.ReferenceSDKObjectDefinitionType,
 				}

--- a/tools/importer-msgraph-metadata/internal/pipeline/task_translate_service.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/task_translate_service.go
@@ -189,7 +189,7 @@ func (p pipelineForService) translateServiceToDataApiSdkTypes() (*sdkModels.Serv
 						}
 
 					case "Skip", "Top":
-						// Don't set here, we handle this implicitly for list operations
+						// Don't set here, we handle this implicitly in the SDK for list operations
 
 					default:
 						objectDefinition, err := param.DataApiSdkObjectDefinition()


### PR DESCRIPTION
- Don't trim the final word when de-duplicating names
- When building resource names, only check for verbs and OData references in the final segment of the resource ID
- Blacklist some resources (`Calendar*` and `*TermStore*`) via a service workaround, since these are bothersome and we have no need to support them
- Perform post-parsing de-duplication of operations, which can happen due to very similar URIs that are sometimes functionally equivalent anyway
  - When picking out duplicates, select the operation with the longest path and/or the longest resource ID name, as this is both deterministic and probably the most desirable outcome (longer paths tend to offer the most granular functionality)
  - Internally, store any ad-hoc request models (i.e. service-specific request models) in the operation, rather than in the global models map, as these will duplicate along with their operations and allows us to implicitly drop those at the same time
