### PR TITLE
config: remove retired service `VideoAnalyzer`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -626,10 +626,6 @@ service "vi" {
   name      = "VideoIndexer"
   available = ["2025-04-01"]
 }
-service "videoanalyzer" {
-  name      = "VideoAnalyzer"
-  available = ["2021-05-01-preview"]
-}
 service "vmware" {
   name      = "VMware"
   available = ["2022-05-01", "2024-09-01"]


### PR DESCRIPTION
Video Analyzer was retired 3 years ago and it's now been [removed from the azure-rest-api-specs repository](https://github.com/Azure/azure-rest-api-specs/pull/38256), causing generation failures.