### PR TITLE
add sovereign@2025-02-27-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -566,6 +566,10 @@ service "solutions" {
   name      = "ManagedApplications"
   available = ["2019-07-01", "2021-07-01"]
 }
+service "sovereign" {
+  name      = "Sovereign"
+  available = ["2025-02-27-preview"]
+}
 service "sql" {
   name      = "Sql"
   available = ["2023-08-01-preview"]


### PR DESCRIPTION
API spec: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/sovereign/resource-manager/Microsoft.Sovereign/preview/2025-02-27-preview/sovereign.json
The feature/RP is going to public preview soon.
The API spec is a preview version, however there will be no breaking change to the current version.  There might be new features in future stable version API, but this version will not be affected. Is it a qualified support candidate?