### PR TITLE
`paloalto` - Include 2025-10-08 in the workaround

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_paloaltonetworks_38348.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_paloaltonetworks_38348.go
@@ -20,35 +20,35 @@ func (workaroundPaloAltoNetworks38348) Name() string {
 }
 
 func (workaroundPaloAltoNetworks38348) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
-	resource, ok := input.Resources["Firewalls"]
+	resource, ok := input.Resources["FirewallResources"]
 	if !ok {
-		return nil, errors.New("expected a resource named `Firewalls` but didn't get one")
+		return nil, errors.New("expected a resource named `FirewallResources` but didn't get one")
 	}
 
-    models := []string{
-        "FirewallResource",
-        "FirewallResourceUpdate",
-    }
+	models := []string{
+		"FirewallResource",
+		"FirewallResourceUpdate",
+	}
 
-    for _, modelName := range models {
-        model, ok := resource.Models[modelName]
-        if !ok {
-            return nil, fmt.Errorf("couldn't find model `%s`", modelName)
-        }
+	for _, modelName := range models {
+		model, ok := resource.Models[modelName]
+		if !ok {
+			return nil, fmt.Errorf("couldn't find model `%s`", modelName)
+		}
 
-        identityField, ok := model.Fields["Identity"]
-        if !ok {
-            return nil, fmt.Errorf("couldn't find the field `Identity` within model `%s`", modelName)
-        }
+		identityField, ok := model.Fields["Identity"]
+		if !ok {
+			return nil, fmt.Errorf("couldn't find the field `Identity` within model `%s`", modelName)
+		}
 
-        identityField.ObjectDefinition.Type = sdkModels.UserAssignedIdentityMapSDKObjectDefinitionType
-        identityField.ObjectDefinition.ReferenceName = nil
+		identityField.ObjectDefinition.Type = sdkModels.UserAssignedIdentityMapSDKObjectDefinitionType
+		identityField.ObjectDefinition.ReferenceName = nil
 
-        model.Fields["Identity"] = identityField
-        resource.Models[modelName] = model
-    }
+		model.Fields["Identity"] = identityField
+		resource.Models[modelName] = model
+	}
 
-    input.Resources["Firewalls"] = resource
+	input.Resources["FirewallResources"] = resource
 
-    return &input, nil
+	return &input, nil
 }

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_paloaltonetworks_38348.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_paloaltonetworks_38348.go
@@ -12,7 +12,7 @@ var _ workaround = workaroundPaloAltoNetworks38348{}
 type workaroundPaloAltoNetworks38348 struct{}
 
 func (workaroundPaloAltoNetworks38348) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
-	return serviceName == "PaloAltoNetworks" && apiVersion.APIVersion == "2025-05-23"
+	return serviceName == "PaloAltoNetworks" && apiVersion.APIVersion == "2025-10-08"
 }
 
 func (workaroundPaloAltoNetworks38348) Name() string {

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_paloaltonetworks_38348.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_paloaltonetworks_38348.go
@@ -1,7 +1,6 @@
 package dataworkarounds
 
 import (
-	"errors"
 	"fmt"
 
 	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
@@ -22,18 +21,18 @@ func (workaroundPaloAltoNetworks38348) Name() string {
 func (workaroundPaloAltoNetworks38348) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
 	// The resource (tag) name differs between API Versions - in `2025-05-23` it's `Firewalls`
 	// whereas in `2025-10-08` it's `FirewallResources`.
-	resourceName := ""
-	for _, candidate := range []string{"Firewalls", "FirewallResources"} {
-		if _, ok := input.Resources[candidate]; ok {
-			resourceName = candidate
-			break
-		}
-	}
-	if resourceName == "" {
-		return nil, errors.New("expected a resource named `Firewalls` or `FirewallResources` but didn't get one")
+	resourceName, ok := map[string]string{
+		"2025-05-23": "Firewalls",
+		"2025-10-08": "FirewallResources",
+	}[input.APIVersion]
+	if !ok {
+		return nil, fmt.Errorf("unexpected API Version %q", input.APIVersion)
 	}
 
-	resource := input.Resources[resourceName]
+	resource, ok := input.Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("expected a resource named `%s` but didn't get one", resourceName)
+	}
 
 	models := []string{
 		"FirewallResource",

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_paloaltonetworks_38348.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_paloaltonetworks_38348.go
@@ -12,7 +12,7 @@ var _ workaround = workaroundPaloAltoNetworks38348{}
 type workaroundPaloAltoNetworks38348 struct{}
 
 func (workaroundPaloAltoNetworks38348) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
-	return serviceName == "PaloAltoNetworks" && apiVersion.APIVersion == "2025-10-08"
+	return serviceName == "PaloAltoNetworks" && (apiVersion.APIVersion == "2025-05-23" || apiVersion.APIVersion == "2025-10-08")
 }
 
 func (workaroundPaloAltoNetworks38348) Name() string {
@@ -20,10 +20,20 @@ func (workaroundPaloAltoNetworks38348) Name() string {
 }
 
 func (workaroundPaloAltoNetworks38348) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
-	resource, ok := input.Resources["FirewallResources"]
-	if !ok {
-		return nil, errors.New("expected a resource named `FirewallResources` but didn't get one")
+	// The resource (tag) name differs between API Versions - in `2025-05-23` it's `Firewalls`
+	// whereas in `2025-10-08` it's `FirewallResources`.
+	resourceName := ""
+	for _, candidate := range []string{"Firewalls", "FirewallResources"} {
+		if _, ok := input.Resources[candidate]; ok {
+			resourceName = candidate
+			break
+		}
 	}
+	if resourceName == "" {
+		return nil, errors.New("expected a resource named `Firewalls` or `FirewallResources` but didn't get one")
+	}
+
+	resource := input.Resources[resourceName]
 
 	models := []string{
 		"FirewallResource",
@@ -48,7 +58,7 @@ func (workaroundPaloAltoNetworks38348) Process(input sdkModels.APIVersion) (*sdk
 		resource.Models[modelName] = model
 	}
 
-	input.Resources["FirewallResources"] = resource
+	input.Resources[resourceName] = resource
 
 	return &input, nil
 }


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. -->

Only `UserAssigned` identity is supported (https://github.com/Azure/azure-rest-api-specs/issues/38348).
```
2026-06-15T16:06:56.345+1000 [DEBUG] provider.terraform-provider-azurerm.exe: [DEBUG] AzureRM Response for https://management.azure.com/subscriptions/cb56xx/resourceGroups/acctestRG-PANGFWVN-lucia/providers/PaloAltoNetworks.Cloudngfw/firewalls/acctest-ngfwvn-lucia?api-version=2025-10-08: 
2026-06-15T16:06:56.345+1000 [DEBUG] provider.terraform-provider-azurerm.exe: HTTP/1.1 400 Bad Request
2026-06-15T16:06:56.348+1000 [DEBUG] provider.terraform-provider-azurerm.exe: X-Ms-Correlation-Request-Id: 9c722fbf-8bc6-684b-bc55-626bf3f5ee8f
2026-06-15T16:06:56.349+1000 [DEBUG] provider.terraform-provider-azurerm.exe: X-Ms-Request-Id: ec60af3a-97d5-4d28-b039-359ed7aee833
2026-06-15T16:06:56.349+1000 [DEBUG] provider.terraform-provider-azurerm.exe
2026-06-15T16:06:56.349+1000 [DEBUG] provider.terraform-provider-azurerm.exe: {"error":{"code":"ResourceCreationValidateFailed","message":"Identity must be UserAssigned type. "}}
```

However, this workaround is not applied in the current version, causing regressions in AzureRM (https://github.com/hashicorp/terraform-provider-azurerm/issues/32567)

## PR Checklist

- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so, please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Related Issue(s)

<!-- Use closing keywords if applicable, e.g., "Fixes #123" -->


## AI Assistance Disclosure

<!-- 
If you are using any kind of AI/LLM assistance to contribute, this must be disclosed in the pull request.

If this is the case, please check the box below and describe the extent of AI usage (e.g., documentation only, code generation, etc.)
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->


> [!NOTE] 
> If this PR changes meaningfully during the course of review, please update the title and description as required.
