### PR TITLE
`importer` - fixup casing for `Microsoft.Cdn` to avoid resource ID parsing errors

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/cleanup/to_sort.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/cleanup/to_sort.go
@@ -128,7 +128,7 @@ func NormalizeResourceProviderName(input string) string {
 		"microsoft.azurestackhci":                  "Microsoft.AzureStackHCI",
 		"microsoft.baremetalinfrastructure":        "Microsoft.BareMetalInfrastructure",
 		"microsoft.botservice":                     "Microsoft.BotService",
-		"microsoft.cdn":                            "Microsoft.CDN",
+		"microsoft.cdn":                            "Microsoft.Cdn",
 		"microsoft.cognitiveservices":              "Microsoft.CognitiveServices",
 		"microsoft.confidentialledger":             "Microsoft.ConfidentialLedger",
 		"microsoft.connectedvmwarevsphere":         "Microsoft.ConnectedVMwarevSphere",


### PR DESCRIPTION
Source files and Service responses all use `Microsoft.Cdn` not `Microsoft.CDN`