### PR TITLE
`importer-rest-api-specs` - new `fileWorkaround` Type

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parse_api_version.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parse_api_version.go
@@ -17,6 +17,9 @@ import (
 
 // parseAPIVersion parses the information for this APIVersion from the AvailableDataSetForAPIVersion.
 func parseAPIVersion(serviceName string, input discoveryModels.AvailableDataSetForAPIVersion, resourceProvider *string) (*sdkModels.APIVersion, error) {
+	// Apply any file-level workarounds to filter out problematic swagger files before parsing
+	input.FilePathsContainingAPIDefinitions = dataworkarounds.ApplyFileWorkarounds(serviceName, input.APIVersion, input.FilePathsContainingAPIDefinitions)
+
 	// First we need to pull out a list of each of the Resource IDs within this API Version
 	// This is required to ensure we have consistent naming of these across the API Version which
 	// makes for a better user experience

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/file_workaround_interface.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/file_workaround_interface.go
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dataworkarounds
+
+import "github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/logging"
+
+// fileWorkaround defines a workaround that filters the list of file paths containing API definitions
+// before parsing begins. This is necessary when conflicting swagger files cause hard errors during
+// parsing that cannot be fixed by post-parse data workarounds.
+type fileWorkaround interface {
+	// IsApplicable determines whether this workaround is applicable for this Service / API Version
+	IsApplicable(serviceName string, apiVersion string) bool
+
+	// Name returns the Service Name and associated Pull Request number associated with this workaround
+	Name() string
+
+	// Process filters the list of file paths, returning only those that should be parsed
+	Process(filePaths []string) []string
+}
+
+// ApplyFileWorkarounds goes through and determines if any file-level workarounds are required for the
+// Service/API Version and applies those - filtering out problematic swagger files before parsing begins.
+func ApplyFileWorkarounds(serviceName string, apiVersion string, filePaths []string) []string {
+	logging.Debugf("Applying File Workarounds for %q / %q..", serviceName, apiVersion)
+	output := filePaths
+	for _, fix := range fileWorkarounds {
+		if !fix.IsApplicable(serviceName, apiVersion) {
+			continue
+		}
+
+		logging.Tracef("Applying File Workaround %q..", fix.Name())
+		output = fix.Process(output)
+		logging.Tracef("Applying File Workaround %q - Completed", fix.Name())
+	}
+	logging.Debugf("Applying File Workarounds for %q / %q - Completed", serviceName, apiVersion)
+	return output
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_insights_45213.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_insights_45213.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dataworkarounds
+
+import "strings"
+
+var _ fileWorkaround = workaroundInsights45213{}
+
+// workaroundInsights45213 works around an issue where Microsoft's TypeSpec migration for the Insights
+// service (2021-05-01-preview) produced a new openapi.json alongside legacy hand-written swagger files.
+// Both define operations under the same swagger tag (DiagnosticSettings) with conflicting pagination
+// metadata (nextLinkName: "nextLink" vs null), causing a hard parse error.
+//
+// This workaround removes the legacy files when the TypeSpec-generated openapi.json is present.
+//
+// Upstream issue: https://github.com/Azure/azure-rest-api-specs/issues/45213
+type workaroundInsights45213 struct{}
+
+func (workaroundInsights45213) IsApplicable(serviceName string, apiVersion string) bool {
+	return serviceName == "Insights" && apiVersion == "2021-05-01-preview"
+}
+
+func (workaroundInsights45213) Name() string {
+	return "Insights / 45213"
+}
+
+func (workaroundInsights45213) Process(filePaths []string) []string {
+	// Only apply if the TypeSpec-generated openapi.json is present
+	hasOpenAPIJson := false
+	for _, path := range filePaths {
+		if strings.HasSuffix(path, "/openapi.json") {
+			hasOpenAPIJson = true
+			break
+		}
+	}
+	if !hasOpenAPIJson {
+		return filePaths
+	}
+
+	// Remove the legacy hand-written files whose operations are superseded by openapi.json
+	legacyFiles := []string{
+		"diagnosticsSettings_API.json",
+		"diagnosticsSettingsCategories_API.json",
+	}
+
+	output := make([]string, 0, len(filePaths))
+	for _, path := range filePaths {
+		shouldSkip := false
+		for _, legacy := range legacyFiles {
+			if strings.HasSuffix(path, "/"+legacy) {
+				shouldSkip = true
+				break
+			}
+		}
+		if !shouldSkip {
+			output = append(output, path)
+		}
+	}
+	return output
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -76,3 +76,11 @@ var workarounds = []workaround{
 	// These workarounds are for a specific use cases that are not API related issues
 	workaroundSqlJobExecutionsCreateNotLRO{},
 }
+
+var fileWorkarounds = []fileWorkaround{
+	// These workarounds filter out problematic swagger files before parsing begins,
+	// typically when TypeSpec-generated files conflict with legacy hand-written files.
+
+	// https://github.com/Azure/azure-rest-api-specs/issues/45213
+	workaroundInsights45213{},
+}


### PR DESCRIPTION
workaround to allow us to side-step broken TypeSpec conversion legacy artifacts.

example: https://github.com/Azure/azure-rest-api-specs/issues/45213

Relates to / Fixes #5524

