### PR TITLE
config: adding desktopvirtualization API v2024-04-03

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -189,8 +189,8 @@ service "datashare" {
 }
 service "desktopvirtualization" {
   name      = "DesktopVirtualization"
-  available = ["2021-09-03-preview", "2022-02-10-preview", "2022-09-09", "2024-04-08-preview"]
-  ignore    = ["2023-09-05", "2024-04-03"]
+  available = ["2021-09-03-preview", "2022-02-10-preview", "2022-09-09", "2024-04-08-preview", "2024-04-03"]
+  ignore    = ["2023-09-05"]
 }
 service "devcenter" {
   name      = "DevCenter"

--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -189,7 +189,7 @@ service "datashare" {
 }
 service "desktopvirtualization" {
   name      = "DesktopVirtualization"
-  available = ["2021-09-03-preview", "2022-02-10-preview", "2022-09-09", "2024-04-08-preview", "2024-04-03"]
+  available = ["2021-09-03-preview", "2022-02-10-preview", "2022-09-09", "2024-04-03"]
   ignore    = ["2023-09-05"]
 }
 service "devcenter" {


### PR DESCRIPTION
Since the currently used `desktopvirtualization` API v2022-02-10-preview would no longer be supported on 11 March 2025, we should upgrade the API version of the `desktopvirtualization` RP.

Previously, I added `desktopvirtualization` API v2024-04-08-preview in [PR](https://github.com/hashicorp/pandora/pull/4589). Although this is the version with full functions recommended in the email, I just received a feedback from the service team that it is not recommended to use the preview version and it is recommended to upgrade to stable v2024-04-03. In addition, after a rough comparison, the functions of 2022-02-10-preview, which is now used by Terraform, are included in stable v2024-04-03, so v2024-04-08-preview is deleted and replaced with the latest stable v2024-04-03.

Swagger:
https://github.com/Azure/azure-rest-api-specs/tree/main/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/stable/2024-04-03