### PR TITLE
dataworkaround: add workaround for datamigration 31001

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_datamigration_31001.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_datamigration_31001.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dataworkarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+)
+
+var _ workaround = workaroundDataMigration31001{}
+
+// workaroundDataMigration31001 sets the correct casing for `MongoDbConnectionInfo` as the discriminated value. Since the
+// swagger doesn't have this defined, the casing of this would switch back and forth on subsequent runs due to the way that we
+// load/parse/flatten the swagger files.
+// Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/31001
+type workaroundDataMigration31001 struct {
+}
+
+func (workaroundDataMigration31001) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
+	return serviceName == "DataMigration" && apiVersion.APIVersion == "2021-06-30"
+}
+
+func (workaroundDataMigration31001) Name() string {
+	return "DataMigration / 31001"
+}
+
+func (workaroundDataMigration31001) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
+	resources := []string{
+		"CustomOperation",
+		"GET",
+		"PUT",
+		"ServiceTaskResource",
+		"TaskResource",
+	}
+
+	for _, resource := range resources {
+		r, ok := input.Resources[resource]
+		if !ok {
+			return nil, fmt.Errorf("expected a Resource named `%s` but didn't get one", r)
+		}
+
+		model, ok := r.Models["MongoDbConnectionInfo"]
+		if !ok {
+			return nil, fmt.Errorf("expected a Model named `MongoDbConnectionInfo` but didn't get one")
+		}
+
+		model.DiscriminatedValue = pointer.To("MongoDbConnectionInfo")
+
+		r.Models["MongoDbConnectionInfo"] = model
+		input.Resources[resource] = r
+	}
+
+	return &input, nil
+}


### PR DESCRIPTION
Explanation is in the workaround, should prevent the flapping casing in https://github.com/hashicorp/pandora/pull/4476