### PR TITLE
`importer`: allow child field to overwrite allOf fields if child is more specific

### DIFF
--- a/tools/data-api-repository/repository/internal/transforms/sdk_model.go
+++ b/tools/data-api-repository/repository/internal/transforms/sdk_model.go
@@ -76,13 +76,18 @@ func mapSDKFieldsForModel(model sdkModels.SDKModel, parentModel *sdkModels.SDKMo
 	for _, fieldName := range sortedFieldNames {
 		// we should skip outputting this field if it's present on the parent
 		fieldInParent := false
+		field := model.Fields[fieldName]
+
 		if parentModel != nil {
 			// the importer flattens fields from parents/AllOf, since we don't use inheritance for that within the
 			// data layer - as such we only want to skip the fields when the parent type is output, e.g. when there's
 			// a discriminator involved
-			for name := range parentModel.Fields {
+			// keep the field if more specific than the parent field even with the same name
+			for name, parentField := range parentModel.Fields {
 				if strings.EqualFold(name, fieldName) {
-					fieldInParent = true
+					if !shouldOverwriteParentField(field, parentField) {
+						fieldInParent = true
+					}
 					break
 				}
 			}
@@ -91,7 +96,6 @@ func mapSDKFieldsForModel(model sdkModels.SDKModel, parentModel *sdkModels.SDKMo
 			continue
 		}
 
-		field := model.Fields[fieldName]
 		isTypeHint := model.FieldNameContainingDiscriminatedValue != nil && strings.EqualFold(*model.FieldNameContainingDiscriminatedValue, fieldName)
 		fieldCode, err := mapSDKFieldToRepository(fieldName, field, isTypeHint, knownData)
 		if err != nil {
@@ -102,4 +106,23 @@ func mapSDKFieldsForModel(model sdkModels.SDKModel, parentModel *sdkModels.SDKMo
 	}
 
 	return &fields, nil
+}
+
+// shouldOverwriteParentField returns true if the child field is more specific than the
+// parent field, meaning the child should be output to overwrite the parent's definition.
+// This handles the case where the parent defines a field as a raw object but the child
+// provides a more specific type for that field.
+func shouldOverwriteParentField(child, parent sdkModels.SDKField) bool {
+	return isRawObjectDefinition(parent.ObjectDefinition) && !isRawObjectDefinition(child.ObjectDefinition)
+}
+
+func isRawObjectDefinition(def sdkModels.SDKObjectDefinition) bool {
+	if def.Type == sdkModels.RawObjectSDKObjectDefinitionType {
+		return true
+	}
+	// e.g. List<RawObject> or Dictionary<RawObject>
+	if def.NestedItem != nil {
+		return isRawObjectDefinition(*def.NestedItem)
+	}
+	return false
 }

--- a/tools/generator-go-sdk/internal/generator/templater_models.go
+++ b/tools/generator-go-sdk/internal/generator/templater_models.go
@@ -321,6 +321,11 @@ func (c modelsTemplater) structLinesForModel(data GeneratorData, fieldNames []st
 					output = append(output, fmt.Sprintf("\n// Fields inherited from %s", ancestorName))
 				}
 				for _, fieldName := range ancestorFieldNames[ancestorName] {
+					// skip if overwriten by child model, if fieldName exists in child model's fields
+					if _, ok := c.model.Fields[fieldName]; ok {
+						continue
+					}
+
 					fieldDetails := ancestorFields[ancestorName][fieldName]
 
 					topLevelObject := helpers.InnerMostSDKObjectDefinition(fieldDetails.ObjectDefinition)

--- a/tools/generator-go-sdk/internal/generator/templater_models.go
+++ b/tools/generator-go-sdk/internal/generator/templater_models.go
@@ -321,7 +321,7 @@ func (c modelsTemplater) structLinesForModel(data GeneratorData, fieldNames []st
 					output = append(output, fmt.Sprintf("\n// Fields inherited from %s", ancestorName))
 				}
 				for _, fieldName := range ancestorFieldNames[ancestorName] {
-					// skip if overwriten by child model, if fieldName exists in child model's fields
+					// skip if overwriten by child model
 					if _, ok := c.model.Fields[fieldName]; ok {
 						continue
 					}

--- a/tools/generator-go-sdk/internal/generator/templater_models.go
+++ b/tools/generator-go-sdk/internal/generator/templater_models.go
@@ -365,7 +365,11 @@ func (c modelsTemplater) structLineForField(fieldName, fieldType string, fieldDe
 		jsonDetails += ",omitempty"
 	} else {
 		if c.fieldIsOptional(data, fieldDetails) || fieldDetails.ReadOnly {
-			fieldType = fmt.Sprintf("*%s", fieldType)
+			// do not add pointer to interface{} type if c.model is a parent type
+			// todo: not add pointer to all interface{} types
+			if !c.model.IsDiscriminatedParentType() || fieldDetails.ObjectDefinition.Type != models.RawObjectSDKObjectDefinitionType {
+				fieldType = fmt.Sprintf("*%s", fieldType)
+			}
 			jsonDetails += ",omitempty"
 		} else if fieldDetails.ObjectDefinition.Nullable {
 			fieldType = fmt.Sprintf("*%s", fieldType)


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. -->

While it is not suggested, OpenAPI2.0 allows the allOf object contains fields with the same name as the discriminators types, this PR is to allow the child's field to overwrite parent fields when child has more specific type. like: https://github.com/hashicorp/terraform-provider-azurerm/pull/32347#discussion_r3206720446 


## PR Checklist

- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so, please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Adding New API Version

<!-- Complete this section if adding a new Service or API Version. Otherwise, delete it. -->

> [!IMPORTANT]
> The primary purpose of API versions in this repository is to serve the **Terraform Azure Providers**. API versions are imported and maintained to support the providers' needs. If you would like to add an API version for use outside of the providers (e.g., another project consuming `go-azure-sdk`), please include a description of what you would like to use it for so we can evaluate the request.

- [ ] I have verified the Service/API Version exists in the Azure REST API Specs.
- [ ] I have followed the [Service Import Guide](../blob/main/docs/resource-manager-service-import.md).
- [ ] This PR is for another downstream project and not for the Terraform Azure Providers.

<!-- If this is NOT for the Terraform Azure Provider, please explain what this change is for: -->


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->
### Preview API Version

<!-- If you are adding a preview API version, please answer the following questions. Otherwise, delete this subsection. -->

> [!IMPORTANT]
> We generally do not add preview API versions to `go-azure-sdk`, and we rarely support preview features in the provider. Exceptions require strong justification, such as when preview features have no GA date or no stable API version exists for a service. Please ensure you have thoroughly considered whether a preview API is truly necessary before proceeding.

- [ ] This PR adds a **preview** API version

1. **Is there a stable (GA) version available?**
   <!-- If a stable version exists, explain why the preview version is being used instead. -->

2. **Why should we support this preview API?**
   <!-- Explain the value/necessity of supporting this preview API, e.g., new feature availability, customer demand, etc. -->

3. **Do existing resources already use a preview API?**
   <!-- List any existing resources that currently use a preview API version. -->

4. **What is the expected timeline for GA?**
   <!-- If known, provide the expected date or timeframe for when this API will become stable. -->


## Changes to Tooling

<!-- Complete this section if modifying any tools. Otherwise, delete it. -->

- [ ] I have added an explanation of what my changes do and why I'd like you to include them.
- [ ] I have written new tests for my changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges.

**Testing Command(s) Used:**
```shell
# e.g., go test ./tools/generator-go-sdk/...
```

**Testing Evidence:**

<!-- Please include testing logs or evidence here, or an explanation on why no testing evidence can be provided. -->

a git diff of a full import, review content in: https://github.com/wuxu92/pandora/commit/9c86faa8c1b3d0a2d44955843d3b66acd6243cb8 

```
        modified:   ../../api-definitions/resource-manager/RedisEnterprise/2025-04-01/AccessPolicyAssignments/Model-AccessPolicyAssignment.json
        modified:   ../../api-definitions/resource-manager/RedisEnterprise/2025-04-01/Databases/Model-AccessPolicyAssignment.json
        modified:   ../../api-definitions/resource-manager/RedisEnterprise/2025-04-01/Databases/Model-Database.json
        modified:   ../../api-definitions/resource-manager/RedisEnterprise/2025-04-01/RedisEnterprise/Model-AccessPolicyAssignment.json
        modified:   ../../api-definitions/resource-manager/RedisEnterprise/2025-04-01/RedisEnterprise/Model-Cluster.json
        modified:   ../../api-definitions/resource-manager/RedisEnterprise/2025-04-01/RedisEnterprise/Model-Database.json
        modified:   ../../api-definitions/resource-manager/Security/2022-05-01/Settings/Model-AlertSyncSettings.json
        modified:   ../../api-definitions/resource-manager/Security/2022-05-01/Settings/Model-DataExportSettings.json
        modified:   ../../api-definitions/resource-manager/Security/2023-05-01/ServerVulnerabilityAssessmentsSettings/Model-AzureServersSetting.json
```
The changes of `RedisEnterprise` looks good to me, as the systemData is not exists in swagger but added in https://github.com/hashicorp/pandora/pull/5383 

## Changes to Resource Config

<!-- Complete this section if modifying resource configuration. Otherwise, delete it. -->

- [ ] I have followed the [Resource Generation Guide](../blob/main/docs/resource-manager-generate-new-resource.md).
- [ ] I have verified the required SDK is available in `hashicorp/go-azure-sdk`.


## Related Issue(s)

<!-- Use closing keywords if applicable, e.g., "Fixes #123" -->


## AI Assistance Disclosure

<!-- 
If you are using any kind of AI/LLM assistance to contribute, this must be disclosed in the pull request.

If this is the case, please check the box below and describe the extent of AI usage (e.g., documentation only, code generation, etc.)
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->


> [!NOTE] 
> If this PR changes meaningfully during the course of review, please update the title and description as required.
