### PR TITLE
dataworkaround: add workaround for resources 29885

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_resources_29885.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_resources_29885.go
@@ -1,0 +1,47 @@
+package dataworkarounds
+
+import (
+	"fmt"
+
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+)
+
+var _ workaround = workaroundResources29885{}
+
+// workaroundResources29885 converts the `PrivateEndpointConnections` property from a string to an interface - this can be removed once
+// https://github.com/Azure/azure-rest-api-specs/issues/29885 has been fixed
+type workaroundResources29885 struct{}
+
+func (workaroundResources29885) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
+	return serviceName == "Resources" && apiVersion.APIVersion == "2020-05-01"
+}
+
+func (workaroundResources29885) Name() string {
+	return "Resources / 29885"
+}
+
+func (workaroundResources29885) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
+	resource, ok := input.Resources["ResourceManagementPrivateLink"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `ResourceManagementPrivateLink` but didn't get one")
+	}
+
+	model, ok := resource.Models["ResourceManagementPrivateLinkEndpointConnections"]
+	if !ok {
+		return nil, fmt.Errorf("couldn't find Model `ResourceManagementPrivateLinkEndpointConnections`")
+	}
+
+	field, ok := model.Fields["PrivateEndpointConnections"]
+	if !ok {
+		return nil, fmt.Errorf("couldn't find the field `PrivateEndpointConnections` in model `ResourceManagementPrivateLinkEndpointConnections`")
+	}
+	if field.ObjectDefinition.NestedItem != nil {
+		field.ObjectDefinition.NestedItem.Type = sdkModels.RawObjectSDKObjectDefinitionType
+	}
+
+	model.Fields["PrivateEndpointConnections"] = field
+	resource.Models["ResourceManagementPrivateLinkEndpointConnections"] = model
+	input.Resources["ResourceManagementPrivateLink"] = resource
+
+	return &input, nil
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -25,6 +25,7 @@ var workarounds = []workaround{
 	workaroundOperationalinsights27524{},
 	workaroundRecoveryServicesSiteRecovery26680{},
 	workaroundRedis22407{},
+	workaroundResources29885{},
 	workaroundStorageCache32537{},
 	workaroundStreamAnalytics27577{},
 	workaroundSubscriptions20254{},


### PR DESCRIPTION
related to:
workaround to covert the `string` type to `interface`
https://github.com/hashicorp/pandora/blob/db7e0f8b253d907aeeb84ce82a273bbda5cc5b91/api-definitions/resource-manager/Resources/2020-05-01/ResourceManagementPrivateLink/Model-ResourceManagementPrivateLinkEndpointConnections.json#L13-L17
https://github.com/hashicorp/terraform-provider-azurerm/issues/26670
https://github.com/Azure/azure-rest-api-specs/issues/29885
