### PR TITLE
importer-msgraph-metadata: workaround for `clientId` field in `oAuth2PermissionGrant` model

### DIFF
--- a/tools/importer-msgraph-metadata/components/workarounds/workaround_oauth2permissiongrant.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workaround_oauth2permissiongrant.go
@@ -24,7 +24,7 @@ func (workaroundOAuth2PermissionGrant) Process(apiVersion string, models parser.
 		return fmt.Errorf("`oAuth2PermissionGrant` model not found")
 	}
 
-	// `clientId` is not read-only
+	// `clientId` is not required
 	if _, ok = model.Fields["clientId"]; !ok {
 		return fmt.Errorf("`clientId` field not found")
 	}

--- a/tools/importer-msgraph-metadata/components/workarounds/workaround_oauth2permissiongrant.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workaround_oauth2permissiongrant.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package workarounds
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/pandora/tools/importer-msgraph-metadata/components/parser"
+)
+
+var _ dataWorkaround = workaroundOAuth2PermissionGrant{}
+
+// workaroundOAuth2PermissionGrant adds missing fields and fixes some field types.
+type workaroundOAuth2PermissionGrant struct{}
+
+func (workaroundOAuth2PermissionGrant) Name() string {
+	return "OAuth2PermissionGrant / clientId is not required when updating"
+}
+
+func (workaroundOAuth2PermissionGrant) Process(apiVersion string, models parser.Models, constants parser.Constants, resourceIds parser.ResourceIds) error {
+	model, ok := models["microsoft.graph.oAuth2PermissionGrant"]
+	if !ok {
+		return fmt.Errorf("`oAuth2PermissionGrant` model not found")
+	}
+
+	// `clientId` is not read-only
+	if _, ok = model.Fields["clientId"]; !ok {
+		return fmt.Errorf("`clientId` field not found")
+	}
+	model.Fields["clientId"].Required = false
+
+	return nil
+}

--- a/tools/importer-msgraph-metadata/components/workarounds/workarounds.go
+++ b/tools/importer-msgraph-metadata/components/workarounds/workarounds.go
@@ -21,6 +21,7 @@ var workarounds = []dataWorkaround{
 	workaroundAccessPackageResourceRoleScope{},
 	workaroundApplication{},
 	workaroundConditionalAccessPolicy{},
+	workaroundOAuth2PermissionGrant{},
 	workaroundUnifiedRoleAssignment{},
 }
 


### PR DESCRIPTION
According to docs, `clientId` is not updateable so it shouldn't be specified when patching.

- https://learn.microsoft.com/en-us/graph/api/oauth2permissiongrant-update?view=graph-rest-1.0
- https://learn.microsoft.com/en-us/graph/api/oauth2permissiongrant-update?view=graph-rest-beta

Related: https://github.com/hashicorp/terraform-provider-azuread/issues/1536