### PR TITLE
dataworkaround: add a workaround for storagecache 32537

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_storagecache_32537.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_storagecache_32537.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dataworkarounds
+
+import (
+	"fmt"
+
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+)
+
+// workaroundStorageCache32537 is a workaround to convert the `percentComplete` field to a float
+// which is what the API returns and results in an unmarshaling error in the SDK when trying to
+// read the response body - this can be removed when PR https://github.com/Azure/azure-rest-api-specs/pull/27577
+// has been merged
+type workaroundStorageCache32537 struct {
+}
+
+func (w workaroundStorageCache32537) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
+	return serviceName == "StorageCache" && apiVersion.APIVersion == "2023-05-01"
+}
+
+func (w workaroundStorageCache32537) Name() string {
+	return "StorageCache / 32537"
+}
+
+func (w workaroundStorageCache32537) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
+	resource, ok := input.Resources["AmlFilesystems"]
+	if !ok {
+		return nil, fmt.Errorf(`expected to find the API Resource "AmlFilesystems" but didn't`)
+	}
+
+	model, ok := resource.Models["AmlFilesystemArchiveStatus"]
+	if !ok {
+		return nil, fmt.Errorf(`expected the API resource "AmlFilesystems" to contain Model "AmlFilesystemArchiveStatus" but it didn't`)
+	}
+
+	field, ok := model.Fields["PercentComplete"]
+	if !ok {
+		return nil, fmt.Errorf(`expected the Model "AmlFilesystemArchiveStatus" to contain the field "PercentComplete" but it didn't'`)
+	}
+
+	field.ObjectDefinition = sdkModels.SDKObjectDefinition{
+		Type: sdkModels.FloatSDKObjectDefinitionType,
+	}
+
+	model.Fields["PercentComplete"] = field
+	resource.Models["AmlFilesystemArchiveStatus"] = model
+	input.Resources["AmlFilesystems"] = resource
+
+	return &input, nil
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -18,14 +18,15 @@ var workarounds = []workaround{
 	workaroundDigitalTwins25120{},
 	workaroundHDInsight26838{},
 	workaroundLoadTest20961{},
-	workaroundRedis22407{},
 	workaroundMachineLearning25142{},
+	workaroundNetwork29303{},
 	workaroundNewRelic29256{},
 	workaroundOperationalinsights27524{},
 	workaroundRecoveryServicesSiteRecovery26680{},
+	workaroundRedis22407{},
+	workaroundStorageCache32537{},
 	workaroundStreamAnalytics27577{},
 	workaroundSubscriptions20254{},
-	workaroundNetwork29303{},
 	workaroundWeb31682{},
 
 	// These workarounds relate to Terraform specific overrides we want to apply (for example for Resource Generation)


### PR DESCRIPTION
We're unable to unmarshal the response body for an Azure Managed Lustre File System if a Blob Integration Job has been configured.

Configuring this job causes the API to begin returning the Archive Status information where `percentComplete` is returned as a float but is defined as an integer in the swagger spec.

PR to fix this in the swagger spec: https://github.com/Azure/azure-rest-api-specs/pull/32537
Related to: https://github.com/hashicorp/terraform-provider-azurerm/issues/28502