### PR TITLE
config - upgrade fleet members version to `2024-04-01`

### DIFF
--- a/config/resources/containerservice.hcl
+++ b/config/resources/containerservice.hcl
@@ -36,7 +36,7 @@ HERE
     }
   }
 
-  api "2023-10-15" {
+  api "2024-04-01" {
     package "FleetMembers" {
       definition "kubernetes_fleet_member" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/members/{memberName}"


### PR DESCRIPTION
The GHA to regenerate the Terraform provider fails with multiple errors that look similar to:

`cannot use id (variable of type "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2024-04-01/fleets".FleetId) as "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-10-15/fleets".FleetId value in argument to client.Get`

The client for the Kubernetes Fleet resources are shared by resources that are both manually written and generated by Pandora:

- `azurerm_kubernetes_fleet_manager` was previously generated by Pandora but was converted to a manually written resource due to limitations in generation
- `azurerm_kubernetes_fleet_member` is still generated by Pandora

The client was updated from `2023-10-15` to `2024-04-01` for Fleet Managers but the Pandora generated Fleet Member resource is still defined to use `2023-10-15` resulting in a clash when regenerating the provider.

