### PR TITLE
importer-msgraph-metadata: workaround to remove nonexistent `administrativeunit` resources in the beta API, since these actually exist in their own service

### DIFF
--- a/tools/importer-msgraph-metadata/components/workarounds/workaround_administrativeunits.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workaround_administrativeunits.go
@@ -1,0 +1,44 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package workarounds
+
+import (
+	"strings"
+
+	"github.com/hashicorp/pandora/tools/importer-msgraph-metadata/components/parser"
+	"github.com/hashicorp/pandora/tools/importer-msgraph-metadata/components/versions"
+)
+
+var _ serviceWorkaround = workaroundAdministrativeUnits{}
+
+// workaroundAdministrativeUnits removes nonexistent `AdministrativeUnit` resources from the `Directory` service in
+// the beta API, as these resources exist in the `administrativeUnits` service for this API version.
+type workaroundAdministrativeUnits struct{}
+
+func (workaroundAdministrativeUnits) Name() string {
+	return "Administrative Units / remove nonexistent resources"
+}
+
+func (workaroundAdministrativeUnits) Process(apiVersion, serviceName string, resources parser.Resources, resourceIds parser.ResourceIds) error {
+	if apiVersion != versions.ApiVersionBeta {
+		return nil
+	}
+
+	if serviceName != "directory" {
+		return nil
+	}
+
+	resourcesToDelete := make([]string, 0)
+	for resourceName := range resources {
+		if strings.HasPrefix(resourceName, "DirectoryAdministrativeUnit") {
+			resourcesToDelete = append(resourcesToDelete, resourceName)
+		}
+	}
+
+	for _, resourceName := range resourcesToDelete {
+		delete(resources, resourceName)
+	}
+
+	return nil
+}

--- a/tools/importer-msgraph-metadata/components/workarounds/workarounds.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workarounds.go
@@ -32,6 +32,7 @@ var serviceWorkarounds = []serviceWorkaround{
 	workaroundBlacklist{},
 
 	// Service-specific workarounds
+	workaroundAdministrativeUnits{},
 	workaroundApplicationTemplates{},
 	workaroundEntitlementManagementAccessPackageAccessPackageResourceRoleScope{},
 	workaroundEntitlementManagementRoleAssignment{},


### PR DESCRIPTION
The beta API has these resources defined in two places: [in their own service](https://github.com/hashicorp/pandora/tree/main/api-definitions/microsoft-graph/AdministrativeUnits/beta) (where they actually are), and in the `directory` service (where they are in the stable API, but not in beta).