### PR TITLE
GHA: remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     interval: daily
     time: "07:00"
     timezone: "UTC"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "07:00"
-    timezone: "UTC"
-  open-pull-requests-limit: 2


### PR DESCRIPTION
Dependabot has stopped opening PRs to update the [Rest API specs submodule](https://github.com/Azure/azure-rest-api-specs/tree/78afda2a2c759dc0caa3a140a94021b322ca8f37) claiming the 2 open PR limit has been reached. There are no open dependabot PRs on the repo and after bumping this limit to 10 we still get the same error:
![image](https://github.com/user-attachments/assets/2bb29636-c8c8-46b3-9bf5-a3c1b111d1e6)
