### PR TITLE
Support caller-specified RetryFuncs

### DIFF
--- a/tools/data-api-repository/repository/internal/models/operations.go
+++ b/tools/data-api-repository/repository/internal/models/operations.go
@@ -76,4 +76,8 @@ type Option struct {
 
 	// OptionsObjectDefinition describes the information contained within the Field
 	ObjectDefinition OptionObjectDefinition `json:"optionsObjectDefinition"`
+
+	// RetryFunc is true when this option specifies a client.RequestRetryFunc that can be passed in. This
+	// overrides HeaderName, ODataFieldName and QueryString when true. Has no effect when false.
+	RetryFunc bool
 }

--- a/tools/data-api-repository/repository/internal/models/operations.go
+++ b/tools/data-api-repository/repository/internal/models/operations.go
@@ -51,6 +51,12 @@ type Operation struct {
 }
 
 type Option struct {
+	// Type signals a special behavior for this Option.
+	//   Data: this option specifies Request data, as described in ObjectDefinition, HeaderName, ODataFieldName and/or QueryStringName.
+	//   ContentType: this option specifies a custom Content Type for the Request to be specified by the caller.
+	//   RetryFunc: this option specifies a client.RequestRetryFunc that can be passed in.
+	Type string
+
 	// HeaderName is the name of the Http Header which this Option should be set into
 	// (e.g. `If-Match`, `x-ms-client-request-id`)
 	HeaderName *string `json:"headerName,omitempty"`
@@ -76,8 +82,4 @@ type Option struct {
 
 	// OptionsObjectDefinition describes the information contained within the Field
 	ObjectDefinition OptionObjectDefinition `json:"optionsObjectDefinition"`
-
-	// RetryFunc is true when this option specifies a client.RequestRetryFunc that can be passed in. This
-	// overrides HeaderName, ODataFieldName and QueryString when true. Has no effect when false.
-	RetryFunc bool
 }

--- a/tools/data-api-repository/repository/internal/transforms/sdk_operation_option.go
+++ b/tools/data-api-repository/repository/internal/transforms/sdk_operation_option.go
@@ -13,7 +13,8 @@ import (
 
 func mapSDKOperationOptionFromRepository(input repositoryModels.Option, knownData helpers.KnownData) (*sdkModels.SDKOperationOption, error) {
 	var objectDefinition sdkModels.SDKOperationOptionObjectDefinition
-	if !input.RetryFunc {
+
+	if input.Type == "Data" {
 		mapping, err := mapSDKOperationOptionObjectDefinitionFromRepository(input.ObjectDefinition, knownData)
 		if err != nil {
 			return nil, fmt.Errorf("mapping the ObjectDefinition: %+v", err)
@@ -22,18 +23,24 @@ func mapSDKOperationOptionFromRepository(input repositoryModels.Option, knownDat
 	}
 
 	return &sdkModels.SDKOperationOption{
+		Type:             input.Type,
 		HeaderName:       input.HeaderName,
 		ODataFieldName:   input.ODataFieldName,
 		QueryStringName:  input.QueryString,
 		ObjectDefinition: objectDefinition,
 		Required:         input.Required,
-		RetryFunc:        input.RetryFunc,
 	}, nil
 }
 
 func mapSDKOperationOptionToRepository(fieldName string, input sdkModels.SDKOperationOption, knownData helpers.KnownData) (*repositoryModels.Option, error) {
+	optionType := sdkModels.SDKOperationOptionTypeData
+	if input.Type != "" {
+		optionType = input.Type
+	}
+
 	var objectDefinition repositoryModels.OptionObjectDefinition
-	if !input.RetryFunc {
+
+	if optionType == sdkModels.SDKOperationOptionTypeData {
 		mapping, err := mapSDKOperationOptionObjectDefinitionToRepository(input.ObjectDefinition, knownData)
 		if err != nil {
 			return nil, fmt.Errorf("mapping the object definition: %+v", err)
@@ -42,12 +49,12 @@ func mapSDKOperationOptionToRepository(fieldName string, input sdkModels.SDKOper
 	}
 
 	option := repositoryModels.Option{
+		Type:             optionType,
 		HeaderName:       input.HeaderName,
 		ODataFieldName:   input.ODataFieldName,
 		QueryString:      input.QueryStringName,
 		Field:            fieldName,
 		ObjectDefinition: objectDefinition,
-		RetryFunc:        input.RetryFunc,
 	}
 
 	if !input.Required {

--- a/tools/data-api-repository/repository/internal/transforms/sdk_operation_option.go
+++ b/tools/data-api-repository/repository/internal/transforms/sdk_operation_option.go
@@ -12,24 +12,33 @@ import (
 )
 
 func mapSDKOperationOptionFromRepository(input repositoryModels.Option, knownData helpers.KnownData) (*sdkModels.SDKOperationOption, error) {
-	objectDefinition, err := mapSDKOperationOptionObjectDefinitionFromRepository(input.ObjectDefinition, knownData)
-	if err != nil {
-		return nil, fmt.Errorf("mapping the ObjectDefinition: %+v", err)
+	var objectDefinition sdkModels.SDKOperationOptionObjectDefinition
+	if !input.RetryFunc {
+		mapping, err := mapSDKOperationOptionObjectDefinitionFromRepository(input.ObjectDefinition, knownData)
+		if err != nil {
+			return nil, fmt.Errorf("mapping the ObjectDefinition: %+v", err)
+		}
+		objectDefinition = *mapping
 	}
 
 	return &sdkModels.SDKOperationOption{
 		HeaderName:       input.HeaderName,
 		ODataFieldName:   input.ODataFieldName,
 		QueryStringName:  input.QueryString,
-		ObjectDefinition: *objectDefinition,
+		ObjectDefinition: objectDefinition,
 		Required:         input.Required,
+		RetryFunc:        input.RetryFunc,
 	}, nil
 }
 
 func mapSDKOperationOptionToRepository(fieldName string, input sdkModels.SDKOperationOption, knownData helpers.KnownData) (*repositoryModels.Option, error) {
-	objectDefinition, err := mapSDKOperationOptionObjectDefinitionToRepository(input.ObjectDefinition, knownData)
-	if err != nil {
-		return nil, fmt.Errorf("mapping the object definition: %+v", err)
+	var objectDefinition repositoryModels.OptionObjectDefinition
+	if !input.RetryFunc {
+		mapping, err := mapSDKOperationOptionObjectDefinitionToRepository(input.ObjectDefinition, knownData)
+		if err != nil {
+			return nil, fmt.Errorf("mapping the object definition: %+v", err)
+		}
+		objectDefinition = *mapping
 	}
 
 	option := repositoryModels.Option{
@@ -37,7 +46,8 @@ func mapSDKOperationOptionToRepository(fieldName string, input sdkModels.SDKOper
 		ODataFieldName:   input.ODataFieldName,
 		QueryString:      input.QueryStringName,
 		Field:            fieldName,
-		ObjectDefinition: *objectDefinition,
+		ObjectDefinition: objectDefinition,
+		RetryFunc:        input.RetryFunc,
 	}
 
 	if !input.Required {

--- a/tools/data-api-sdk/v1/models/sdk_operation_option.go
+++ b/tools/data-api-sdk/v1/models/sdk_operation_option.go
@@ -20,4 +20,8 @@ type SDKOperationOption struct {
 
 	// Required specifies whether this Option must be specified in the Request or not.
 	Required bool `json:"required"`
+
+	// RetryFunc is true when this option specifies a client.RequestRetryFunc that can be passed in. This
+	// overrides ObjectDefinition, HeaderName, ODataFieldName and QueryStringName when true. Has no effect when false.
+	RetryFunc bool
 }

--- a/tools/data-api-sdk/v1/models/sdk_operation_option.go
+++ b/tools/data-api-sdk/v1/models/sdk_operation_option.go
@@ -3,11 +3,25 @@
 
 package models
 
+type SDKOperationOptionType = string
+
+const (
+	SDKOperationOptionTypeData        SDKOperationOptionType = "Data"
+	SDKOperationOptionTypeContentType SDKOperationOptionType = "ContentType"
+	SDKOperationOptionTypeRetryFunc   SDKOperationOptionType = "RetryFunc"
+)
+
 // SDKOperationOption defines a QueryString or HTTP Header that can be specified for an
 // Operation.
 type SDKOperationOption struct {
 	// HeaderName specifies the name of the HTTP Header associated with this Option.
 	HeaderName *string `json:"headerName,omitempty"`
+
+	// Type signals a special behavior for this Option.
+	//   Data: this option specifies Request data, as described in ObjectDefinition, HeaderName, ODataFieldName and/or QueryStringName.
+	//   ContentType: this option specifies a custom Content Type for the Request to be specified by the caller.
+	//   RetryFunc: this option specifies a client.RequestRetryFunc that can be passed in.
+	Type SDKOperationOptionType
 
 	// ODataFieldName specifies the name for the OData query string parameter associated with this Option.
 	ODataFieldName *string `json:"odataFieldName,omitempty"`
@@ -20,8 +34,4 @@ type SDKOperationOption struct {
 
 	// Required specifies whether this Option must be specified in the Request or not.
 	Required bool `json:"required"`
-
-	// RetryFunc is true when this option specifies a client.RequestRetryFunc that can be passed in. This
-	// overrides ObjectDefinition, HeaderName, ODataFieldName and QueryStringName when true. Has no effect when false.
-	RetryFunc bool
 }

--- a/tools/generator-go-sdk/internal/generator/templater_methods.go
+++ b/tools/generator-go-sdk/internal/generator/templater_methods.go
@@ -579,27 +579,36 @@ func (c methodsPandoraTemplater) requestOptions() (*string, error) {
 		}
 	}
 
-	items := []string{
-		fmt.Sprintf("ContentType: %q", c.operation.ContentType),
-		fmt.Sprintf(`ExpectedStatusCodes: []int{
-			%s,
-}`, strings.Join(expectedStatusCodes, ",\n\t\t\t")),
-		fmt.Sprintf("HttpMethod: http.Method%s", method),
-		fmt.Sprintf("Path: %s", path),
+	options := map[string]string{
+		"ContentType":         fmt.Sprintf("%q", c.operation.ContentType),
+		"ExpectedStatusCodes": fmt.Sprintf("[]int{\n\t\t\t%s,\n}", strings.Join(expectedStatusCodes, ",\n\t\t\t")),
+		"HttpMethod":          fmt.Sprintf("http.Method%s", method),
+		"Path":                path,
 	}
-	if len(c.operation.Options) > 0 {
-		items = append(items, "OptionsObject: options")
 
-		// Look for a RetryFunc option
+	if len(c.operation.Options) > 0 {
+		options["OptionsObject"] = "options"
+
+		// Look for special options
 		for optionName, option := range c.operation.Options {
-			if option.RetryFunc {
-				items = append(items, fmt.Sprintf("RetryFunc: options.%s", optionName))
+			switch option.Type {
+			case models.SDKOperationOptionTypeContentType:
+				options["ContentType"] = fmt.Sprintf("options.%s", optionName)
+				break
+			case models.SDKOperationOptionTypeRetryFunc:
+				options["RetryFunc"] = fmt.Sprintf("options.%s", optionName)
 				break
 			}
 		}
 	}
+
 	if c.operation.FieldContainingPaginationDetails != nil {
-		items = append(items, fmt.Sprintf("Pager: &%sCustomPager{}", c.operationName))
+		options["Pager"] = fmt.Sprintf("&%sCustomPager{}", c.operationName)
+	}
+
+	items := make([]string, 0, len(options))
+	for key, value := range options {
+		items = append(items, fmt.Sprintf("%s: %s", key, value))
 	}
 	sort.Strings(items)
 
@@ -838,8 +847,12 @@ func (c methodsPandoraTemplater) optionsStruct(data GeneratorData) (*string, err
 	headerAssignments := make([]string, 0)
 
 	for optionName, option := range c.operation.Options {
-		// When the option specifies a RequestRetryFunc, skip normal handling of the option
-		if option.RetryFunc {
+		// Handle special options
+		switch option.Type {
+		case models.SDKOperationOptionTypeContentType:
+			properties = append(properties, fmt.Sprintf("%s string", optionName))
+			continue
+		case models.SDKOperationOptionTypeRetryFunc:
 			properties = append(properties, fmt.Sprintf("%s client.RequestRetryFunc", optionName))
 			continue
 		}
@@ -848,21 +861,26 @@ func (c methodsPandoraTemplater) optionsStruct(data GeneratorData) (*string, err
 		if err != nil {
 			return nil, fmt.Errorf("determining golang type name for option %q's ObjectDefinition: %+v", optionName, err)
 		}
+
 		properties = append(properties, fmt.Sprintf("%s *%s", optionName, *optionType))
+
 		if option.ODataFieldName != nil {
 			value := fmt.Sprintf("*o.%s", *option.ODataFieldName)
 			if option.ObjectDefinition.Type == models.IntegerSDKOperationOptionObjectDefinitionType {
 				value = fmt.Sprintf("int(%s)", value)
 			}
+
 			odataAssignments = append(odataAssignments, fmt.Sprintf(`if o.%[1]s != nil {
 	out.%[2]s = %[3]s
 }`, optionName, *option.ODataFieldName, value))
 		}
+
 		if option.HeaderName != nil {
 			headerAssignments = append(headerAssignments, fmt.Sprintf(`if o.%[1]s != nil {
 	out.Append("%[2]s", fmt.Sprintf("%%v", *o.%[1]s))
 }`, optionName, *option.HeaderName))
 		}
+
 		if option.QueryStringName != nil {
 			queryStringAssignments = append(queryStringAssignments, fmt.Sprintf(`if o.%[1]s != nil {
 	out.Append("%[2]s", fmt.Sprintf("%%v", *o.%[1]s))

--- a/tools/generator-go-sdk/internal/generator/templater_methods_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_methods_test.go
@@ -607,7 +607,7 @@ func TestTemplateGetMethodWithRetryFuncOption(t *testing.T) {
 			Method:              "GET",
 			Options: map[string]models.SDKOperationOption{
 				"TheRetryFunc": {
-					RetryFunc: true,
+					Type: models.SDKOperationOptionTypeRetryFunc,
 				},
 			},
 			ResourceIDName: stringPointer("PandaPop"),
@@ -682,6 +682,99 @@ func (c pandaClient) Get(ctx context.Context , id PandaPop, options GetOperation
 	var model string
 	result.Model = &model
 	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}
+`
+	assertTemplatedCodeMatches(t, expected, *actual)
+}
+
+func TestTemplatePutMethodWithContentTypeOption(t *testing.T) {
+	input := GeneratorData{
+		baseClientPackage: "testclient",
+		packageName:       "skinnyPandas",
+		serviceClientName: "pandaClient",
+		source:            AccTestLicenceType,
+		resourceIds: map[string]models.ResourceID{
+			"PandaPop": {
+				ExampleValue: "LingLing",
+			},
+		},
+	}
+
+	actual, err := methodsPandoraTemplater{
+		operation: models.SDKOperation{
+			ContentType:         "application/json",
+			ExpectedStatusCodes: []int{204},
+			Method:              "PUT",
+			Options: map[string]models.SDKOperationOption{
+				"UploadContentType": {
+					Type: models.SDKOperationOptionTypeContentType,
+				},
+			},
+			ResourceIDName: stringPointer("PandaPop"),
+		},
+		operationName: "Put",
+	}.immediateOperationTemplate(input)
+	if err != nil {
+		t.Fatalf("err %+v", err)
+	}
+
+	expected := `
+type PutOperationResponse struct {
+	HttpResponse *http.Response
+	OData *odata.OData
+}
+
+type PutOperationOptions struct {
+	UploadContentType string
+}
+
+func DefaultPutOperationOptions() PutOperationOptions {
+	return PutOperationOptions{}
+}
+
+func (o PutOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+	return &out
+}
+
+func (o PutOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o PutOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	return &out
+}
+
+// Put ...
+func (c pandaClient) Put(ctx context.Context , id PandaPop, options PutOperationOptions) (result PutOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: options.UploadContentType,
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: options,
+		Path: id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
 		return
 	}
 

--- a/tools/generator-go-sdk/internal/generator/templater_methods_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_methods_test.go
@@ -586,3 +586,107 @@ func (c pandaClient) ListCompleteMatchingPredicate(ctx context.Context, id Panda
 
 	assertTemplatedCodeMatches(t, expected, *actual)
 }
+
+func TestTemplateGetMethodWithRetryFuncOption(t *testing.T) {
+	input := GeneratorData{
+		baseClientPackage: "testclient",
+		packageName:       "skinnyPandas",
+		serviceClientName: "pandaClient",
+		source:            AccTestLicenceType,
+		resourceIds: map[string]models.ResourceID{
+			"PandaPop": {
+				ExampleValue: "LingLing",
+			},
+		},
+	}
+
+	actual, err := methodsPandoraTemplater{
+		operation: models.SDKOperation{
+			ContentType:         "application/json",
+			ExpectedStatusCodes: []int{200},
+			Method:              "GET",
+			Options: map[string]models.SDKOperationOption{
+				"TheRetryFunc": {
+					RetryFunc: true,
+				},
+			},
+			ResourceIDName: stringPointer("PandaPop"),
+			ResponseObject: &models.SDKObjectDefinition{
+				Type: models.StringSDKObjectDefinitionType,
+			},
+		},
+		operationName: "Get",
+	}.immediateOperationTemplate(input)
+	if err != nil {
+		t.Fatalf("err %+v", err)
+	}
+
+	expected := `
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData *odata.OData
+	Model *string
+}
+
+type GetOperationOptions struct {
+	TheRetryFunc client.RequestRetryFunc
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	return &out
+}
+
+// Get ...
+func (c pandaClient) Get(ctx context.Context , id PandaPop, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: options,
+		Path: id.ID(),
+		RetryFunc: options.TheRetryFunc,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model string
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}
+`
+	assertTemplatedCodeMatches(t, expected, *actual)
+}

--- a/tools/importer-msgraph-metadata/internal/pipeline/task_parse_resources.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/task_parse_resources.go
@@ -428,8 +428,9 @@ func (p pipelineForService) parseResources(resourceIds parser.ResourceIds, model
 						continue
 					}
 
-					// Binary payloads are handled by the SDK
 					if content.Schema.Value != nil && content.Schema.Value.Format == "binary" {
+						// Set the request type to Binary. When translating to Data API SDK types, we will also work in a
+						// ContentType option to be set by the caller.
 						requestType = pointer.To(parser.DataTypeBinary)
 						break
 					}

--- a/tools/importer-msgraph-metadata/internal/pipeline/task_translate_service.go
+++ b/tools/importer-msgraph-metadata/internal/pipeline/task_translate_service.go
@@ -98,6 +98,9 @@ func (p pipelineForService) translateServiceToDataApiSdkTypes() (*sdkModels.Serv
 						Type:          sdkModels.ReferenceSDKOperationOptionObjectDefinitionType,
 					},
 				},
+				"RetryFunc": {
+					RetryFunc: true,
+				},
 			}
 
 			if operation.RequestHeaders != nil {


### PR DESCRIPTION
### Changes

* Add a `Type` to `SDKOperationOption` to accommodate additional options that are orthogonal to the existing marshallable options (which become headers, query string arguments, or odata settings).
* Support a caller-specified `Content-Type` header via `SDKOperationOptionTypeContentType`, useful for file uploads and other scenarios with a customizable request body.
* Support a caller-specified `RequestRetryFunc` via `SDKOperationOptionTypeRequestFunc`, more details below.
* For MS Graph API definitions, add a `RetryFunc` option to all operations.
* For MS Graph API definitions, add a `ContentType` option whenever the request body is a binary payload.

### Background

Currently we have some hardcoded RetryFuncs to handle specific error cases where we want to either safely retry the original request, to elect to _not_ retry a request that would ordinarily be retried (e.g. 429 response), or to provide a custom error message for certain failures. This is already plumbed in and uses go-retryablehttp for backoff and retry handling.

There is already some hardcoded use of RetryFuncs, for example [in the Resource Manager Base Client](https://github.com/hashicorp/go-azure-sdk/blob/4c5d3e520faacb3faa502950a48c4db9f11e0d6e/sdk/client/resourcemanager/retry_policies.go), but individual SDKs can currently also supply a RetryFunc.

With Microsoft Graph, there are lots of edge cases where certain errors need specific handling, and it's not possible to autogenerate these - nor would it be desirable since they would apply for every invocation of an operation absent of any usage context. It's therefore necessary to expose a means of supply a RetryFunc to the caller, so they can be inlined into the AzureAD provider.

This implementation makes it possible for importers to include an optional operation option to allow the caller to specify a RetryFunc. By default this is not added, and doesn't count towards possible options, so this addition will not affect the signatures of any existing operation methods (e.g. in Resource Manager SDKs, existing or future). I've elected to have the MS Graph importer add this option to every operation.

Hamilton has its own equivalent of RetryFuncs, which since it's a handwritten SDK are built into the clients. Some examples: [service principals](https://github.com/manicminer/hamilton/blob/af82bb6bb88e2b06a1b6c1793876f73d2fe34a7b/msgraph/serviceprincipals.go#L65-L75), [users](https://github.com/manicminer/hamilton/blob/af82bb6bb88e2b06a1b6c1793876f73d2fe34a7b/msgraph/users.go#L64-L69), [groups](https://github.com/manicminer/hamilton/blob/af82bb6bb88e2b06a1b6c1793876f73d2fe34a7b/msgraph/groups.go#L64-L69), [OAuth2 grants](https://github.com/manicminer/hamilton/blob/af82bb6bb88e2b06a1b6c1793876f73d2fe34a7b/msgraph/delegated_permission_grants_client.go#L68-L77), [access package resource requests](https://github.com/manicminer/hamilton/blob/main/msgraph/accesspackageresourcerequest.go#L66-L68)... the list goes on.
