### PR TITLE
`importer`: do not repeat plural if input is already in plural

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/cleanup/normalize_api_definitions.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/cleanup/normalize_api_definitions.go
@@ -40,6 +40,7 @@ func NormalizeTag(input string) string {
 	// come across them?)
 	output := input
 	output = strings.ReplaceAll(output, "EndPoint", "Endpoint")
+	output = strings.ReplaceAll(output, "VirtualMachineScaleSetVMS", "VirtualMachineScaleSetVMs")
 	output = strings.ReplaceAll(output, "NetWork", "Network")
 	output = strings.ReplaceAll(output, "Baremetalinfrastructure", "BareMetalInfrastructure")
 	output = strings.ReplaceAll(output, "virtualWans", "VirtualWANs")

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/cleanup/pluralise_helper.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/cleanup/pluralise_helper.go
@@ -64,7 +64,7 @@ func GetPlural(input string) string {
 	}
 
 	for _, v := range irregularPlurals() {
-		if input == v.single {
+		if input == v.single || v.plural == input {
 			return v.plural
 		}
 	}


### PR DESCRIPTION
This PR is an improvement for PR #4876 as filename or tags may already in special plural format, so `skus` should not be `skuses`