### PR TITLE
importer-msgraph-metadata: Add workarounds for several bugs in Graph Api Spec

### DIFF
--- a/tools/importer-msgraph-metadata/components/workarounds/workaround_connectedorganization.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workaround_connectedorganization.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package workarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-msgraph-metadata/components/parser"
+)
+
+var _ dataWorkaround = workaroundConnectedOrganization{}
+
+// workaroundConnectedOrganization adds missing fields and fixes some field types.
+type workaroundConnectedOrganization struct{}
+
+func (workaroundConnectedOrganization) Name() string {
+	return "Connected Organization / identitySources is not read-only"
+}
+
+func (workaroundConnectedOrganization) Process(apiVersion string, models parser.Models, constants parser.Constants, resourceIds parser.ResourceIds) error {
+	model, ok := models["microsoft.graph.connectedOrganization"]
+	if !ok {
+		return fmt.Errorf("`connectedOrganization` model not found")
+	}
+
+	// `identitySources` is not read-only
+	if _, ok = model.Fields["identitySources"]; !ok {
+		return fmt.Errorf("`identitySources` field not found")
+	}
+	model.Fields["identitySources"].ReadOnly = false
+
+	return nil
+}

--- a/tools/importer-msgraph-metadata/components/workarounds/workaround_crosstenantaccesspolicyconfigurationpartner.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workaround_crosstenantaccesspolicyconfigurationpartner.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package workarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-msgraph-metadata/components/parser"
+)
+
+var _ dataWorkaround = workaroundCrossTenantAccessPolicyConfigurationPartner{}
+
+// workaroundCrossTenantAccessPolicyConfigurationPartner adds missing fields and fixes some field types.
+type workaroundCrossTenantAccessPolicyConfigurationPartner struct{}
+
+func (workaroundCrossTenantAccessPolicyConfigurationPartner) Name() string {
+	return "Cross Tenant Access Policy Configuration Partner / tenantId is not read-only"
+}
+
+func (workaroundCrossTenantAccessPolicyConfigurationPartner) Process(apiVersion string, models parser.Models, constants parser.Constants, resourceIds parser.ResourceIds) error {
+	model, ok := models["microsoft.graph.crossTenantAccessPolicyConfigurationPartner"]
+	if !ok {
+		return fmt.Errorf("`crossTenantAccessPolicyConfigurationPartner` model not found")
+	}
+
+	// `tenantId` is not read-only
+	if _, ok = model.Fields["tenantId"]; !ok {
+		return fmt.Errorf("`tenantId` field not found")
+	}
+	model.Fields["tenantId"].ReadOnly = false
+
+	return nil
+}

--- a/tools/importer-msgraph-metadata/components/workarounds/workaround_unifiedrolemanagementpolicy.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workaround_unifiedrolemanagementpolicy.go
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package workarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-msgraph-metadata/components/parser"
+)
+
+var _ dataWorkaround = workaroundUnifiedRoleManagementPolicy{}
+
+// workaroundUnifiedRoleManagementPolicy adds missing fields and fixes some field types.
+type workaroundUnifiedRoleManagementPolicy struct{}
+
+func (workaroundUnifiedRoleManagementPolicy) Name() string {
+	return "Unified Role Management Policy / lastModifiedBy and lastModifiedDateTime are read-only"
+}
+
+func (workaroundUnifiedRoleManagementPolicy) Process(apiVersion string, models parser.Models, constants parser.Constants, resourceIds parser.ResourceIds) error {
+	model, ok := models["microsoft.graph.unifiedRoleManagementPolicy"]
+	if !ok {
+		return fmt.Errorf("`unifiedRoleManagementPolicy` model not found")
+	}
+
+	// `lastModifiedBy` is read-only
+	if _, ok = model.Fields["lastModifiedBy"]; !ok {
+		return fmt.Errorf("`lastModifiedBy` field not found")
+	}
+	model.Fields["lastModifiedBy"].ReadOnly = true
+
+	// `lastModifiedDateTime` is read-only
+	if _, ok = model.Fields["lastModifiedDateTime"]; !ok {
+		return fmt.Errorf("`lastModifiedDateTime` field not found")
+	}
+	model.Fields["lastModifiedDateTime"].ReadOnly = true
+
+	return nil
+}

--- a/tools/importer-msgraph-metadata/components/workarounds/workarounds.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workarounds.go
@@ -22,6 +22,9 @@ var workarounds = []dataWorkaround{
 	workaroundApplication{},
 	workaroundConditionalAccessPolicy{},
 	workaroundUnifiedRoleAssignment{},
+	workaroundUnifiedRoleManagementPolicy{},
+	workaroundConnectedOrganization{},
+	workaroundCrossTenantAccessPolicyConfigurationPartner{},
 }
 
 // serviceWorkarounds make post-parsing changes to individual services and are able to make any changes to resources


### PR DESCRIPTION
This PR fixes some bugs I encountered whilst using the Graph SDK generated by pandora.

### Model `microsoft.graph.connectedOrganization`
The field `identitySources` cannot be read-only, as it needs to be set when creating a new connected organization.
Docs Ref: https://learn.microsoft.com/en-us/graph/api/entitlementmanagement-post-connectedorganizations?view=graph-rest-beta&tabs=http#request

### Model `microsoft.graph.crossTenantAccessPolicyConfigurationPartner`
The field `tenantId` cannot be read-only, otherwise it is impossible to create a new cross tenant access policy partner organization.
Docs Ref: https://learn.microsoft.com/en-us/graph/api/crosstenantaccesspolicy-post-partners?view=graph-rest-1.0&tabs=http#request

### Model `microsoft.graph.unifiedRoleManagementPolicy`
The fields `lastModifiedBy` and `lastModifiedDateTime` must be read only, as they can only be modified by the backend service. Attempting to set them results in HTTP Error 400 Bad Request.
Docs Ref: https://learn.microsoft.com/en-us/graph/api/unifiedrolemanagementpolicy-update?view=graph-rest-1.0&tabs=http#request