### PR TITLE
config - remove `MobileNetwork` service due to retirement

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -383,10 +383,6 @@ service "migrate" {
   available = ["2020-01-01", "2020-07-07"]
   ignore    = ["2023-06-06"]
 }
-service "mobilenetwork" {
-  name      = "MobileNetwork"
-  available = ["2022-11-01", "2024-04-01"]
-}
 service "mongocluster" {
   name      = "MongoCluster"
   available = ["2024-07-01", "2025-09-01"]


### PR DESCRIPTION
Will resolve the generation errors in #5102 

Note: This service has been retired, the API specs have been removed. The Mobile Network resources will have to be removed from the `azurerm` provider outside of a major version, however since the RP has been fully removed it's not a breaking change.

`InvalidResourceNamespace: The resource namespace 'Microsoft.MobileNetwork' is invalid.`