### PR TITLE
config: add network 2024-05-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -409,7 +409,7 @@ service "netapp" {
 }
 service "network" {
   name      = "Network"
-  available = ["2023-09-01", "2023-11-01", "2024-01-01", "2024-03-01"]
+  available = ["2023-09-01", "2023-11-01", "2024-01-01", "2024-03-01", "2024-05-01"]
 }
 service "networkanalytics" {
   name      = "NetworkAnalytics"


### PR DESCRIPTION
To support the [Network Manager IP address management](https://learn.microsoft.com/en-us/azure/virtual-network-manager/how-to-manage-ip-addresses-network-manager?tabs=azureportal) feature, the network API version 2024-05-01 has been released.
Details: [Azure REST API specs PR #31095](https://github.com/Azure/azure-rest-api-specs/pull/31095)