### PR TITLE
generator-go-sdk: support model behaviors

### DIFF
--- a/tools/generator-go-sdk/internal/cmd/generate.go
+++ b/tools/generator-go-sdk/internal/cmd/generate.go
@@ -59,7 +59,7 @@ func (g GenerateCommand) Run(args []string) int {
 	}
 
 	if g.sourceDataType == models.MicrosoftGraphSourceDataType {
-		input.settings.EnableModelBehaviors = true
+		input.settings.AllowOmittingDiscriminatedValue = true
 		input.settings.GenerateDescriptionsForModels = true
 		input.settings.RecurseParentModels = false
 
@@ -72,7 +72,7 @@ func (g GenerateCommand) Run(args []string) int {
 			"beta":   models.MicrosoftGraphMetaDataSourceDataOrigin,
 		}
 	} else if g.sourceDataType == models.ResourceManagerSourceDataType {
-		input.settings.EnableModelBehaviors = false
+		input.settings.AllowOmittingDiscriminatedValue = false
 		input.settings.GenerateDescriptionsForModels = false
 		input.settings.RecurseParentModels = true
 

--- a/tools/generator-go-sdk/internal/cmd/generate.go
+++ b/tools/generator-go-sdk/internal/cmd/generate.go
@@ -59,6 +59,7 @@ func (g GenerateCommand) Run(args []string) int {
 	}
 
 	if g.sourceDataType == models.MicrosoftGraphSourceDataType {
+		input.settings.EnableModelBehaviors = true
 		input.settings.GenerateDescriptionsForModels = true
 		input.settings.RecurseParentModels = false
 
@@ -71,6 +72,8 @@ func (g GenerateCommand) Run(args []string) int {
 			"beta":   models.MicrosoftGraphMetaDataSourceDataOrigin,
 		}
 	} else if g.sourceDataType == models.ResourceManagerSourceDataType {
+		input.settings.EnableModelBehaviors = false
+		input.settings.GenerateDescriptionsForModels = false
 		input.settings.RecurseParentModels = true
 
 		input.settings.UseOldBaseLayerFor(

--- a/tools/generator-go-sdk/internal/generator/data.go
+++ b/tools/generator-go-sdk/internal/generator/data.go
@@ -74,6 +74,9 @@ type GeneratorData struct {
 	// the package name for the API version
 	versionPackageName string
 
+	// whether model behaviors are enabled
+	enableModelBehaviors bool
+
 	// whether descriptions should be generated for model fields etc.
 	generateDescriptionsForModels bool
 
@@ -117,6 +120,7 @@ func (i ServiceGeneratorInput) generatorData(settings Settings) GeneratorData {
 		commonTypesIncludePath:        commonTypesIncludePath,
 		commonTypesPackageName:        commonTypesPackageName,
 		constants:                     i.ResourceDetails.Constants,
+		enableModelBehaviors:          settings.EnableModelBehaviors,
 		generateDescriptionsForModels: settings.GenerateDescriptionsForModels,
 		isDataPlane:                   models.SourceDataTypeIsDataPlane(i.Type),
 		models:                        i.ResourceDetails.Models,

--- a/tools/generator-go-sdk/internal/generator/data.go
+++ b/tools/generator-go-sdk/internal/generator/data.go
@@ -74,8 +74,8 @@ type GeneratorData struct {
 	// the package name for the API version
 	versionPackageName string
 
-	// whether model behaviors are enabled
-	enableModelBehaviors bool
+	// whether callers can configure models to omit the discriminated value field when marshalling
+	allowOmittingDiscriminatedValue bool
 
 	// whether descriptions should be generated for model fields etc.
 	generateDescriptionsForModels bool
@@ -113,27 +113,27 @@ func (i ServiceGeneratorInput) generatorData(settings Settings) GeneratorData {
 	}
 
 	return GeneratorData{
-		apiVersion:                    i.VersionName,
-		canonicalApiVersion:           settings.CanonicalApiVersion(i.VersionName),
-		baseClientPackage:             baseClientPackageForSdk(i.Type),
-		commonTypes:                   i.CommonTypes,
-		commonTypesIncludePath:        commonTypesIncludePath,
-		commonTypesPackageName:        commonTypesPackageName,
-		constants:                     i.ResourceDetails.Constants,
-		enableModelBehaviors:          settings.EnableModelBehaviors,
-		generateDescriptionsForModels: settings.GenerateDescriptionsForModels,
-		isDataPlane:                   models.SourceDataTypeIsDataPlane(i.Type),
-		models:                        i.ResourceDetails.Models,
-		operations:                    i.ResourceDetails.Operations,
-		packageName:                   resourcePackageName,
-		recurseParentModels:           settings.RecurseParentModels,
-		resourceIds:                   i.ResourceDetails.ResourceIDs,
-		resourceOutputPath:            resourceOutputPath,
-		serviceClientName:             fmt.Sprintf("%sClient", strings.Title(i.ResourceName)),
-		servicePackageName:            strings.ToLower(i.ServiceName),
-		source:                        i.Source,
-		sourceType:                    i.Type,
-		useNewBaseLayer:               useNewBaseLayer,
+		apiVersion:                      i.VersionName,
+		canonicalApiVersion:             settings.CanonicalApiVersion(i.VersionName),
+		baseClientPackage:               baseClientPackageForSdk(i.Type),
+		commonTypes:                     i.CommonTypes,
+		commonTypesIncludePath:          commonTypesIncludePath,
+		commonTypesPackageName:          commonTypesPackageName,
+		constants:                       i.ResourceDetails.Constants,
+		allowOmittingDiscriminatedValue: settings.AllowOmittingDiscriminatedValue,
+		generateDescriptionsForModels:   settings.GenerateDescriptionsForModels,
+		isDataPlane:                     models.SourceDataTypeIsDataPlane(i.Type),
+		models:                          i.ResourceDetails.Models,
+		operations:                      i.ResourceDetails.Operations,
+		packageName:                     resourcePackageName,
+		recurseParentModels:             settings.RecurseParentModels,
+		resourceIds:                     i.ResourceDetails.ResourceIDs,
+		resourceOutputPath:              resourceOutputPath,
+		serviceClientName:               fmt.Sprintf("%sClient", strings.Title(i.ResourceName)),
+		servicePackageName:              strings.ToLower(i.ServiceName),
+		source:                          i.Source,
+		sourceType:                      i.Type,
+		useNewBaseLayer:                 useNewBaseLayer,
 	}
 }
 

--- a/tools/generator-go-sdk/internal/generator/settings.go
+++ b/tools/generator-go-sdk/internal/generator/settings.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Settings struct {
-	CanonicalApiVersions          map[string]string
-	CommonTypesPackageName        string
-	EnableModelBehaviors          bool
-	GenerateDescriptionsForModels bool
-	RecurseParentModels           bool
-	VersionsToGenerateCommonTypes map[string]models.SourceDataOrigin
-	servicesUsingOldBaseLayer     map[string]struct{}
+	CanonicalApiVersions            map[string]string
+	CommonTypesPackageName          string
+	AllowOmittingDiscriminatedValue bool
+	GenerateDescriptionsForModels   bool
+	RecurseParentModels             bool
+	VersionsToGenerateCommonTypes   map[string]models.SourceDataOrigin
+	servicesUsingOldBaseLayer       map[string]struct{}
 }
 
 func (s *Settings) CanonicalApiVersion(version string) *string {

--- a/tools/generator-go-sdk/internal/generator/settings.go
+++ b/tools/generator-go-sdk/internal/generator/settings.go
@@ -12,6 +12,7 @@ import (
 type Settings struct {
 	CanonicalApiVersions          map[string]string
 	CommonTypesPackageName        string
+	EnableModelBehaviors          bool
 	GenerateDescriptionsForModels bool
 	RecurseParentModels           bool
 	VersionsToGenerateCommonTypes map[string]models.SourceDataOrigin

--- a/tools/generator-go-sdk/internal/generator/templater_models.go
+++ b/tools/generator-go-sdk/internal/generator/templater_models.go
@@ -145,7 +145,7 @@ type %[1]s interface {
 
 	// Determine any behavioral struct field lines, if enabled
 	behavioralStructLines := ""
-	if data.enableModelBehaviors {
+	if data.allowOmittingDiscriminatedValue {
 		if c.model.FieldNameContainingDiscriminatedValue != nil {
 			behavioralStructLines += strings.ReplaceAll(`
 	// Model Behaviors
@@ -631,7 +631,7 @@ func (s %[1]s) MarshalJSON() ([]byte, error) {
 			}
 		}
 
-		if data.enableModelBehaviors {
+		if data.allowOmittingDiscriminatedValue {
 			output += fmt.Sprintf(`
 	if !s.OmitDiscriminatedValue {
 		decoded[%[1]q] = %[2]q

--- a/tools/generator-go-sdk/internal/generator/templater_models_discriminators_test.go
+++ b/tools/generator-go-sdk/internal/generator/templater_models_discriminators_test.go
@@ -311,8 +311,8 @@ func TestTemplaterModelsImplementationWithModelBehaviors(t *testing.T) {
 			DiscriminatedValue:                    stringPointer("train"),
 		},
 	}.template(GeneratorData{
-		enableModelBehaviors: true,
-		packageName:          "somepackage",
+		allowOmittingDiscriminatedValue: true,
+		packageName:                     "somepackage",
 		models: map[string]models.SDKModel{
 			"ModeOfTransit": {
 				FieldNameContainingDiscriminatedValue: stringPointer("Type"),


### PR DESCRIPTION
Initial behavior to omit discriminated value when marshalling. Model behaviors are opt-in; enabled only for MS Graph at this time.

**Example SDK Output**

<img width="916" alt="Screenshot 2024-09-23 at 12 57 42" src="https://github.com/user-attachments/assets/10ffb93c-2d6d-455f-99ac-1c78126559e9">
  <br>
  <br>

<img width="761" alt="Screenshot 2024-09-23 at 12 57 57" src="https://github.com/user-attachments/assets/d792ab6c-73ae-46f4-8168-793cec1b633f">
