### PR TITLE
Add LRO workaround for ProtectionContainers DELETE operation

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -8,6 +8,7 @@ var workarounds = []workaround{
 
 	// Common workarounds
 	// https://github.com/Azure/azure-rest-api-specs/issues/22758
+	// https://github.com/Azure/azure-rest-api-specs/issues/37325
 	commonWorkaroundIsLRO{"RecoveryServicesBackup", []string{"2023-02-01", "2025-02-01"}, []string{"ProtectedItems", "ProtectionContainers"}, []string{"CreateOrUpdate", "Delete"}},
 
 	// Workarounds


### PR DESCRIPTION
The `PUT` and `DELETE` operations in ProtectionContainers are asynchronous (https://github.com/Azure/azure-rest-api-specs/blob/main/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2025-02-01/bms.json#L3180-L3240). In 2025-02-01 API Swagger, LRO property is added to the `PUT` operation, but not for `DELETE`. Added this workaround as we'll need it to support backup SAP database feature.

I have also raised an [issue](https://github.com/Azure/azure-rest-api-specs/issues/37325) in API specs and reached out to the service team to get a fix.