### PR TITLE
tools/importer-rest-api-specs: add network workaround 38407 for 2025-07-01

### DIFF
--- a/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_network_38407.go
+++ b/tools/importer-rest-api-specs/internal/components/apidefinitions/parser/dataworkarounds/workaround_network_38407.go
@@ -14,7 +14,8 @@ type workaroundNetwork38407 struct{}
 var _ workaround = workaroundNetwork38407{}
 
 func (w workaroundNetwork38407) IsApplicable(serviceName string, apiVersion sdkModels.APIVersion) bool {
-	return serviceName == "Network" && apiVersion.APIVersion == "2025-01-01"
+	// Fixed upstream for 2026-01-01 by https://github.com/Azure/azure-rest-api-specs/pull/45621.
+	return serviceName == "Network" && (apiVersion.APIVersion == "2025-01-01" || apiVersion.APIVersion == "2025-07-01")
 }
 
 func (w workaroundNetwork38407) Name() string {


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. -->
add a workaround for https://github.com/Azure/azure-rest-api-specs/issues/38407 in 2025-07-01, since the issue will only be resolved after next release 2026-01-01 (maybe still need several months, as [2025-09-01](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01) was released on Aug 2026).

## PR Checklist

- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so, please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to Tooling

<!-- Complete this section if modifying any tools. Otherwise, delete it. -->

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [ ] I have written new tests for my changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges.

**Testing Command(s) Used:**
```shell
# e.g., go test ./tools/generator-go-sdk/...
```

**Testing Evidence:**

<!-- Please include testing logs or evidence here, or an explanation on why no testing evidence can be provided. -->
```
-> % go test ./internal/components/apidefinitions/parser                   
ok      github.com/hashicorp/pandora/tools/importer-rest-api-specs/internal/components/apidefinitions/parser    11.289s
```