### PR TITLE
`managedidentity` - generate resource for `2024-11-30`

### DIFF
--- a/config/resources/managedidentity.hcl
+++ b/config/resources/managedidentity.hcl
@@ -4,7 +4,7 @@
 service "ManagedIdentity" {
   terraform_package = "managedidentity"
 
-  api "2023-01-31" {
+  api "2024-11-30" {
     package "ManagedIdentities" {
       definition "user_assigned_identity" {
         id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}"


### PR DESCRIPTION
To support new `isolationScope` property, resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/30213
swagger link: https://github.com/Azure/azure-rest-api-specs/blob/d8abc16a5028c51c10dac73809d907a07bbf25b1/specification/msi/resource-manager/Microsoft.ManagedIdentity/stable/2024-11-30/ManagedIdentity.json#L699