### PR TITLE
`tooling` - Change runner to custom-linux-xl for unit tests

### DIFF
--- a/.github/workflows/unit-test-rest-api-specs-importer.yaml
+++ b/.github/workflows/unit-test-rest-api-specs-importer.yaml
@@ -12,9 +12,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
+    runs-on: custom-linux-xl
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:


### PR DESCRIPTION
removed fail fast as only relevant to matrix tests, and this workflow has no matrix.