### PR TITLE
config: adding DeviceRegistry 2023-11-01-preview / 2024-09-01-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -198,7 +198,7 @@ service "deviceprovisioningservices" {
 }
 service "deviceregistry" {
   name      = "DeviceRegistry"
-  available = ["2023-11-01-preview", "2024-09-01-preview"]
+  available = ["2024-09-01-preview"]
 }
 service "deviceupdate" {
   name      = "DeviceUpdate"

--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -196,6 +196,10 @@ service "deviceprovisioningservices" {
   name      = "DeviceProvisioningServices"
   available = ["2022-02-05", "2022-12-12"]
 }
+service "deviceregistry" {
+  name      = "DeviceRegistry"
+  available = ["2023-11-01-preview", "2024-09-01-preview"]
+}
 service "deviceupdate" {
   name      = "DeviceUpdate"
   available = ["2022-10-01", "2023-07-01"]


### PR DESCRIPTION
Enables device registry team to build the golang sdk for DeviceRegistry service (for the [go-azure-sdk ](https://github.com/hashicorp/go-azure-sdk/tree/main?tab=readme-ov-file) repo), then we can add DeviceRegistry to azurerm terraform: https://github.com/hashicorp/terraform-provider-azurerm

Specs to onboard: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/preview