### PR TITLE
Add PostgreSQL@2025-01-01-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -459,7 +459,7 @@ service "portal" {
 }
 service "postgresql" {
   name      = "PostgreSql"
-  available = ["2017-12-01", "2020-01-01", "2024-08-01"]
+  available = ["2017-12-01", "2020-01-01", "2024-08-01", "2025-01-01-preview"]
 }
 service "postgresqlhsc" {
   name      = "PostgreSqlHSC"


### PR DESCRIPTION
2025-01-01-preview API specs: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2025-01-01-preview

There's a strong feature request for PostgreSQL 17 from the community. However, the latest stable API version is still[ work in progress ](https://github.com/Azure/azure-rest-api-specs/pull/36219)which contains lots of breaking changes, and the release has been delayed for several times.

As an interim, to unblock us, we'll use 2025-01-01-preview to support v17. The service team has confirmed that if we migrate completely from the stable API to the preview one, all existing features will continue to function as expected. And the Preview API will provide production-level quality. I have already done local tests to make sure there's no breaking change.