### PR TITLE
`kubernetes_cluster_trusted_access_role_binding` - update auto-generated resource api version from `2023-03-02-preview` to `2024-05-01`

### DIFF
--- a/config/resources/containerservice.hcl
+++ b/config/resources/containerservice.hcl
@@ -4,7 +4,7 @@
 service "ContainerService" {
   terraform_package = "containers"
 
-  api "2023-03-02-preview" {
+  api "2024-05-01" {
     package "TrustedAccess" {
       definition "kubernetes_cluster_trusted_access_role_binding" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{managedClusterName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}"
@@ -12,7 +12,6 @@ service "ContainerService" {
         website_subcategory = "Container"
         description = <<HERE
 Manages a Kubernetes Cluster Trusted Access Role Binding
-~> **Note:** This Resource is in **Preview** to use this you must be opted into the Preview. You can do this by running `az feature register --namespace Microsoft.ContainerService --name TrustedAccessPreview` and then `az provider register -n Microsoft.ContainerService`
 HERE
         test_data {
           basic_variables {


### PR DESCRIPTION
Test results for generated resource with api version `2024-05-01`
<img width="758" alt="image" src="https://github.com/user-attachments/assets/3457990b-23f2-468b-8cf8-3f860bf3f8dc">
<img width="736" alt="image" src="https://github.com/user-attachments/assets/34c41763-3f3f-4f20-88ad-4b3c943cc13d">
