### PR TITLE
Remove `kubernetes_cluster_trusted_access_role_binding` from the auto-generated resource

### DIFF
--- a/config/resources/containerservice.hcl
+++ b/config/resources/containerservice.hcl
@@ -4,38 +4,6 @@
 service "ContainerService" {
   terraform_package = "containers"
 
-  api "2023-03-02-preview" {
-    package "TrustedAccess" {
-      definition "kubernetes_cluster_trusted_access_role_binding" {
-        id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{managedClusterName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}"
-        display_name = "Kubernetes Cluster Trusted Access Role Binding"
-        website_subcategory = "Container"
-        description = <<HERE
-Manages a Kubernetes Cluster Trusted Access Role Binding
-~> **Note:** This Resource is in **Preview** to use this you must be opted into the Preview. You can do this by running `az feature register --namespace Microsoft.ContainerService --name TrustedAccessPreview` and then `az provider register -n Microsoft.ContainerService`
-HERE
-        test_data {
-          basic_variables {
-            lists = {
-              "roles" = ["Microsoft.MachineLearningServices/workspaces/mlworkload"]
-            }
-            strings = {
-              "source_resource_id" = "machine_learning_workspace_id"
-            }
-          }
-          complete_variables {
-            lists = {
-              "roles" = ["Microsoft.MachineLearningServices/workspaces/mlworkload", "Microsoft.MachineLearningServices/workspaces/inference-v1"]
-            }
-            strings = {
-              "source_resource_id" = "machine_learning_workspace_id"
-            }
-          }
-        }
-      }
-    }
-  }
-
   api "2024-04-01" {
     package "FleetMembers" {
       definition "kubernetes_fleet_member" {


### PR DESCRIPTION
to fix issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/28838

as suggested in https://github.com/hashicorp/pandora/pull/4467#issuecomment-2601830730, I'll disable the auto-gen here and change the resource to a manually written one.