### PR TITLE
feat: add api 2024-06-01-preview of search service

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -523,7 +523,7 @@ service "scvmm" {
 }
 service "search" {
   name      = "Search"
-  available = ["2022-09-01", "2023-11-01"]
+  available = ["2022-09-01", "2023-11-01", "2024-06-01-preview"]
 }
 service "security" {
   name      = "Security"


### PR DESCRIPTION
I'm interested in adding support for issue https://github.com/hashicorp/terraform-provider-azurerm/issues/26575 and for that I think the first action is to add the preview api version `2024-06-01-preview` for the search service.