### PR TITLE
add postgresqlhsc@2023-03-02-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -463,7 +463,7 @@ service "postgresql" {
 }
 service "postgresqlhsc" {
   name      = "PostgreSqlHSC"
-  available = ["2022-11-08"]
+  available = ["2022-11-08", "2023-03-02-preview"]
 }
 service "powerbidedicated" {
   name      = "PowerBIDedicated"


### PR DESCRIPTION
We should be able to add entra id roles to the CosmosDB for PostgreSQL. This would also solve this long lasting [issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/26891) in the terraform-provider-azurerm repo.