### PR TITLE
Add support for Nginx API version 2025-03-01-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -430,7 +430,7 @@ service "newrelic" {
 }
 service "nginx" {
   name      = "Nginx"
-  available = ["2024-11-01-preview"]
+  available = ["2024-11-01-preview", "2025-03-01-preview"]
 }
 service "notificationhubs" {
   name      = "NotificationHubs"


### PR DESCRIPTION
Add support for Nginx API version 2025-03-01-preview from azure-rest-api-spec for Terraform

**Preview API Exception Request – NGINX 2025-03-01-preview**
We’re requesting an exception to use the NGINX ARM preview API version 2025-03-01-preview.
The last stable API (2023-09-01) predates all current customer-facing production features. Critical security capabilities, including NGINX Web Application Firewall (WAF), are only available via this preview version. Without this exception, Terraform users cannot access these features.
We commit to long-term support and no breaking changes for this preview API. Although labeled “preview,” it operates as a stable version in practice. The next stable NGINX ARM API version is targeted for April 2026, and this exception is transitional.
Going forward, we’ve updated our approach to use stable APIs by default, reserving preview versions only for features under active testing.
Thanks for your consideration - happy to provide more details if needed.