### PR TITLE
config: adding desktopvirtualization API v2024-04-08-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -189,7 +189,7 @@ service "datashare" {
 }
 service "desktopvirtualization" {
   name      = "DesktopVirtualization"
-  available = ["2021-09-03-preview", "2022-02-10-preview", "2022-09-09", "2024-04-08-preview",]
+  available = ["2021-09-03-preview", "2022-02-10-preview", "2022-09-09", "2024-04-08-preview"]
   ignore    = ["2023-09-05", "2024-04-03"]
 }
 service "devcenter" {

--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -189,7 +189,7 @@ service "datashare" {
 }
 service "desktopvirtualization" {
   name      = "DesktopVirtualization"
-  available = ["2021-09-03-preview", "2022-02-10-preview", "2022-09-09"]
+  available = ["2021-09-03-preview", "2022-02-10-preview", "2022-09-09", "2024-04-08-preview",]
   ignore    = ["2023-09-05", "2024-04-03"]
 }
 service "devcenter" {


### PR DESCRIPTION
Given the following info, the desktopvirtualization API v2022-02-10-preview currently in use should be upgraded to 2024-04-08-preview.

```
On 11 March 2025, the following DesktopVirtualization APIs will no longer be supported, and you'll need to update to either API v. 2024-04-08-preview or API v. 2024-04-03: 
•	2021-08-04-preview 
•	2021-09-03-preview 
•	2022-01-12-privatepreview 
•	2022-02-10-preview 
•	2022-04-01-preview 
•	2022-08-09-privatepreview 
•	2023-01-28-privatepreview 
•	2023-01-30-preview 
•	2023-03-03-privatepreview 
•	2023-04-06-preview 
•	2023-11-01-preview 
•	2023-11-29-privatepreview 
•	2023-12-25-privatepreview 

If you update to API v. 2024-04-03, we recommend testing it first to see if it fits your needs, as API v. 2024-04-03 doesn't contain all the functionality as the APIs listed above. To retain all functionality, you'll need to update to API v. 2024-04-08-preview. 
```

Fix [#28259](https://github.com/hashicorp/terraform-provider-azurerm/issues/28259).
