### PR TITLE
Added DNS `2023-07-01-preview` API version

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -223,7 +223,7 @@ service "digitaltwins" {
 }
 service "dns" {
   name      = "DNS"
-  available = ["2018-05-01"]
+  available = ["2018-05-01","2023-07-01-preview"]
 }
 service "dnsresolver" {
   name      = "DNSResolver"


### PR DESCRIPTION
DNS 2023-07-01-preview adds support for DNSSec in Azure DNS Zones.

Helps progress https://github.com/hashicorp/terraform-provider-azurerm/issues/28732 - Support for DNSSec in azurerm_dns_zone

The Github web editor is adding a empty newline at the end of the file which I can't get rid of - let me know if you'd like it removed.