### PR TITLE
generator-go-sdk: fix unmarshalling fields that reference a model interface

### DIFF
--- a/tools/generator-go-sdk/internal/generator/templater_models_discriminators_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_models_discriminators_test.go
@@ -114,9 +114,9 @@ func UnmarshalModeOfTransitImplementation(input []byte) (ModeOfTransit, error) {
 		return nil, fmt.Errorf("unmarshaling ModeOfTransit into map[string]interface: %+v", err)
 	}
 
-	value, ok := temp["type"].(string)
-	if !ok {
-		return nil, nil
+	var value string
+	if v, ok := temp["type"]; ok {
+		value = fmt.Sprintf("%v", v)
 	}
 
 	if strings.EqualFold(value, "car") {
@@ -524,10 +524,11 @@ func (s FirstImplementation) MarshalJSON() ([]byte, error) {
 var _ json.Unmarshaler = &FirstImplementation{}
 
 func (s *FirstImplementation) UnmarshalJSON(bytes []byte) error {
-	type alias FirstImplementation
-	var decoded alias
+	var decoded struct {
+		Type string ''json:"type"''
+	}
 	if err := json.Unmarshal(bytes, &decoded); err != nil {
-		return fmt.Errorf("unmarshaling into FirstImplementation: %+v", err)
+		return fmt.Errorf("unmarshaling: %+v", err)
 	}
 
 	s.Type = decoded.Type


### PR DESCRIPTION
When a model fields references an interface (i.e. a parent model), this currently fails to unmarshal. This PR fixes that by generating a temporary struct minus those such fields, unmarshalling into it, and then calling the explicit `Unmarshal{Foo}Implementation` function for that model.

Additionally, make the `Unmarshal{Foo}Implementation` functions more forgiving, so if the discriminated value field is missing, it continues to unmarshal into, and return, a `Raw{Foo}Impl` struct instead of just returning nil.