### PR TITLE
Add recoveryservices@2025-08-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -490,7 +490,7 @@ service "quota" {
 }
 service "recoveryservices" {
   name      = "RecoveryServices"
-  available = ["2024-01-01", "2024-04-01", "2025-02-01"]
+  available = ["2024-01-01", "2024-04-01", "2025-02-01", "2025-08-01"]
 }
 service "recoveryservicesbackup" {
   name      = "RecoveryServicesBackup"


### PR DESCRIPTION
During testing of ASE DB Backup support, we identified that the current API version (`Recovery Services @ 2024-01-01`) [_prevents deleting a Recovery Services vault if it contains soft-deleted backup items._](https://learn.microsoft.com/en-us/rest/api/recoveryservices/deleted-vaults?view=rest-recoveryservices-2025-08-01)

This behavior [blocks](https://github.com/hashicorp/terraform-provider-azurerm/pull/30651#issuecomment-3375283354)`Recovery Services Backup @ 2025-02-01` SDK upgrade. It is due to the [_Secure by Default_ public preview feature ](https://learn.microsoft.com/en-us/azure/backup/secure-by-default) introduced in all stable APIs after 2024-09-30-preview. With this feature enabled, all backup items are soft deleted by default and cannot be adjusted. I have confirmed with the service team, it has been extended to all regions as public preview features.

`Recovery Services @ 2025-08-01` resolves this limitation by allowing soft deletion of a vault even when it contains soft-deleted backup items. And it contains a feature to [recover soft deleted vault](https://learn.microsoft.com/en-us/rest/api/recoveryservices/deleted-vaults?view=rest-recoveryservices-2025-08-01), which we could potentially onboard after it's GA. 

Therefore, this PR imports 2025-08-01.
