### PR TITLE
Support for purview 2024-04-01-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -482,7 +482,7 @@ service "privatedns" {
 }
 service "purview" {
   name      = "Purview"
-  available = ["2021-07-01", "2021-12-01"]
+  available = ["2021-07-01", "2021-12-01", "2024-04-01-preview"]
 }
 service "quota" {
   name      = "Quota"


### PR DESCRIPTION
Adds support for the lastest purview API.  This will allow support of Purview Accounts without automatically deploying a managed Azure Storage account.