### PR TITLE
Add cosmos-db 2025-10-15

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -141,7 +141,7 @@ service "containerservice" {
 }
 service "cosmos-db" {
   name      = "CosmosDB"
-  available = ["2022-05-15", "2022-11-15", "2023-04-15", "2024-08-15", "2025-04-15"]
+  available = ["2022-05-15", "2022-11-15", "2023-04-15", "2024-08-15", "2025-04-15", "2025-10-15"]
 }
 service "cost-management" {
   name      = "CostManagement"


### PR DESCRIPTION
Spec: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2025-10-15

This PR is created to add Azure Cosmos DB fleet to [Terraform Provider for Azure](https://github.com/hashicorp/terraform-provider-azurerm) in response to issue hashicorp/terraform-provider-azurerm#31243.