### PR TITLE
add `containerInstance@2024-11-01-preview`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -126,7 +126,7 @@ service "consumption" {
 }
 service "containerinstance" {
   name      = "ContainerInstance"
-  available = ["2023-05-01"]
+  available = ["2023-05-01", "2024-11-01-preview"]
 }
 service "containerregistry" {
   name      = "ContainerRegistry"


### PR DESCRIPTION
The Standby Container Group Pool feature depends on `Container Group Profile` which is avaliable in this version.