### PR TITLE
Regenerate `recoveryservicesbackup@2025-02-01` to support LRO

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -8,7 +8,7 @@ var workarounds = []workaround{
 
 	// Common workarounds
 	// https://github.com/Azure/azure-rest-api-specs/issues/22758
-	commonWorkaroundIsLRO{"RecoveryServicesBackup", []string{"2023-02-01"}, []string{"ProtectedItems"}, []string{"CreateOrUpdate", "Delete"}},
+	commonWorkaroundIsLRO{"RecoveryServicesBackup", []string{"2023-02-01", "2025-02-01"}, []string{"ProtectedItems"}, []string{"CreateOrUpdate", "Delete"}},
 
 	// Workarounds
 	workaroundAlertsManagement{},


### PR DESCRIPTION
To support backup SAP databases, we'll need to upgrade `recoveryservicesbackup` SDK version to 2025-02-01. However, for `protectedItems`, relevant operations are not marked as LRO. Add this version to `commonWorkaroundIsLRO`.