### PR TITLE
add a common workaround for LROs not marked as LRO

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/common_workaround_is_lro.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/common_workaround_is_lro.go
@@ -1,0 +1,53 @@
+package dataworkarounds
+
+import (
+	"fmt"
+	"slices"
+
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+)
+
+// This is a common workaround for operations that are asynchronous but don't specify the `x-ms-long-running-operation` field as `true`
+var _ workaround = commonWorkaroundIsLRO{}
+
+type commonWorkaroundIsLRO struct {
+	serviceName string
+	apiVersions []string
+	resources   []string
+	operations  []string
+}
+
+func (w commonWorkaroundIsLRO) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
+	return serviceName == w.serviceName && slices.Contains(w.apiVersions, apiVersion.APIVersion)
+}
+
+func (w commonWorkaroundIsLRO) Name() string {
+	return fmt.Sprintf("Common Workaround `Is LRO` for `%s`", w.serviceName)
+}
+
+func (w commonWorkaroundIsLRO) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
+	for _, resource := range w.resources {
+		r, ok := input.Resources[resource]
+		if !ok {
+			return nil, fmt.Errorf("expected a resource named `%s` but didn't find one", resource)
+		}
+
+		for _, operation := range w.operations {
+			o, ok := r.Operations[operation]
+			if !ok {
+				return nil, fmt.Errorf("couldn't find operation `%s`", operation)
+			}
+
+			if o.LongRunning {
+				return nil, fmt.Errorf("expected operation `%s` to not be marked as `LongRunning`. The workaround for this operation should be removed", operation)
+			}
+
+			o.LongRunning = true
+			r.Operations[operation] = o
+		}
+
+		input.Resources[resource] = r
+	}
+
+	return &input, nil
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -5,6 +5,12 @@ package dataworkarounds
 
 var workarounds = []workaround{
 	// These workarounds are related to issues with the upstream API Definitions
+
+	// Common workarounds
+	// https://github.com/Azure/azure-rest-api-specs/issues/22758
+	commonWorkaroundIsLRO{"RecoveryServicesBackup", []string{"2023-02-01"}, []string{"ProtectedItems"}, []string{"CreateOrUpdate", "Delete"}},
+
+	// Workarounds
 	workaroundAlertsManagement{},
 	workaroundAuthorization25080{},
 	workaroundAutomation25108{},


### PR DESCRIPTION
Workaround needed to fully move `azurerm_backup_protected_vm` from `azure-sdk-for-go` to `go-azure-sdk`. Adding it as a common workaround since it looks like we'll need to use this for other resources in `recoveryservices` as well.

If this approach is acceptable, we could also remove `workaround_automation_25435.go` and replace it with `commonWorkaroundIsLRO`