### PR TITLE
Add `cosmos-db` version 2026-03-15 and fix error when user specified resource ID is incorrectly identified as known segments used for scope

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -145,7 +145,7 @@ service "containerservice" {
 }
 service "cosmos-db" {
   name      = "CosmosDB"
-  available = ["2022-05-15", "2022-11-15", "2023-04-15", "2024-08-15", "2025-04-15", "2025-10-15"]
+  available = ["2022-05-15", "2022-11-15", "2023-04-15", "2024-08-15", "2025-04-15", "2025-10-15", "2026-03-15"]
 }
 service "cost-management" {
   name      = "CostManagement"

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/resourceids/parse_segments.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/resourceids/parse_segments.go
@@ -102,8 +102,18 @@ func (p *Parser) parseResourceIdFromOperation(uri string, operation *spec.Operat
 				}
 			}
 			if isScope {
-				segments = append(segments, sdkModels.NewScopeResourceIDSegment(normalizedSegment))
-				continue
+				precededByResourceType := false
+				if len(segments) > 0 {
+					previousSegment := segments[len(segments)-1]
+					if previousSegment.Type == sdkModels.StaticResourceIDSegmentType {
+						precededByResourceType = true
+					}
+				}
+
+				if !precededByResourceType {
+					segments = append(segments, sdkModels.NewScopeResourceIDSegment(normalizedSegment))
+					continue
+				}
 			}
 
 			if strings.EqualFold(normalizedSegment, "subscription") || strings.EqualFold(normalizedSegment, "subscriptionId") {

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/resourceids/parse_segments_test.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/resourceids/parse_segments_test.go
@@ -388,6 +388,40 @@ func TestParseResourceIDFromOperation_UserAssignedIdentityId(t *testing.T) {
 	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
 }
 
+func TestParseResourceIDFromOperation_UserSpecifiedResourceIdSameAsKnownSegmentsUsedForScope(t *testing.T) {
+	t.Parallel()
+	swagger := spec.NewOperation("Example_Operation")
+	// `roleAssignmentId` is listed as known segments used for scope
+	uri := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.DocumentDB/roleAssignments/{roleAssignmentId}"
+
+	parser := NewParser(nil)
+	resourceId, err := parser.parseResourceIdFromOperation(uri, swagger)
+	if err != nil {
+		t.Fatalf("parsing Resource ID from %q: %+v", uri, err)
+	}
+
+	if resourceId.uriSuffix != nil {
+		t.Fatalf("expected no uriSuffix but got %q", *resourceId.uriSuffix)
+	}
+	if len(resourceId.constants) != 0 {
+		t.Fatalf("expected 0 constants but got %d", len(resourceId.constants))
+	}
+	if resourceId.segments == nil {
+		t.Fatalf("expected 8 segments but got 0")
+	}
+	expectedSegments := []sdkModels.ResourceIDSegment{
+		sdkModels.NewStaticValueResourceIDSegment("subscriptions", "subscriptions"),
+		sdkModels.NewSubscriptionIDResourceIDSegment("subscriptionId"),
+		sdkModels.NewStaticValueResourceIDSegment("resourceGroups", "resourceGroups"),
+		sdkModels.NewResourceGroupNameResourceIDSegment("resourceGroupName"),
+		sdkModels.NewStaticValueResourceIDSegment("providers", "providers"),
+		sdkModels.NewResourceProviderResourceIDSegment("resourceProvider", "Microsoft.DocumentDB"),
+		sdkModels.NewStaticValueResourceIDSegment("roleAssignments", "roleAssignments"),
+		sdkModels.NewUserSpecifiedResourceIDSegment("roleAssignmentId", "roleAssignmentId"),
+	}
+	validateSegmentsMatch(t, *resourceId.segments, expectedSegments)
+}
+
 func validateSegmentsMatch(t *testing.T, actual []sdkModels.ResourceIDSegment, expected []sdkModels.ResourceIDSegment) {
 	if len(actual) != len(expected) {
 		t.Fatalf("expected there to be %d segments but got %d", len(expected), len(actual))


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. -->

`cosmos-db` API version 2026-03-15 is added for hashicorp/terraform-provider-azurerm#31546. In this version, the typical SDK generation fails due to duplicated resource IDs of Cassandra, Gremlin, Mongo MI, SQL, and table role assignment as shown in the log below. The error happens because of identification of `roleAssignmentId` user specified segment and its corresponding static segment as scope segment, causing the segments to be excluded when [deciding if the resource IDs are unique](https://github.com/v-yhyeo0202/pandora/blob/8568fec2b9a80847297d204f4e38d23fdd78cc70/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/resourceids/generate_names.go#L142). To fix the issue, `segmentInScopeDenyList` function is written to exclude the resource IDs' segments from being identified as scope.

```
Error: parsing Data for the Service "CosmosDB": parsing Data for Service "CosmosDB": parsing "CosmosDB" API Version "2026-03-15": parsing the Resource IDs from "/home/v-yyeo/pandora/submodules/rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/openapi.json": finding Resource IDs: generating Names for Resource IDs: determining unique names for conflicting uri's "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId} | /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleAssignments/{roleAssignmentId} | /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleAssignments/{roleAssignmentId} | /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleAssignments/{roleAssignmentId} | /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleAssignments/{roleAssignmentId}": not enough segments in "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleAssignments/{roleAssignmentId}" to determine a unique name - conflicts with "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}"
```

The previous API version did not exhibit this problem because there was only one role assignment API (SQL). Its `roleAssignmentId` user specified segment and its corresponding static segment were marked as scope and removed too but there was no multiple role assignment to cause the duplication issue.


## PR Checklist

- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so, please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Adding New API Version

<!-- Complete this section if adding a new Service or API Version. Otherwise, delete it. -->

> [!IMPORTANT]
> The primary purpose of API versions in this repository is to serve the **Terraform Azure Providers**. API versions are imported and maintained to support the providers' needs. If you would like to add an API version for use outside of the providers (e.g., another project consuming `go-azure-sdk`), please include a description of what you would like to use it for so we can evaluate the request.

- [x] I have verified the Service/API Version exists in the Azure REST API Specs.
- [x] I have followed the [Service Import Guide](../blob/main/docs/resource-manager-service-import.md).
- [ ] ~This PR is for another downstream project and not for the Terraform Azure Providers.~


## Changes to Tooling

<!-- Complete this section if modifying any tools. Otherwise, delete it. -->

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges.

**Testing Command(s) Used:**
```shell
cd ~/pandora/tools/importer-rest-api-specs
go test -v ./internal/components/apidefinitions/parser/resourceids/ -run TestParseResourceIDFromOperation
go test -v ./internal/components/apidefinitions/parser/resourceids/ -run TestSegmentInScopeDenyList
```

**Testing Evidence:**

<!-- Please include testing logs or evidence here, or an explanation on why no testing evidence can be provided. -->

Tests in `pandora/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/resourceids/parse_segments_test.go` and `helpers_test.go` are run.
```
--- PASS: TestParseResourceIDFromOperation_ConstantSingle (0.00s)
--- PASS: TestParseResourceIDFromOperation_ManagementGroupId (0.00s)
--- PASS: TestParseResourceIDFromOperation_InvalidSegmentTypeGetsTransformed (0.00s)
--- PASS: TestParseResourceIDFromOperation_SubscriptionId (0.00s)
--- PASS: TestParseResourceIDFromOperation_InvalidSegmentDefaultAsStaticValueGetsLeft (0.00s)
--- PASS: TestParseResourceIDFromOperation_ResourceGroupId (0.00s)
--- PASS: TestParseResourceIDFromOperation_InvalidSegmentDefaultGetsTransformed (0.00s)
--- PASS: TestParseResourceIDFromOperation_Scope (0.00s)
--- PASS: TestParseResourceIDFromOperation_ConstantMultiple (0.00s)
--- PASS: TestParseResourceIDFromOperation_ResourceGroupId_IncorrectSegment (0.00s)
--- PASS: TestParseResourceIDFromOperation_UriSuffixOnly (0.00s)
--- PASS: TestParseResourceIDFromOperation_UserAssignedIdentityId (0.00s)
--- PASS: TestSegmentInScopeDenyList (0.00s)
    --- PASS: TestSegmentInScopeDenyList/matches_documentdb_cassandra_role_assignment_denial (0.00s)
    --- PASS: TestSegmentInScopeDenyList/matches_documentdb_sql_role_assignment_denial_regardless_of_casing (0.00s)
    --- PASS: TestSegmentInScopeDenyList/does_not_deny_matching_segment_when_uri_is_a_different_resource_type (0.00s)
    --- PASS: TestSegmentInScopeDenyList/does_not_deny_unknown_segment (0.00s)
```


> [!NOTE] 
> If this PR changes meaningfully during the course of review, please update the title and description as required.
