### PR TITLE
add workaround for security insights

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_securityinsights_22893.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_securityinsights_22893.go
@@ -1,0 +1,52 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dataworkarounds
+
+import (
+	"errors"
+	"fmt"
+
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+)
+
+var _ workaround = WorkaroundSecurityInsights22893{}
+
+type WorkaroundSecurityInsights22893 struct{}
+
+func (WorkaroundSecurityInsights22893) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
+	return serviceName == "SecurityInsights" && apiVersion.APIVersion == "2022-10-01-preview"
+}
+
+func (w WorkaroundSecurityInsights22893) Name() string {
+	return "Security Insights / 22893"
+}
+
+func (w WorkaroundSecurityInsights22893) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
+	resource, ok := input.Resources["ThreatIntelligence"]
+	if !ok {
+		return nil, errors.New("expected a resource named `ThreatIntelligence` but didn't get one")
+	}
+
+	model, ok := resource.Models["ThreatIntelligenceGranularMarkingModel"]
+	if !ok {
+		return nil, errors.New("expected a model named `ThreatIntelligenceGranularMarkingModel` but didn't get one")
+	}
+
+	field, ok := model.Fields["MarkingRef"]
+	if !ok {
+		return nil, errors.New("expected a field named `MarkingRef` but didn't get one")
+	}
+
+	if field.ObjectDefinition.Type != sdkModels.IntegerSDKObjectDefinitionType {
+		return nil, fmt.Errorf("expected the `CustomizableObservations` field type to be `%s`, got `%s`, this workaround can be removed", sdkModels.IntegerSDKObjectDefinitionType, field.ObjectDefinition.Type)
+	}
+
+	field.ObjectDefinition.Type = sdkModels.StringSDKObjectDefinitionType
+
+	model.Fields["MarkingRef"] = field
+	resource.Models["ThreatIntelligenceGranularMarkingModel"] = model
+	input.Resources["ThreatIntelligence"] = resource
+
+	return &input, nil
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -49,6 +49,7 @@ var workarounds = []workaround{
 	workaroundRedHatOpenShift43540{},
 	workaroundRedis22407{},
 	WorkaroundSecurityInsights22503{},
+	WorkaroundSecurityInsights22893{},
 	workaroundSql33215{},
 	workaroundStorageCache32537{},
 	workaroundStreamAnalytics27577{},


### PR DESCRIPTION
Adds a workaround for https://github.com/Azure/azure-rest-api-specs/issues/22893

This is a prerequisite to migrating `sentinel` to `go-azure-sdk`

Error showing this issue is still present:
```
unmarshaling into ThreatIntelligenceIndicatorModel: json:
│ cannot unmarshal string into Go struct field
│ ThreatIntelligenceGranularMarkingModel.properties.granularMarkings.markingRef of type int64
```