### PR TITLE
workaround - MongoCluster `identity` field

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_mongocluster_38810.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_mongocluster_38810.go
@@ -1,0 +1,45 @@
+package dataworkarounds
+
+import (
+	"errors"
+
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+)
+
+var _ workaround = workaroundMongoCluster38810{}
+
+type workaroundMongoCluster38810 struct{}
+
+func (workaroundMongoCluster38810) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
+	return serviceName == "MongoCluster" && apiVersion.APIVersion == "2025-09-01"
+}
+
+func (workaroundMongoCluster38810) Name() string {
+	return "MongoCluster / 38810"
+}
+
+func (workaroundMongoCluster38810) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
+	resource, ok := input.Resources["MongoClusters"]
+	if !ok {
+		return nil, errors.New("expected a resource named `MongoClusters` but didn't get one")
+	}
+
+	model, ok := resource.Models["MongoCluster"]
+	if !ok {
+		return nil, errors.New("couldn't find model `MongoCluster`")
+	}
+
+	identityField, ok := model.Fields["Identity"]
+	if !ok {
+		return nil, errors.New("couldn't find the field `Identity`")
+	}
+
+	identityField.ObjectDefinition.Type = sdkModels.UserAssignedIdentityMapSDKObjectDefinitionType
+	identityField.ObjectDefinition.ReferenceName = nil
+
+	model.Fields["Identity"] = identityField
+	resource.Models["MongoCluster"] = model
+	input.Resources["MongoClusters"] = resource
+
+	return &input, nil
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -28,6 +28,7 @@ var workarounds = []workaround{
 	workaroundHDInsight26838{},
 	workaroundLoadTest20961{},
 	workaroundMachineLearning25142{},
+	workaroundMongoCluster38810{},
 	workaroundNetwork29303{},
 	workaroundNetwork38407{},
 	workaroundNewRelic29256{},


### PR DESCRIPTION
workaround for https://github.com/Azure/azure-rest-api-specs/issues/38810