### PR TITLE
`keyvault` - Skip constant normalization for access policy permissions

### DIFF
--- a/tools/data-api-repository/repository/internal/models/constants.go
+++ b/tools/data-api-repository/repository/internal/models/constants.go
@@ -14,6 +14,11 @@ type Constant struct {
 	// Type specifies what kind of Constant this is (a StringConstant, IntegerConstant etc).
 	Type ConstantType `json:"type"`
 
+	// SkipNormalization indicates that the normalization function should not be
+	// generated for this constant. This is a workaround for API bugs where the
+	// exact casing of constant values must be preserved.
+	SkipNormalization bool `json:"skipNormalization,omitempty"`
+
 	// Values defines the possible values for this Constant
 	//
 	// > ".. why not use a `map[string]ConstantValue` here?" I hear you ask

--- a/tools/data-api-repository/repository/internal/transforms/sdk_constant.go
+++ b/tools/data-api-repository/repository/internal/transforms/sdk_constant.go
@@ -23,8 +23,9 @@ func MapSDKConstantFromRepository(input repositoryModels.Constant) (*sdkModels.S
 		values[item.Key] = item.Value
 	}
 	return &sdkModels.SDKConstant{
-		Type:   *constantType,
-		Values: values,
+		Type:              *constantType,
+		Values:            values,
+		SkipNormalization: input.SkipNormalization,
 	}, nil
 }
 
@@ -53,9 +54,10 @@ func MapSDKConstantToRepository(constantName string, details sdkModels.SDKConsta
 	}
 
 	return &repositoryModels.Constant{
-		Name:   constantName,
-		Type:   pointer.From(constantType),
-		Values: values,
+		Name:              constantName,
+		Type:              pointer.From(constantType),
+		SkipNormalization: details.SkipNormalization,
+		Values:            values,
 	}, nil
 }
 

--- a/tools/data-api-sdk/v1/models/sdk_constant.go
+++ b/tools/data-api-sdk/v1/models/sdk_constant.go
@@ -18,4 +18,9 @@ type SDKConstant struct {
 	// float values.
 	// NOTE: the Constant Name is a valid Identifier.
 	Values map[string]string `json:"values"`
+
+	// SkipNormalization indicates that the normalization function should not be
+	// generated for this constant. This is a workaround for API bugs where the
+	// exact casing of constant values must be preserved.
+	SkipNormalization bool `json:"skipNormalization,omitempty"`
 }

--- a/tools/generator-go-sdk/internal/generator/templater_constants.go
+++ b/tools/generator-go-sdk/internal/generator/templater_constants.go
@@ -37,8 +37,16 @@ func (c constantsTemplater) template(data GeneratorData) (*string, error) {
 		// The Key Vault API requires that the EXACT casing sent in the Response is sent in the Request
 		// to remove a Key Vault Access Policy.
 		// TODO: remove this when https://github.com/Azure/azure-rest-api-specs/issues/42963 has been resolved
-		if data.servicePackageName == "keyvault" && data.packageName == "Vaults" && data.apiVersion == "2026-02-01" {
-			generateNormalizationFunction = false
+		if data.servicePackageName == "keyvault" && data.packageName == "vaults" && data.apiVersion == "2026-02-01" {
+			affectedConstants := map[string]struct{}{
+				"CertificatePermissions": {},
+				"KeyPermissions":         {},
+				"SecretPermissions":      {},
+				"StoragePermissions":     {},
+			}
+			if _, ok := affectedConstants[constantName]; ok {
+				generateNormalizationFunction = false
+			}
 		}
 
 		// used to reduce the TLOC being output

--- a/tools/generator-go-sdk/internal/generator/templater_constants.go
+++ b/tools/generator-go-sdk/internal/generator/templater_constants.go
@@ -34,6 +34,13 @@ func (c constantsTemplater) template(data GeneratorData) (*string, error) {
 		// rollout of the new base layer, to allow us to go gradually
 		generateNormalizationFunction := data.useNewBaseLayer
 
+		// The Key Vault API requires that the EXACT casing sent in the Response is sent in the Request
+		// to remove a Key Vault Access Policy.
+		// TODO: remove this when https://github.com/Azure/azure-rest-api-specs/issues/42963 has been resolved
+		if data.servicePackageName == "keyvault" && data.packageName == "Vaults" && data.apiVersion == "2026-02-01" {
+			generateNormalizationFunction = false
+		}
+
 		// used to reduce the TLOC being output
 		usedInAResourceId := false
 		for _, id := range data.resourceIds {

--- a/tools/generator-go-sdk/internal/generator/templater_constants.go
+++ b/tools/generator-go-sdk/internal/generator/templater_constants.go
@@ -34,19 +34,9 @@ func (c constantsTemplater) template(data GeneratorData) (*string, error) {
 		// rollout of the new base layer, to allow us to go gradually
 		generateNormalizationFunction := data.useNewBaseLayer
 
-		// The Key Vault API requires that the EXACT casing sent in the Response is sent in the Request
-		// to remove a Key Vault Access Policy.
-		// TODO: remove this when https://github.com/Azure/azure-rest-api-specs/issues/42963 has been resolved
-		if data.servicePackageName == "keyvault" && data.packageName == "vaults" && data.apiVersion == "2026-02-01" {
-			affectedConstants := map[string]struct{}{
-				"CertificatePermissions": {},
-				"KeyPermissions":         {},
-				"SecretPermissions":      {},
-				"StoragePermissions":     {},
-			}
-			if _, ok := affectedConstants[constantName]; ok {
-				generateNormalizationFunction = false
-			}
+		// Check if the constant has been flagged to skip normalization via a data workaround
+		if values.SkipNormalization {
+			generateNormalizationFunction = false
 		}
 
 		// used to reduce the TLOC being output

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_keyvault_42963.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_keyvault_42963.go
@@ -1,0 +1,56 @@
+// Copyright IBM Corp. 2021, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataworkarounds
+
+import (
+	"fmt"
+
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+)
+
+// workaroundKeyVault42963 is a workaround for a Key Vault API bug where the exact casing
+// of permission constant values must be preserved. When removing a Key Vault Access Policy,
+// the API requires the request to use the exact same casing for permission values as returned
+// in the response. If the SDK normalizes these constants (e.g., LowerCase from TitleCase),
+// the API silently fails the request.
+//
+// Swagger Issue: https://github.com/Azure/azure-rest-api-specs/issues/42963
+var _ workaround = workaroundKeyVault42963{}
+
+type workaroundKeyVault42963 struct{}
+
+func (workaroundKeyVault42963) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
+	return serviceName == "KeyVault" && apiVersion.APIVersion == "2026-02-01"
+}
+
+func (workaroundKeyVault42963) Name() string {
+	return "KeyVault / 42963"
+}
+
+func (workaroundKeyVault42963) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
+	resource, ok := input.Resources["Vaults"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `Vaults` but didn't get one")
+	}
+
+	affectedConstants := []string{
+		"CertificatePermissions",
+		"KeyPermissions",
+		"SecretPermissions",
+		"StoragePermissions",
+	}
+
+	for _, constantName := range affectedConstants {
+		constant, ok := resource.Constants[constantName]
+		if !ok {
+			return nil, fmt.Errorf("expected a Constant named `%s` but didn't get one", constantName)
+		}
+		constant.SkipNormalization = true
+		resource.Constants[constantName] = constant
+	}
+
+	input.Resources["Vaults"] = resource
+
+	return &input, nil
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -33,6 +33,7 @@ var workarounds = []workaround{
 	workaroundDigitalTwins25120{},
 	workaroundFluidRelay39089{},
 	workaroundHDInsight26838{},
+	workaroundKeyVault42963{},
 	workaroundLoadTest20961{},
 	workaroundMachineLearning25142{},
 	workaroundMachineLearning40149{},


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. -->

All Key Vault control plane API versions prior to 2026-02-01 will be **retired** on February 27, 2027, so we are [updating to 2026-02-01](https://github.com/hashicorp/terraform-provider-azurerm/pull/32320).

However, there is a **known API bug**: when removing a Key Vault Access Policy, the API requires the request to _**use the exact same casing for permission values as returned in the response**_. If the SDK normalizes these constants (e.g. to LowerCase from TitleCase), the API silently fails the request, which times out eventually.

This PR works around the issue by skipping the normalization function for the four affected constants (`CertificatePermissions, KeyPermissions, SecretPermissions, StoragePermissions`) in KeyVault/Vaults/2026-02-01, preserving the original casing from the API response.

Azure Rest API Specs issue for track:
https://github.com/Azure/azure-rest-api-specs/issues/42963

Relevant past PRs for contexts:
https://github.com/hashicorp/pandora/pull/3672/changes

## PR Checklist

- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so, please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Adding New API Version

<!-- Complete this section if adding a new Service or API Version. Otherwise, delete it. -->

> [!IMPORTANT]
> The primary purpose of API versions in this repository is to serve the **Terraform Azure Providers**. API versions are imported and maintained to support the providers' needs. If you would like to add an API version for use outside of the providers (e.g., another project consuming `go-azure-sdk`), please include a description of what you would like to use it for so we can evaluate the request.

- [ ] I have verified the Service/API Version exists in the Azure REST API Specs.
- [ ] I have followed the [Service Import Guide](../blob/main/docs/resource-manager-service-import.md).
- [ ] This PR is for another downstream project and not for the Terraform Azure Providers.

<!-- If this is NOT for the Terraform Azure Provider, please explain what this change is for: -->


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->
### Preview API Version

<!-- If you are adding a preview API version, please answer the following questions. Otherwise, delete this subsection. -->

> [!IMPORTANT]
> We generally do not add preview API versions to `go-azure-sdk`, and we rarely support preview features in the provider. Exceptions require strong justification, such as when preview features have no GA date or no stable API version exists for a service. Please ensure you have thoroughly considered whether a preview API is truly necessary before proceeding.

- [ ] This PR adds a **preview** API version

1. **Is there a stable (GA) version available?**
   <!-- If a stable version exists, explain why the preview version is being used instead. -->

2. **Why should we support this preview API?**
   <!-- Explain the value/necessity of supporting this preview API, e.g., new feature availability, customer demand, etc. -->

3. **Do existing resources already use a preview API?**
   <!-- List any existing resources that currently use a preview API version. -->

4. **What is the expected timeline for GA?**
   <!-- If known, provide the expected date or timeframe for when this API will become stable. -->


## Changes to Tooling

<!-- Complete this section if modifying any tools. Otherwise, delete it. -->

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [ ] I have written new tests for my changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges.

**Testing Command(s) Used:**
```shell
# e.g., go test ./tools/generator-go-sdk/...
```

**Testing Evidence:**

<!-- Please include testing logs or evidence here, or an explanation on why no testing evidence can be provided. -->


## Changes to Resource Config

<!-- Complete this section if modifying resource configuration. Otherwise, delete it. -->

- [ ] I have followed the [Resource Generation Guide](../blob/main/docs/resource-manager-generate-new-resource.md).
- [ ] I have verified the required SDK is available in `hashicorp/go-azure-sdk`.


## Related Issue(s)

<!-- Use closing keywords if applicable, e.g., "Fixes #123" -->


## AI Assistance Disclosure

<!-- 
If you are using any kind of AI/LLM assistance to contribute, this must be disclosed in the pull request.

If this is the case, please check the box below and describe the extent of AI usage (e.g., documentation only, code generation, etc.)
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->


> [!NOTE] 
> If this PR changes meaningfully during the course of review, please update the title and description as required.
