### PR TITLE
GHA: bump go version for terraform generator

### DIFF
--- a/.github/workflows/automation-regenerate-terraform.yaml
+++ b/.github/workflows/automation-regenerate-terraform.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.21.3'
+          go-version: '1.22.7'
 
       - name: "Launch SSH Agent"
         run: |


### PR DESCRIPTION
Regenerate Terraform Provider GHA is failing with the current error message when running `make tools` in the provider codebase:

```
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
golangci/golangci-lint info checking GitHub for tag 'v1.55.1'
golangci/golangci-lint info found version: 1.55.1 for v1.55.1/linux/amd64
install: cannot create regular file '/bin/golangci-lint': Permission denied
```