### PR TITLE
`workarounds` - normalize example value in resource ID user specified segment to prevent erroneous diffs

### DIFF
--- a/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
+++ b/tools/importer-rest-api-specs/components/parser/dataworkarounds/workaround_inconsistent_swagger_segments.go
@@ -45,6 +45,8 @@ func (workaroundInconsistentlyDefinedSegments) Process(apiDefinition importerMod
 							val.Name = singularNameOfPrevious
 							if !strings.HasSuffix(val.Name, "Name") {
 								val.Name = fmt.Sprintf("%sName", singularNameOfPrevious)
+								// the parser sets the same value into Name and ExampleValue so this needs to be applied to ExampleValue as well
+								val.ExampleValue = fmt.Sprintf("%sName", singularNameOfPrevious)
 							}
 						}
 					}


### PR DESCRIPTION
At some point we began experiencing flapping diffs in the example value for resource ID segments 

Example PR of this phenomenon:
https://github.com/hashicorp/pandora/pull/4433
https://github.com/hashicorp/pandora/pull/4461

This workaround was added to standardize the resource ID segments to be consistent when resource IDs that are actually the same are defined with different user defined segments in the swagger e.g.

`/subscription/{subscriptionId}/resourceGroup/resourceGroupName/provider/Microsoft.SomeProvider/virtualMachines/{virtualMachineName}`
`/subscription/{subscriptionId}/resourceGroup/resourceGroupName/provider/Microsoft.SomeProvider/virtualMachines/{name}`

The example value which is metadata that we populate for documentation purposes when generating resources actually uses the same value that the segment name does, so this workaround should apply to the example value as well.