### PR TITLE
workaround: add missing `kind` field to ApiConnectionDefinition (Web/2016-06-01)

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_web_kind_api_connection_45544.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_web_kind_api_connection_45544.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dataworkarounds
+
+import (
+	"fmt"
+
+	sdkModels "github.com/hashicorp/pandora/tools/data-api-sdk/v1/models"
+)
+
+var _ workaround = workaroundWebKindApiConnection45544{}
+
+// workaroundWebKindApiConnection45544 adds the missing `kind` field to ApiConnectionDefinition.
+// The stable 2016-06-01 spec was written from scratch in March 2018 (PR #2761) as a
+// retroactive swagger for an already-running API. The author wrote a new ResourceDefinition
+// base class but accidentally omitted the `kind` property that existed in the 2015-08-01-preview
+// spec. The Azure backend has always accepted and persisted V1 and V2 — V2 is required for
+// Logic App Standard workflows and exposes the connectionRuntimeUrl property.
+// Confirmed by live API testing (PUT + GET round-trip) and acknowledged by the Microsoft
+// ARM Deployments team (Azure/bicep#3512, July 2026).
+// Swagger Issue: https://github.com/Azure/azure-rest-api-specs/issues/45544
+type workaroundWebKindApiConnection45544 struct{}
+
+func (workaroundWebKindApiConnection45544) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
+	return serviceName == "Web" && apiVersion.APIVersion == "2016-06-01"
+}
+
+func (workaroundWebKindApiConnection45544) Name() string {
+	return "Web / kind missing from ApiConnectionDefinition"
+}
+
+func (workaroundWebKindApiConnection45544) Process(input sdkModels.APIVersion) (*sdkModels.APIVersion, error) {
+	resource, ok := input.Resources["Connections"]
+	if !ok {
+		return nil, fmt.Errorf("expected a Resource named `Connections` but didn't get one")
+	}
+
+	model, ok := resource.Models["ApiConnectionDefinition"]
+	if !ok {
+		return nil, fmt.Errorf("couldn't find Model `ApiConnectionDefinition`")
+	}
+
+	// Guard: if Kind is already present (spec fixed upstream) do nothing
+	if _, exists := model.Fields["Kind"]; exists {
+		return &input, nil
+	}
+
+	model.Fields["Kind"] = sdkModels.SDKField{
+		Description: "Kind of resource",
+		JsonName:    "kind",
+		ObjectDefinition: sdkModels.SDKObjectDefinition{
+			Type: sdkModels.StringSDKObjectDefinitionType,
+		},
+		Optional: true,
+	}
+
+	resource.Models["ApiConnectionDefinition"] = model
+	input.Resources["Connections"] = resource
+
+	return &input, nil
+}

--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workarounds.go
@@ -57,6 +57,7 @@ var workarounds = []workaround{
 	workaroundSubscriptions20254{},
 	workaroundWeb14529{},
 	workaroundWeb31682{},
+	workaroundWebKindApiConnection45544{},
 	WorkaroundWeb43978{},
 
 	// Special Case for Network duplicated Enum


### PR DESCRIPTION


The stable 2016-06-01 spec omitted the `kind` property when it was rewritten from scratch in March 2018 (azure-rest-api-specs PR #2761). The property was present on the Resource base class in the 2015-08-01-preview spec but was not carried forward to the new ResourceDefinition base class in the stable spec.

The Azure backend has always accepted and persisted kind=V1 and kind=V2. kind=V2 is required for Logic App Standard workflows as V2 connections expose the connectionRuntimeUrl property used at runtime.

This workaround injects the missing Kind field into ApiConnectionDefinition so that go-azure-sdk and downstream consumers (e.g. terraform-provider-azurerm) can create V2 API connections.

Upstream spec fix: https://github.com/Azure/azure-rest-api-specs/issues/45544

Related:
- https://github.com/Azure/bicep/issues/3512
- https://github.com/hashicorp/terraform-provider-azurerm/issues/16195

<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. -->


## PR Checklist

- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so, please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Adding New API Version

<!-- Complete this section if adding a new Service or API Version. Otherwise, delete it. -->

> [!IMPORTANT]
> The primary purpose of API versions in this repository is to serve the **Terraform Azure Providers**. API versions are imported and maintained to support the providers' needs. If you would like to add an API version for use outside of the providers (e.g., another project consuming `go-azure-sdk`), please include a description of what you would like to use it for so we can evaluate the request.

- [x] I have verified the Service/API Version exists in the Azure REST API Specs.
- [x] I have followed the [Service Import Guide](../blob/main/docs/resource-manager-service-import.md).
- [ ] This PR is for another downstream project and not for the Terraform Azure Providers.

<!-- If this is NOT for the Terraform Azure Provider, please explain what this change is for: -->


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->
### Preview API Version

<!-- If you are adding a preview API version, please answer the following questions. Otherwise, delete this subsection. -->

> [!IMPORTANT]
> We generally do not add preview API versions to `go-azure-sdk`, and we rarely support preview features in the provider. Exceptions require strong justification, such as when preview features have no GA date or no stable API version exists for a service. Please ensure you have thoroughly considered whether a preview API is truly necessary before proceeding.

- [ ] This PR adds a **preview** API version

1. **Is there a stable (GA) version available?**
   <!-- If a stable version exists, explain why the preview version is being used instead. -->

2. **Why should we support this preview API?**
   <!-- Explain the value/necessity of supporting this preview API, e.g., new feature availability, customer demand, etc. -->

3. **Do existing resources already use a preview API?**
   <!-- List any existing resources that currently use a preview API version. -->

4. **What is the expected timeline for GA?**
   <!-- If known, provide the expected date or timeframe for when this API will become stable. -->


## Changes to Tooling

<!-- Complete this section if modifying any tools. Otherwise, delete it. -->

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [ ] I have written new tests for my changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges.

**Testing Command(s) Used:**
```shell
# e.g., go test ./tools/generator-go-sdk/...
```

**Testing Evidence:**

<!-- Please include testing logs or evidence here, or an explanation on why no testing evidence can be provided. -->


## Changes to Resource Config

<!-- Complete this section if modifying resource configuration. Otherwise, delete it. -->

- [ ] I have followed the [Resource Generation Guide](../blob/main/docs/resource-manager-generate-new-resource.md).
- [x] I have verified the required SDK is available in `hashicorp/go-azure-sdk`.


## Related Issue(s)

<!-- Use closing keywords if applicable, e.g., "Fixes #123" -->


## AI Assistance Disclosure

<!-- 
If you are using any kind of AI/LLM assistance to contribute, this must be disclosed in the pull request.

If this is the case, please check the box below and describe the extent of AI usage (e.g., documentation only, code generation, etc.)
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->


> [!NOTE] 
> If this PR changes meaningfully during the course of review, please update the title and description as required.
